### PR TITLE
18 umsetzung von wls commonexception

### DIFF
--- a/.github/workflows/build_wls-common_pull-request.yaml
+++ b/.github/workflows/build_wls-common_pull-request.yaml
@@ -18,4 +18,4 @@ jobs:
           distribution: 'temurin'
 
       - name: Build with Maven
-        run: mvn -f wls-common/pom.xml test
+        run: mvn -f wls-common/pom.xml verify

--- a/wls-common/exception/pom.xml
+++ b/wls-common/exception/pom.xml
@@ -14,6 +14,14 @@
     <version>0.0.1-SNAPSHOT</version>
     <description>Projekt für die Fehlerinfrastruktur die Serviceübergreifend ist</description>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/wls-common/exception/pom.xml
+++ b/wls-common/exception/pom.xml
@@ -20,6 +20,13 @@
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/wls-common/exception/pom.xml
+++ b/wls-common/exception/pom.xml
@@ -16,9 +16,49 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <version>6.2.3</version> <!-- wegen CVE-2024-22257  -->
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>6.1.5</version> <!-- wegen CVE-2024-22259 -->
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- Validation -->
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <!-- Mapping -->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
         </dependency>
 
         <!-- Testing -->

--- a/wls-common/exception/pom.xml
+++ b/wls-common/exception/pom.xml
@@ -26,12 +26,10 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
-            <version>6.2.3</version> <!-- wegen CVE-2024-22257  -->
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>6.1.5</version> <!-- wegen CVE-2024-22259 -->
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/FachlicheWlsException.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/FachlicheWlsException.java
@@ -14,7 +14,7 @@ public final class FachlicheWlsException extends WlsException {
         super(WlsExceptionCategory.FACHLICH, data);
     }
 
-    public static CodeIsSet<FachlicheWlsException> withCode(String code) {
+    public static CodeIsSet<FachlicheWlsException> withCode(final String code) {
         return new WlsExceptionFactory<>(exceptionCreation).withCode(code);
     }
 }

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/FachlicheWlsException.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/FachlicheWlsException.java
@@ -2,11 +2,11 @@ package de.muenchen.oss.wahllokalsystem.wls.common.exception;
 
 public class FachlicheWlsException extends WlsException {
 
-	public FachlicheWlsException(String code, String service, String message) {
-		super(WlsExceptionCategory.FACHLICH, code, service, message);
-	}
+    public FachlicheWlsException(String code, String service, String message) {
+        super(WlsExceptionCategory.FACHLICH, code, service, message);
+    }
 
-	public FachlicheWlsException(Throwable cause, String code, String service, String message) {
-		super(cause, WlsExceptionCategory.FACHLICH, code, service, message);
-	}
+    public FachlicheWlsException(Throwable cause, String code, String service, String message) {
+        super(cause, WlsExceptionCategory.FACHLICH, code, service, message);
+    }
 }

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/FachlicheWlsException.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/FachlicheWlsException.java
@@ -1,12 +1,20 @@
 package de.muenchen.oss.wahllokalsystem.wls.common.exception;
 
-public class FachlicheWlsException extends WlsException {
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.WlsExceptionCreator;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.WlsExceptionFactory;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.states.CodeIsSet;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionData;
 
-    public FachlicheWlsException(String code, String service, String message) {
-        super(WlsExceptionCategory.FACHLICH, code, service, message);
+public final class FachlicheWlsException extends WlsException {
+
+    private static final WlsExceptionCreator<FachlicheWlsException> exceptionCreation = (FachlicheWlsException::new);
+
+    private FachlicheWlsException(final WlsExceptionData data) {
+        super(WlsExceptionCategory.FACHLICH, data);
     }
 
-    public FachlicheWlsException(Throwable cause, String code, String service, String message) {
-        super(cause, WlsExceptionCategory.FACHLICH, code, service, message);
+    public static CodeIsSet<FachlicheWlsException> withCode(String code) {
+        return new WlsExceptionFactory<>(exceptionCreation).withCode(code);
     }
 }

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/FachlicheWlsException.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/FachlicheWlsException.java
@@ -1,0 +1,12 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception;
+
+public class FachlicheWlsException extends WlsException {
+
+	public FachlicheWlsException(String code, String service, String message) {
+		super(WlsExceptionCategory.FACHLICH, code, service, message);
+	}
+
+	public FachlicheWlsException(Throwable cause, String code, String service, String message) {
+		super(cause, WlsExceptionCategory.FACHLICH, code, service, message);
+	}
+}

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/InfrastrukturelleWlsException.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/InfrastrukturelleWlsException.java
@@ -1,0 +1,12 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception;
+
+public class InfrastrukturelleWlsException extends WlsException {
+
+	public InfrastrukturelleWlsException(String code, String service, String message) {
+		this(null, code, service, message);
+	}
+
+	public InfrastrukturelleWlsException(Throwable cause, String code, String service, String message) {
+		super(cause, WlsExceptionCategory.INFRASTRUKTUR, code, service, message);
+	}
+}

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/InfrastrukturelleWlsException.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/InfrastrukturelleWlsException.java
@@ -1,12 +1,20 @@
 package de.muenchen.oss.wahllokalsystem.wls.common.exception;
 
-public class InfrastrukturelleWlsException extends WlsException {
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.WlsExceptionCreator;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.WlsExceptionFactory;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.states.CodeIsSet;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionData;
 
-    public InfrastrukturelleWlsException(String code, String service, String message) {
-        this(null, code, service, message);
+public final class InfrastrukturelleWlsException extends WlsException {
+
+    private static final WlsExceptionCreator<InfrastrukturelleWlsException> exceptionCreation = (InfrastrukturelleWlsException::new);
+
+    private InfrastrukturelleWlsException(final WlsExceptionData data) {
+        super(WlsExceptionCategory.INFRASTRUKTUR, data);
     }
 
-    public InfrastrukturelleWlsException(Throwable cause, String code, String service, String message) {
-        super(cause, WlsExceptionCategory.INFRASTRUKTUR, code, service, message);
+    public static CodeIsSet<InfrastrukturelleWlsException> withCode(final String code) {
+        return new WlsExceptionFactory<>(exceptionCreation).withCode(code);
     }
 }

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/InfrastrukturelleWlsException.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/InfrastrukturelleWlsException.java
@@ -2,11 +2,11 @@ package de.muenchen.oss.wahllokalsystem.wls.common.exception;
 
 public class InfrastrukturelleWlsException extends WlsException {
 
-	public InfrastrukturelleWlsException(String code, String service, String message) {
-		this(null, code, service, message);
-	}
+    public InfrastrukturelleWlsException(String code, String service, String message) {
+        this(null, code, service, message);
+    }
 
-	public InfrastrukturelleWlsException(Throwable cause, String code, String service, String message) {
-		super(cause, WlsExceptionCategory.INFRASTRUKTUR, code, service, message);
-	}
+    public InfrastrukturelleWlsException(Throwable cause, String code, String service, String message) {
+        super(cause, WlsExceptionCategory.INFRASTRUKTUR, code, service, message);
+    }
 }

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/SicherheitsWlsException.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/SicherheitsWlsException.java
@@ -1,0 +1,12 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception;
+
+public class SicherheitsWlsException extends WlsException {
+
+	public SicherheitsWlsException(String code, String service, String message) {
+		this(null, code, service, message);
+	}
+
+	public SicherheitsWlsException(Throwable cause, String code, String service, String message) {
+		super(cause, WlsExceptionCategory.SECURITY, code, service, message);
+	}
+}

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/SicherheitsWlsException.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/SicherheitsWlsException.java
@@ -1,12 +1,20 @@
 package de.muenchen.oss.wahllokalsystem.wls.common.exception;
 
-public class SicherheitsWlsException extends WlsException {
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.WlsExceptionCreator;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.WlsExceptionFactory;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.states.CodeIsSet;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionData;
 
-    public SicherheitsWlsException(String code, String service, String message) {
-        this(null, code, service, message);
+public final class SicherheitsWlsException extends WlsException {
+
+    private static final WlsExceptionCreator<SicherheitsWlsException> exceptionCreation = (SicherheitsWlsException::new);
+
+    private SicherheitsWlsException(final WlsExceptionData data) {
+        super(WlsExceptionCategory.SECURITY, data);
     }
 
-    public SicherheitsWlsException(Throwable cause, String code, String service, String message) {
-        super(cause, WlsExceptionCategory.SECURITY, code, service, message);
+    public static CodeIsSet<SicherheitsWlsException> withCode(final String code) {
+        return new WlsExceptionFactory<>(exceptionCreation).withCode(code);
     }
 }

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/SicherheitsWlsException.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/SicherheitsWlsException.java
@@ -2,11 +2,11 @@ package de.muenchen.oss.wahllokalsystem.wls.common.exception;
 
 public class SicherheitsWlsException extends WlsException {
 
-	public SicherheitsWlsException(String code, String service, String message) {
-		this(null, code, service, message);
-	}
+    public SicherheitsWlsException(String code, String service, String message) {
+        this(null, code, service, message);
+    }
 
-	public SicherheitsWlsException(Throwable cause, String code, String service, String message) {
-		super(cause, WlsExceptionCategory.SECURITY, code, service, message);
-	}
+    public SicherheitsWlsException(Throwable cause, String code, String service, String message) {
+        super(cause, WlsExceptionCategory.SECURITY, code, service, message);
+    }
 }

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/TechnischeWlsException.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/TechnischeWlsException.java
@@ -2,11 +2,11 @@ package de.muenchen.oss.wahllokalsystem.wls.common.exception;
 
 public class TechnischeWlsException extends WlsException {
 
-	public TechnischeWlsException(String code, String service, String message) {
-		this(null, code, service, message);
-	}
+    public TechnischeWlsException(String code, String service, String message) {
+        this(null, code, service, message);
+    }
 
-	public TechnischeWlsException(Throwable cause, String code, String service, String message) {
-		super(cause, WlsExceptionCategory.TECHNISCH, code, service, message);
-	}
+    public TechnischeWlsException(Throwable cause, String code, String service, String message) {
+        super(cause, WlsExceptionCategory.TECHNISCH, code, service, message);
+    }
 }

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/TechnischeWlsException.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/TechnischeWlsException.java
@@ -1,0 +1,12 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception;
+
+public class TechnischeWlsException extends WlsException {
+
+	public TechnischeWlsException(String code, String service, String message) {
+		this(null, code, service, message);
+	}
+
+	public TechnischeWlsException(Throwable cause, String code, String service, String message) {
+		super(cause, WlsExceptionCategory.TECHNISCH, code, service, message);
+	}
+}

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/TechnischeWlsException.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/TechnischeWlsException.java
@@ -1,12 +1,20 @@
 package de.muenchen.oss.wahllokalsystem.wls.common.exception;
 
-public class TechnischeWlsException extends WlsException {
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.WlsExceptionCreator;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.WlsExceptionFactory;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.states.CodeIsSet;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionData;
 
-    public TechnischeWlsException(String code, String service, String message) {
-        this(null, code, service, message);
+public final class TechnischeWlsException extends WlsException {
+
+    private static final WlsExceptionCreator<TechnischeWlsException> exceptionCreation = (TechnischeWlsException::new);
+
+    private TechnischeWlsException(final WlsExceptionData data) {
+        super(WlsExceptionCategory.TECHNISCH, data);
     }
 
-    public TechnischeWlsException(Throwable cause, String code, String service, String message) {
-        super(cause, WlsExceptionCategory.TECHNISCH, code, service, message);
+    public static CodeIsSet<TechnischeWlsException> withCode(final String code) {
+        return new WlsExceptionFactory<>(exceptionCreation).withCode(code);
     }
 }

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/WlsException.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/WlsException.java
@@ -1,0 +1,28 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public abstract class WlsException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final WlsExceptionCategory category;
+	private final String code;
+	//Kann aus Konstruktoren raus da die Exception primär intern erstellt wird
+	//wird nur gesetzt wenn eine Exception von einen anderen Service verabeitet wird
+	private final String service;
+	private final String message;
+
+	public WlsException(final WlsExceptionCategory category, final String code, final String service, final String message) {
+		this(null, category, code, service, message);
+	}
+
+	public WlsException(final Throwable cause, final WlsExceptionCategory category, final String code, final String service, final String message) {
+		super(cause);
+		this.category = category;
+		this.code = code;
+		this.service = service;
+		this.message = message;
+	}
+}

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/WlsException.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/WlsException.java
@@ -5,7 +5,7 @@ import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionDa
 import lombok.Getter;
 
 @Getter
-//@formatter:off steht im Conflict mit checkstyle - TODO Issue erstellen und verlinken
+//@formatter:off steht im Conflict mit checkstyle - siehe Issue #53
 public abstract sealed class WlsException extends RuntimeException
         permits FachlicheWlsException, TechnischeWlsException, InfrastrukturelleWlsException, SicherheitsWlsException {
     //formatter:on

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/WlsException.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/WlsException.java
@@ -1,28 +1,28 @@
 package de.muenchen.oss.wahllokalsystem.wls.common.exception;
 
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionData;
 import lombok.Getter;
 
 @Getter
-public abstract class WlsException extends RuntimeException {
+//@formatter:off steht im Conflict mit checkstyle - TODO Issue erstellen und verlinken
+public abstract sealed class WlsException extends RuntimeException
+        permits FachlicheWlsException, TechnischeWlsException, InfrastrukturelleWlsException, SicherheitsWlsException {
+    //formatter:on
 
     private static final long serialVersionUID = 1L;
 
     private final WlsExceptionCategory category;
     private final String code;
-    //Kann aus Konstruktoren raus da die Exception primär intern erstellt wird
-    //wird nur gesetzt wenn eine Exception von einen anderen Service verabeitet wird
-    private final String service;
+    private final String serviceName;
     private final String message;
 
-    public WlsException(final WlsExceptionCategory category, final String code, final String service, final String message) {
-        this(null, category, code, service, message);
+    protected WlsException(final WlsExceptionCategory category, WlsExceptionData wlsExceptionData) {
+        super(wlsExceptionData.getCause());
+        this.category = category;
+        this.code = wlsExceptionData.getCode();
+        this.serviceName = wlsExceptionData.getServiceName();
+        this.message = wlsExceptionData.getMessage();
     }
 
-    public WlsException(final Throwable cause, final WlsExceptionCategory category, final String code, final String service, final String message) {
-        super(cause);
-        this.category = category;
-        this.code = code;
-        this.service = service;
-        this.message = message;
-    }
 }

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/WlsException.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/WlsException.java
@@ -17,7 +17,7 @@ public abstract sealed class WlsException extends RuntimeException
     private final String serviceName;
     private final String message;
 
-    protected WlsException(final WlsExceptionCategory category, WlsExceptionData wlsExceptionData) {
+    protected WlsException(final WlsExceptionCategory category, final WlsExceptionData wlsExceptionData) {
         super(wlsExceptionData.getCause());
         this.category = category;
         this.code = wlsExceptionData.getCode();

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/WlsException.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/WlsException.java
@@ -5,24 +5,24 @@ import lombok.Getter;
 @Getter
 public abstract class WlsException extends RuntimeException {
 
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	private final WlsExceptionCategory category;
-	private final String code;
-	//Kann aus Konstruktoren raus da die Exception primär intern erstellt wird
-	//wird nur gesetzt wenn eine Exception von einen anderen Service verabeitet wird
-	private final String service;
-	private final String message;
+    private final WlsExceptionCategory category;
+    private final String code;
+    //Kann aus Konstruktoren raus da die Exception primär intern erstellt wird
+    //wird nur gesetzt wenn eine Exception von einen anderen Service verabeitet wird
+    private final String service;
+    private final String message;
 
-	public WlsException(final WlsExceptionCategory category, final String code, final String service, final String message) {
-		this(null, category, code, service, message);
-	}
+    public WlsException(final WlsExceptionCategory category, final String code, final String service, final String message) {
+        this(null, category, code, service, message);
+    }
 
-	public WlsException(final Throwable cause, final WlsExceptionCategory category, final String code, final String service, final String message) {
-		super(cause);
-		this.category = category;
-		this.code = code;
-		this.service = service;
-		this.message = message;
-	}
+    public WlsException(final Throwable cause, final WlsExceptionCategory category, final String code, final String service, final String message) {
+        super(cause);
+        this.category = category;
+        this.code = code;
+        this.service = service;
+        this.message = message;
+    }
 }

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/WlsExceptionCategory.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/WlsExceptionCategory.java
@@ -1,0 +1,8 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception;
+
+public enum WlsExceptionCategory {
+    FACHLICH,
+    TECHNISCH,
+    SECURITY,
+    INFRASTRUKTUR
+}

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/WlsExceptionCategory.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/WlsExceptionCategory.java
@@ -1,8 +1,5 @@
 package de.muenchen.oss.wahllokalsystem.wls.common.exception;
 
 public enum WlsExceptionCategory {
-    FACHLICH,
-    TECHNISCH,
-    SECURITY,
-    INFRASTRUKTUR
+    FACHLICH, TECHNISCH, SECURITY, INFRASTRUKTUR
 }

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/builder/WlsExceptionCreator.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/builder/WlsExceptionCreator.java
@@ -1,0 +1,9 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.builder;
+
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.WlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionData;
+
+@FunctionalInterface
+public interface WlsExceptionCreator<T extends WlsException> {
+    T createWlsException(WlsExceptionData wlsExceptionData);
+}

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/builder/WlsExceptionFactory.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/builder/WlsExceptionFactory.java
@@ -11,25 +11,25 @@ public class WlsExceptionFactory<T extends WlsException> implements ExceptionFin
 
     private final WlsExceptionCreator<T> exceptionCreator;
 
-    public WlsExceptionFactory(WlsExceptionCreator<T> builder) {
+    public WlsExceptionFactory(final WlsExceptionCreator<T> builder) {
         wlsExceptionData = new WlsExceptionData();
         this.exceptionCreator = builder;
     }
 
     @Override
-    public CodeIsSet<T> withCode(String code) {
+    public CodeIsSet<T> withCode(final String code) {
         wlsExceptionData.setCode(code);
         return this;
     }
 
     @Override
-    public CodeIsSet<T> inService(String serviceName) {
+    public CodeIsSet<T> inService(final String serviceName) {
         wlsExceptionData.setServiceName(serviceName);
         return this;
     }
 
     @Override
-    public CodeIsSet<T> withCause(Throwable cause) {
+    public CodeIsSet<T> withCause(final Throwable cause) {
         wlsExceptionData.setCause(cause);
         return this;
     }

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/builder/WlsExceptionFactory.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/builder/WlsExceptionFactory.java
@@ -1,0 +1,42 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.builder;
+
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.WlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.states.CodeIsSet;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.states.ExceptionFinalizable;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.states.ExceptionInitializable;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionData;
+
+public class WlsExceptionFactory<T extends WlsException> implements ExceptionFinalizable<T>, CodeIsSet<T>, ExceptionInitializable {
+    private final WlsExceptionData wlsExceptionData;
+
+    private final WlsExceptionCreator<T> exceptionCreator;
+
+    public WlsExceptionFactory(WlsExceptionCreator<T> builder) {
+        wlsExceptionData = new WlsExceptionData();
+        this.exceptionCreator = builder;
+    }
+
+    @Override
+    public CodeIsSet<T> withCode(String code) {
+        wlsExceptionData.setCode(code);
+        return this;
+    }
+
+    @Override
+    public CodeIsSet<T> inService(String serviceName) {
+        wlsExceptionData.setServiceName(serviceName);
+        return this;
+    }
+
+    @Override
+    public CodeIsSet<T> withCause(Throwable cause) {
+        wlsExceptionData.setCause(cause);
+        return this;
+    }
+
+    @Override
+    public T buildWithMessage(final String message) {
+        wlsExceptionData.setMessage(message);
+        return exceptionCreator.createWlsException(wlsExceptionData);
+    }
+}

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/builder/states/CodeIsSet.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/builder/states/CodeIsSet.java
@@ -1,0 +1,9 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.states;
+
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.WlsException;
+
+public interface CodeIsSet<T extends WlsException> extends ExceptionFinalizable<T> {
+    CodeIsSet<T> inService(String serviceName);
+
+    CodeIsSet<T> withCause(Throwable cause);
+}

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/builder/states/ExceptionFinalizable.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/builder/states/ExceptionFinalizable.java
@@ -1,0 +1,7 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.states;
+
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.WlsException;
+
+public interface ExceptionFinalizable<T extends WlsException> {
+    T buildWithMessage(String message);
+}

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/builder/states/ExceptionInitializable.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/builder/states/ExceptionInitializable.java
@@ -1,0 +1,7 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.states;
+
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.WlsException;
+
+public interface ExceptionInitializable {
+    CodeIsSet<? extends WlsException> withCode(String code);
+}

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/AbstractExceptionHandler.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/AbstractExceptionHandler.java
@@ -25,7 +25,7 @@ public abstract class AbstractExceptionHandler {
 
     private final DTOMapper dtoMapper;
 
-    protected WlsExceptionDTO getWahlExceptionDTO(@NonNull Throwable throwable) {
+    protected WlsExceptionDTO getWahlExceptionDTO(@NonNull final Throwable throwable) {
         log.debug("Throwable > {}", throwable.toString());
         final WlsExceptionDTO data;
 
@@ -49,7 +49,7 @@ public abstract class AbstractExceptionHandler {
 
     protected abstract String getService();
 
-    protected WlsExceptionDTO createForTransientException(Throwable throwable) {
+    protected WlsExceptionDTO createForTransientException(final Throwable throwable) {
         return new WlsExceptionDTO(WlsExceptionCategory.T, ExceptionKonstanten.CODE_TRANSIENT, getService(),
                 String.format("Temporäres Problem, Ursache: %s, Nachricht: %s", throwable.getClass(), throwable.getMessage()));
     }
@@ -58,7 +58,7 @@ public abstract class AbstractExceptionHandler {
         return new WlsExceptionDTO(WlsExceptionCategory.S, ExceptionKonstanten.CODE_SECURITY_ACCESS_DENIED, getService(), throwable.getMessage());
     }
 
-    protected ResponseEntity<WlsExceptionDTO> createResponse(WlsExceptionDTO wlsExceptionDTO) {
+    protected ResponseEntity<WlsExceptionDTO> createResponse(final WlsExceptionDTO wlsExceptionDTO) {
         return switch (wlsExceptionDTO.category()) {
         case T -> new ResponseEntity<>(wlsExceptionDTO,
                 ExceptionKonstanten.CODE_TRANSIENT.equals(wlsExceptionDTO.code()) ? HttpStatus.CONFLICT : HTTP_STATUS_TECHNISCHER_FEHLER);

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/AbstractExceptionHandler.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/AbstractExceptionHandler.java
@@ -1,0 +1,73 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.errorhandler;
+
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.WlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.DTOMapper;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExceptionCategory;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExceptionDTO;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.util.ExceptionKonstanten;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.lang.NonNull;
+import org.springframework.security.access.AccessDeniedException;
+
+@Slf4j
+@RequiredArgsConstructor
+public abstract class AbstractExceptionHandler {
+
+    private static final HttpStatus HTTP_STATUS_TECHNISCHER_FEHLER = HttpStatus.INTERNAL_SERVER_ERROR;
+    private static final HttpStatus HTTP_STATUS_FACHLICHER_FEHLER = HttpStatus.BAD_REQUEST;
+    private static final HttpStatus HTTP_STATUS_SICHERHEITSFEHLER = HttpStatus.FORBIDDEN;
+    private static final HttpStatus HTTP_STATUS_INFRASTRUKTURELLER_FEHLER = HttpStatus.INTERNAL_SERVER_ERROR;
+
+    private final DTOMapper dtoMapper;
+
+    protected WlsExceptionDTO getWahlExceptionDTO(@NonNull Throwable throwable) {
+        log.debug("Throwable > {}", throwable.toString());
+        final WlsExceptionDTO data;
+
+        if (throwable instanceof WlsException wlsException) {
+            data = dtoMapper.toDTO(wlsException);
+        } else if (throwable instanceof AccessDeniedException) {
+            data = createForAccessDeniedException(throwable);
+        } else if (throwable instanceof HttpMessageNotReadableException) {
+            data = new WlsExceptionDTO(WlsExceptionCategory.F, ExceptionKonstanten.CODE_HTTP_MESSAGE_NOT_READABLE, getService(),
+                    String.format("HTTP-Nachricht nicht lesbar: %s", throwable.getMessage()));
+        } else if (throwable instanceof TransientDataAccessException) {
+            data = createForTransientException(throwable);
+        } else {
+            data = new WlsExceptionDTO(WlsExceptionCategory.T, ExceptionKonstanten.CODE_ALLGEMEIN_UNBEKANNT, getService(),
+                    String.format("Ursache: %s, Nachricht: %s", throwable.getClass(), throwable.getMessage()));
+        }
+
+        log.debug("Erzeugte Fehlerdaten > {}", data);
+        return data;
+    }
+
+    protected abstract String getService();
+
+    protected WlsExceptionDTO createForTransientException(Throwable throwable) {
+        return new WlsExceptionDTO(WlsExceptionCategory.T, ExceptionKonstanten.CODE_TRANSIENT, getService(),
+                String.format("Temporäres Problem, Ursache: %s, Nachricht: %s", throwable.getClass(), throwable.getMessage()));
+    }
+
+    protected WlsExceptionDTO createForAccessDeniedException(final Throwable throwable) {
+        return new WlsExceptionDTO(WlsExceptionCategory.S, ExceptionKonstanten.CODE_SECURITY_ACCESS_DENIED, getService(), throwable.getMessage());
+    }
+
+    protected ResponseEntity<WlsExceptionDTO> createResponse(WlsExceptionDTO wlsExceptionDTO) {
+        return switch (wlsExceptionDTO.category()) {
+        case T -> new ResponseEntity<>(wlsExceptionDTO,
+                ExceptionKonstanten.CODE_TRANSIENT.equals(wlsExceptionDTO.code()) ? HttpStatus.CONFLICT : HTTP_STATUS_TECHNISCHER_FEHLER);
+        case F -> ExceptionKonstanten.CODE_ENTITY_NOT_FOUND.equals(wlsExceptionDTO.code()) ? new ResponseEntity<>(HttpStatus.NO_CONTENT)
+                : new ResponseEntity<>(wlsExceptionDTO, HTTP_STATUS_FACHLICHER_FEHLER);
+        case I -> new ResponseEntity<>(wlsExceptionDTO,
+                HTTP_STATUS_INFRASTRUKTURELLER_FEHLER);
+        case S -> new ResponseEntity<>(wlsExceptionDTO, HTTP_STATUS_SICHERHEITSFEHLER);
+        };
+    }
+
+}

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/WlsResponseErrorHandler.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/WlsResponseErrorHandler.java
@@ -27,7 +27,7 @@ public class WlsResponseErrorHandler extends DefaultResponseErrorHandler {
     private final ObjectMapper mapper;
 
     @Override
-    public void handleError(@NonNull ClientHttpResponse response) throws WlsException {
+    public void handleError(@NonNull final ClientHttpResponse response) throws WlsException {
         final WlsException createdException;
         try {
             val wlsExceptionDTO = mapper.readValue(response.getBody(), WlsExceptionDTO.class);
@@ -61,7 +61,7 @@ public class WlsResponseErrorHandler extends DefaultResponseErrorHandler {
         return sb.toString();
     }
 
-    private WlsException createException(WlsExceptionDTO wahlExceptionDTO) {
+    private WlsException createException(final WlsExceptionDTO wahlExceptionDTO) {
         val category = wahlExceptionDTO.category();
         log.debug("Erzeugen einer Exception aus der Kategorie: {}", category);
 

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/WlsResponseErrorHandler.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/WlsResponseErrorHandler.java
@@ -1,0 +1,79 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.errorhandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.FachlicheWlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.InfrastrukturelleWlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.SicherheitsWlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.TechnischeWlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.WlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.builder.states.CodeIsSet;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExceptionDTO;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.util.ExceptionKonstanten;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+
+@Slf4j
+@RequiredArgsConstructor
+@Getter
+@Setter
+public class WlsResponseErrorHandler extends DefaultResponseErrorHandler {
+
+    private final ObjectMapper mapper;
+
+    @Override
+    public void handleError(@NonNull ClientHttpResponse response) throws WlsException {
+        final WlsException createdException;
+        try {
+            val wlsExceptionDTO = mapper.readValue(response.getBody(), WlsExceptionDTO.class);
+            log.debug("HttpStatus: {} - {}", response.getStatusCode(), response.getStatusText());
+
+            createdException = createException(wlsExceptionDTO);
+            log.debug("Erstellte Exception: {}", createdException.toString());
+        } catch (Exception e) {
+            log.error("Beim Erzeugen der WLS-Exception kam es zu einem Fehler. Erzeuge einen Standard-WlsException", e);
+            throw createUnknownTechnischeWlsExceptionWithCause(e);
+        }
+
+        throw createdException;
+    }
+
+    private TechnischeWlsException createUnknownTechnischeWlsExceptionWithCause(final Throwable cause) {
+        return TechnischeWlsException.withCode(ExceptionKonstanten.CODE_ALLGEMEIN_UNBEKANNT).inService(ExceptionKonstanten.SERVICE_UNBEKANNT).withCause(cause)
+                .buildWithMessage(buildUndefinedErrorMessageWithCauseMessages(cause));
+    }
+
+    private String buildUndefinedErrorMessageWithCauseMessages(final Throwable cause) {
+        val sb = new StringBuilder(ExceptionKonstanten.MESSAGE_UNBEKANNTER_FEHLER);
+
+        sb.append("\nWegen: ").append(cause.getClass());
+
+        val message = cause.getMessage();
+        if (!message.isBlank()) {
+            sb.append(" mit:\n").append(message);
+        }
+
+        return sb.toString();
+    }
+
+    private WlsException createException(WlsExceptionDTO wahlExceptionDTO) {
+        val category = wahlExceptionDTO.category();
+        log.debug("Erzeugen einer Exception aus der Kategorie: {}", category);
+
+        return switch (category) {
+        case F -> completeWithDTOData(FachlicheWlsException.withCode(wahlExceptionDTO.code()), wahlExceptionDTO);
+        case I -> completeWithDTOData(InfrastrukturelleWlsException.withCode(wahlExceptionDTO.code()), wahlExceptionDTO);
+        case S -> completeWithDTOData(SicherheitsWlsException.withCode(wahlExceptionDTO.code()), wahlExceptionDTO);
+        case T -> completeWithDTOData(TechnischeWlsException.withCode(wahlExceptionDTO.code()), wahlExceptionDTO);
+        };
+    }
+
+    private WlsException completeWithDTOData(final CodeIsSet<?> startedWlsExceptionCreation, final WlsExceptionDTO dtoData) {
+        return startedWlsExceptionCreation.inService(dtoData.service()).buildWithMessage(dtoData.message());
+    }
+}

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/model/WlsExceptionCategory.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/model/WlsExceptionCategory.java
@@ -1,4 +1,4 @@
-package de.muenchen.oss.wahllokalsystem.wls.common.exception;
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.model;
 
 public enum WlsExceptionCategory {
     FACHLICH, TECHNISCH, SECURITY, INFRASTRUKTUR

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/model/WlsExceptionData.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/model/WlsExceptionData.java
@@ -1,14 +1,12 @@
 package de.muenchen.oss.wahllokalsystem.wls.common.exception.model;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class WlsExceptionData {
 
     private String message;

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/model/WlsExceptionData.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/model/WlsExceptionData.java
@@ -1,0 +1,18 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class WlsExceptionData {
+
+    private String message;
+    private String serviceName;
+    private String code;
+    private Throwable cause;
+}

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/DTOMapper.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/DTOMapper.java
@@ -1,0 +1,24 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model;
+
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.WlsException;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper
+public interface DTOMapper {
+
+    @Mapping(target = "service", source = "serviceName")
+    WlsExceptionDTO toDTO(WlsException wlsException);
+
+    default WlsExceptionCategory toDTOCategory(de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory exceptionCategory) {
+        if (exceptionCategory == null) {
+            return null;
+        }
+        return switch (exceptionCategory) {
+        case FACHLICH -> WlsExceptionCategory.F;
+        case INFRASTRUKTUR -> WlsExceptionCategory.I;
+        case SECURITY -> WlsExceptionCategory.S;
+        case TECHNISCH -> WlsExceptionCategory.T;
+        };
+    }
+}

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/DTOMapper.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/DTOMapper.java
@@ -10,7 +10,7 @@ public interface DTOMapper {
     @Mapping(target = "service", source = "serviceName")
     WlsExceptionDTO toDTO(WlsException wlsException);
 
-    default WlsExceptionCategory toDTOCategory(de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory exceptionCategory) {
+    default WlsExceptionCategory toDTOCategory(final de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory exceptionCategory) {
         if (exceptionCategory == null) {
             return null;
         }

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/WlsExceptionCategory.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/WlsExceptionCategory.java
@@ -1,0 +1,8 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model;
+
+public enum WlsExceptionCategory {
+    F, //FACHLICH
+    T, //TECHNISCH
+    S, //SECURITY
+    I //INFRASTRUCTURE
+}

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/WlsExceptionDTO.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/WlsExceptionDTO.java
@@ -20,12 +20,12 @@ public record WlsExceptionDTO(@NotNull WlsExceptionCategory category, @NotNull S
         });
 
         this.service = Optional.ofNullable(service).orElseGet(() -> {
-            log.warn("Service war nicht enthalten. Setzte allgemeinen Service");
+            log.warn("Service ist nicht enthalten. Setze allgemeinen Service");
             return ExceptionKonstanten.SERVICE_UNBEKANNT;
         });
 
         this.message = Optional.ofNullable(message).orElseGet(() -> {
-            log.warn("Nachricht war nicht enthalten. Setze allgemeine Nachricht");
+            log.warn("Nachricht ist nicht enthalten. Setze allgemeine Nachricht");
             return ExceptionKonstanten.MESSAGE_UNBEKANNTER_FEHLER;
         });
     }

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/WlsExceptionDTO.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/WlsExceptionDTO.java
@@ -1,0 +1,32 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model;
+
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.util.ExceptionKonstanten;
+import jakarta.validation.constraints.NotNull;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public record WlsExceptionDTO(@NotNull WlsExceptionCategory category, @NotNull String code, @NotNull String service, @NotNull String message) {
+
+    public WlsExceptionDTO(final WlsExceptionCategory category, final String code, final String service, final String message) {
+        this.category = Optional.ofNullable(category).orElseGet(() -> {
+            log.warn("Category ist nicht enthalten");
+            return WlsExceptionCategory.T;
+        });
+
+        this.code = Optional.ofNullable(code).orElseGet(() -> {
+            log.warn("Code ist nicht enthalten. Setze allgemeinen Code");
+            return ExceptionKonstanten.CODE_ALLGEMEIN_UNBEKANNT;
+        });
+
+        this.service = Optional.ofNullable(service).orElseGet(() -> {
+            log.warn("Service war nicht enthalten. Setzte allgemeinen Service");
+            return ExceptionKonstanten.SERVICE_UNBEKANNT;
+        });
+
+        this.message = Optional.ofNullable(message).orElseGet(() -> {
+            log.warn("Nachricht war nicht enthalten. Setze allgemeine Nachricht");
+            return ExceptionKonstanten.MESSAGE_UNBEKANNTER_FEHLER;
+        });
+    }
+}

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/util/ExceptionKonstanten.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/util/ExceptionKonstanten.java
@@ -1,0 +1,40 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.util;
+
+public interface ExceptionKonstanten {
+
+    /**
+     * Code in der Kategorie CATEGORY_FACHLICH für gesuchte Entität nicht gefunden
+     */
+    String CODE_ENTITY_NOT_FOUND = "204";
+
+    /**
+     * Code der Kategorie CATEGORY_FACHLICH für "HTTP-Nachricht nicht lesbar".
+     */
+    String CODE_HTTP_MESSAGE_NOT_READABLE = "450";
+
+    /**
+     * Code der Kategorie CATEGORY_TECHNISCH für Fehlersituationen, die bei erneutem Senden des unter fachlichen Gesichtspunkten unveränderten Requests gelingen
+     * könnten.
+     */
+    String CODE_TRANSIENT = "451";
+
+    /**
+     * Allgemeiner Code für einen unbekannten Fehler
+     */
+    String CODE_ALLGEMEIN_UNBEKANNT = "999";
+
+    /**
+     * Sicherheitscode wenn der Zugriff verweigert wurde
+     */
+    String CODE_SECURITY_ACCESS_DENIED = "403";
+
+    /**
+     * Fehlermeldung fuer einen unbekannten Fehler
+     */
+    String MESSAGE_UNBEKANNTER_FEHLER = "Es ist ein unbekannter Fehler aufgetreten";
+
+    /**
+     * String fuer Service in Fehlerdaten wenn der Service nicht bekannt ist
+     */
+    String SERVICE_UNBEKANNT = "_SERVICE_UNBEKANNT_";
+}

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/util/ExceptionKonstanten.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/util/ExceptionKonstanten.java
@@ -13,7 +13,8 @@ public interface ExceptionKonstanten {
     String CODE_HTTP_MESSAGE_NOT_READABLE = "450";
 
     /**
-     * Code der Kategorie CATEGORY_TECHNISCH für Fehlersituationen, die bei erneutem Senden des unter fachlichen Gesichtspunkten unveränderten Requests gelingen
+     * Code der Kategorie CATEGORY_TECHNISCH für Fehlersituationen, die bei erneutem Senden des unter
+     * fachlichen Gesichtspunkten unveränderten Requests gelingen
      * könnten.
      */
     String CODE_TRANSIENT = "451";

--- a/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/util/ServiceIDFormatter.java
+++ b/wls-common/exception/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/util/ServiceIDFormatter.java
@@ -1,0 +1,18 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ServiceIDFormatter {
+
+    private final String serviceName;
+
+    public ServiceIDFormatter(@Value("${service.info.oid}") final String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    public String getId() {
+        return serviceName;
+    }
+}

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/FachlicheWlsExceptionTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/FachlicheWlsExceptionTest.java
@@ -1,0 +1,24 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception;
+
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class FachlicheWlsExceptionTest {
+
+    @Test
+    void verifyDataIsSetCorrect() {
+        val code = "089";
+        val message = "very useful message";
+        val serviceName = "testService";
+        val causingException = new NullPointerException("something was null");
+        val fachlicheWlsException = FachlicheWlsException.withCode(code).inService(serviceName).withCause(causingException).buildWithMessage(message);
+
+        Assertions.assertThat(fachlicheWlsException.getCategory()).isSameAs(WlsExceptionCategory.FACHLICH);
+        Assertions.assertThat(fachlicheWlsException.getCode()).isSameAs(code);
+        Assertions.assertThat(fachlicheWlsException.getMessage()).isSameAs(message);
+        Assertions.assertThat(fachlicheWlsException.getServiceName()).isSameAs(serviceName);
+        Assertions.assertThat(fachlicheWlsException.getCause()).isSameAs(causingException);
+    }
+}

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/InfrastrukturelleWlsExceptionTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/InfrastrukturelleWlsExceptionTest.java
@@ -1,0 +1,27 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception;
+
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class InfrastrukturelleWlsExceptionTest {
+
+    @Test
+    void verifyDataIsSetCorrect() {
+        val code = "089";
+        val message = "very useful message";
+        val serviceName = "testService";
+        val causingException = new NullPointerException("something was null");
+
+        val infrastrukturelleWlsException = InfrastrukturelleWlsException.withCode(code).inService(serviceName).withCause(causingException)
+                .buildWithMessage(message);
+
+        Assertions.assertThat(infrastrukturelleWlsException.getCategory()).isSameAs(WlsExceptionCategory.INFRASTRUKTUR);
+        Assertions.assertThat(infrastrukturelleWlsException.getCode()).isSameAs(code);
+        Assertions.assertThat(infrastrukturelleWlsException.getMessage()).isSameAs(message);
+        Assertions.assertThat(infrastrukturelleWlsException.getServiceName()).isSameAs(serviceName);
+        Assertions.assertThat(infrastrukturelleWlsException.getCause()).isSameAs(causingException);
+    }
+
+}

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/SicherheitsWlsExceptionTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/SicherheitsWlsExceptionTest.java
@@ -1,0 +1,25 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception;
+
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class SicherheitsWlsExceptionTest {
+
+    @Test
+    void verifyDataIsSetCorrect() {
+        val code = "089";
+        val message = "very useful message";
+        val serviceName = "testService";
+        val causingException = new NullPointerException("something was null");
+
+        val sicherheitsWlsException = SicherheitsWlsException.withCode(code).inService(serviceName).withCause(causingException).buildWithMessage(message);
+
+        Assertions.assertThat(sicherheitsWlsException.getCategory()).isSameAs(WlsExceptionCategory.SECURITY);
+        Assertions.assertThat(sicherheitsWlsException.getCode()).isSameAs(code);
+        Assertions.assertThat(sicherheitsWlsException.getMessage()).isSameAs(message);
+        Assertions.assertThat(sicherheitsWlsException.getServiceName()).isSameAs(serviceName);
+        Assertions.assertThat(sicherheitsWlsException.getCause()).isSameAs(causingException);
+    }
+}

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/TechnischeWlsExceptionTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/TechnischeWlsExceptionTest.java
@@ -1,0 +1,27 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception;
+
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TechnischeWlsExceptionTest {
+
+    @Test
+    void verifyDataIsSetCorrect() {
+        val code = "089";
+        val message = "very useful message";
+        val serviceName = "testService";
+        val causingException = new NullPointerException("something was null");
+
+        val technischeWlsException = TechnischeWlsException.withCode(code).inService(serviceName).withCause(causingException)
+                .buildWithMessage(message);
+
+        Assertions.assertThat(technischeWlsException.getCategory()).isSameAs(WlsExceptionCategory.TECHNISCH);
+        Assertions.assertThat(technischeWlsException.getCode()).isSameAs(code);
+        Assertions.assertThat(technischeWlsException.getMessage()).isSameAs(message);
+        Assertions.assertThat(technischeWlsException.getServiceName()).isSameAs(serviceName);
+        Assertions.assertThat(technischeWlsException.getCause()).isSameAs(causingException);
+    }
+
+}

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/builder/WlsExceptionFactoryTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/builder/WlsExceptionFactoryTest.java
@@ -1,0 +1,57 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.builder;
+
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.FachlicheWlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.WlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionData;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WlsExceptionFactoryTest {
+
+    @Mock
+    private WlsExceptionCreator<WlsException> mockedCreator;
+
+    @Test
+    void exceptionDataIsCollectedAndSendToCreator() {
+        val unitUnderTest = new WlsExceptionFactory<>(mockedCreator);
+
+        val dataForBuild = new WlsExceptionData("message", "serviceName", "code", new NullPointerException("npe"));
+        val mockedWlsException = FachlicheWlsException.withCode(dataForBuild.getCode()).buildWithMessage(dataForBuild.getMessage());
+        Mockito.when(mockedCreator.createWlsException(dataForBuild)).thenReturn(mockedWlsException);
+
+        unitUnderTest.withCode(dataForBuild.getCode());
+        unitUnderTest.inService(dataForBuild.getServiceName());
+        unitUnderTest.withCause(dataForBuild.getCause());
+        val createdWlsException = unitUnderTest.buildWithMessage(dataForBuild.getMessage());
+
+        Assertions.assertThat(createdWlsException).isSameAs(mockedWlsException);
+    }
+
+    @Test
+    void withCodeReturnsFactoryItself() {
+        val unitUnderTest = new WlsExceptionFactory<>(mockedCreator);
+
+        Assertions.assertThat(unitUnderTest.withCode("code")).isSameAs(unitUnderTest);
+    }
+
+    @Test
+    void inServiceReturnsFactoryItself() {
+        val unitUnderTest = new WlsExceptionFactory<>(mockedCreator);
+
+        Assertions.assertThat(unitUnderTest.inService("service")).isSameAs(unitUnderTest);
+    }
+
+    @Test
+    void withCauseReturnsFactoryItself() {
+        val unitUnderTest = new WlsExceptionFactory<>(mockedCreator);
+
+        Assertions.assertThat(unitUnderTest.withCause(new NullPointerException("npe"))).isSameAs(unitUnderTest);
+    }
+
+}

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/AbstractExceptionHandlerTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/AbstractExceptionHandlerTest.java
@@ -1,0 +1,228 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.errorhandler;
+
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.SicherheitsWlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.DTOMapper;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExceptionCategory;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExceptionDTO;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.util.ExceptionKonstanten;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractExceptionHandlerTest {
+
+    private static final String GET_SERVICE_RESULT = "theService";
+
+    private final DTOMapper dtoMapper = Mockito.mock(DTOMapper.class);
+
+    final AbstractExceptionHandler unitUnderTest = new AbstractExceptionHandler(dtoMapper) {
+        @Override
+        protected String getService() {
+            return GET_SERVICE_RESULT;
+        }
+    };
+
+    @Nested
+    class GetWahlExceptionDTO {
+
+        @Test
+        void handleWlsException() {
+            val code = "089";
+            val serviceName = "service name";
+            val cause = new NullPointerException("sth null");
+            val message = "message for exception";
+            val exceptionToHandle = SicherheitsWlsException.withCode(code).inService(serviceName).withCause(cause).buildWithMessage(message);
+
+            val mappedDTO = new WlsExceptionDTO(WlsExceptionCategory.S, code, serviceName, message);
+            Mockito.when(dtoMapper.toDTO(exceptionToHandle)).thenReturn(mappedDTO);
+
+            val result = unitUnderTest.getWahlExceptionDTO(exceptionToHandle);
+
+            Assertions.assertThat(result).isSameAs(mappedDTO);
+        }
+
+        @Test
+        void handleAccessDeniedException() {
+            val causingException = new NullPointerException("some was null");
+            val accessDeniedException = new AccessDeniedException("you shall not pass", causingException);
+
+            val result = unitUnderTest.getWahlExceptionDTO(accessDeniedException);
+
+            val expectedResult = new WlsExceptionDTO(WlsExceptionCategory.S, ExceptionKonstanten.CODE_SECURITY_ACCESS_DENIED, GET_SERVICE_RESULT,
+                    accessDeniedException.getMessage());
+
+            Assertions.assertThat(result).isEqualTo(expectedResult);
+
+        }
+
+        @Test
+        void handleHttpMessageNotReadableException() {
+            val cause = new IllegalArgumentException("text is not a fax");
+            final HttpInputMessage inputMessage = (null);
+            val messageNotReadableException = new HttpMessageNotReadableException("wrong type of message", cause, inputMessage);
+
+            val result = unitUnderTest.getWahlExceptionDTO(messageNotReadableException);
+
+            val expectedResult = new WlsExceptionDTO(WlsExceptionCategory.F, ExceptionKonstanten.CODE_HTTP_MESSAGE_NOT_READABLE, GET_SERVICE_RESULT,
+                    "HTTP-Nachricht nicht lesbar: " + messageNotReadableException.getMessage());
+
+            Assertions.assertThat(result).isEqualTo(expectedResult);
+        }
+
+        @Test
+        void handleTransientDataAccessException() {
+            val causingException = new NullPointerException("some was null");
+            val transientException = new TransientDataAccessException("my TransientDataAccessException message", causingException) {
+
+            };
+
+            val result = unitUnderTest.getWahlExceptionDTO(transientException);
+
+            val expectedResult = new WlsExceptionDTO(WlsExceptionCategory.T, ExceptionKonstanten.CODE_TRANSIENT, GET_SERVICE_RESULT,
+                    "Temporäres Problem, Ursache: " + transientException.getClass() + ", Nachricht: " + transientException.getMessage());
+
+            Assertions.assertThat(result).isEqualTo(expectedResult);
+        }
+
+        @Test
+        void handleAnythingElse() {
+            val nullPointerException = new NullPointerException("object was null");
+
+            val result = unitUnderTest.getWahlExceptionDTO(nullPointerException);
+
+            val expectedResult = new WlsExceptionDTO(WlsExceptionCategory.T, ExceptionKonstanten.CODE_ALLGEMEIN_UNBEKANNT, GET_SERVICE_RESULT,
+                    "Ursache: " + nullPointerException.getClass() + ", Nachricht: " + nullPointerException.getMessage());
+
+            Assertions.assertThat(result).isEqualTo(expectedResult);
+        }
+    }
+
+    @Test
+    void createForTransientException() {
+        val causingException = new NullPointerException("some was null");
+        val transientException = new TransientDataAccessException("my TransientDataAccessException message", causingException) {
+
+        };
+
+        val result = unitUnderTest.createForTransientException(transientException);
+
+        val expectedResult = new WlsExceptionDTO(WlsExceptionCategory.T, ExceptionKonstanten.CODE_TRANSIENT, GET_SERVICE_RESULT,
+                "Temporäres Problem, Ursache: " + transientException.getClass() + ", Nachricht: " + transientException.getMessage());
+
+        Assertions.assertThat(result).isEqualTo(expectedResult);
+    }
+
+    @Test
+    void createForAccessDeniedException() {
+        val causingException = new NullPointerException("some was null");
+        val accessDeniedException = new AccessDeniedException("you shall not pass", causingException);
+
+        val result = unitUnderTest.createForAccessDeniedException(accessDeniedException);
+
+        val expectedResult = new WlsExceptionDTO(WlsExceptionCategory.S, ExceptionKonstanten.CODE_SECURITY_ACCESS_DENIED, GET_SERVICE_RESULT,
+                accessDeniedException.getMessage());
+
+        Assertions.assertThat(result).isEqualTo(expectedResult);
+    }
+
+    @Nested
+    class CreateResponse {
+
+        @Test
+        void categoryIsNull() {
+            val wlsExceptionDTO = createWlsExceptionDTOWithCategory(null);
+
+            val result = unitUnderTest.createResponse(wlsExceptionDTO);
+
+            val expectedResult = ResponseEntity.internalServerError().body(wlsExceptionDTO);
+
+            Assertions.assertThat(result).isEqualTo(expectedResult);
+        }
+
+        @Test
+        void categoryIsFachlichNotFound() {
+            val wlsExceptionDTO = createWlsExceptionDTOWithCategoryAndCode(WlsExceptionCategory.F, ExceptionKonstanten.CODE_ENTITY_NOT_FOUND);
+
+            val result = unitUnderTest.createResponse(wlsExceptionDTO);
+
+            val expectedResult = ResponseEntity.noContent().build();
+
+            Assertions.assertThat(result).isEqualTo(expectedResult);
+        }
+
+        @Test
+        void categoryIsFachlichNotNotFound() {
+            val wlsExceptionDTO = createWlsExceptionDTOWithCategoryAndCode(WlsExceptionCategory.F, ExceptionKonstanten.CODE_ENTITY_NOT_FOUND + "ABC");
+
+            val result = unitUnderTest.createResponse(wlsExceptionDTO);
+
+            val expectedResult = ResponseEntity.badRequest().body(wlsExceptionDTO);
+
+            Assertions.assertThat(result).isEqualTo(expectedResult);
+        }
+
+        @Test
+        void categoryIsTechnischNotTransient() {
+            val wlsExceptionDTO = createWlsExceptionDTOWithCategoryAndCode(WlsExceptionCategory.T, ExceptionKonstanten.CODE_TRANSIENT + "ABC");
+
+            val result = unitUnderTest.createResponse(wlsExceptionDTO);
+
+            val expectedResult = ResponseEntity.internalServerError().body(wlsExceptionDTO);
+
+            Assertions.assertThat(result).isEqualTo(expectedResult);
+        }
+
+        @Test
+        void categoryIsTechnischTransient() {
+            val wlsExceptionDTO = createWlsExceptionDTOWithCategoryAndCode(WlsExceptionCategory.T, ExceptionKonstanten.CODE_TRANSIENT);
+
+            val result = unitUnderTest.createResponse(wlsExceptionDTO);
+
+            val expectedResult = ResponseEntity.status(HttpStatus.CONFLICT).body(wlsExceptionDTO);
+
+            Assertions.assertThat(result).isEqualTo(expectedResult);
+        }
+
+        @Test
+        void categoryIsSicherheit() {
+            val wlsExceptionDTO = createWlsExceptionDTOWithCategory(WlsExceptionCategory.S);
+
+            val result = unitUnderTest.createResponse(wlsExceptionDTO);
+
+            val expectedResult = ResponseEntity.status(HttpStatus.FORBIDDEN).body(wlsExceptionDTO);
+
+            Assertions.assertThat(result).isEqualTo(expectedResult);
+        }
+
+        @Test
+        void categoryIsInfrastruktur() {
+            val wlsExceptionDTO = createWlsExceptionDTOWithCategory(WlsExceptionCategory.I);
+
+            val result = unitUnderTest.createResponse(wlsExceptionDTO);
+
+            val expectedResult = ResponseEntity.internalServerError().body(wlsExceptionDTO);
+
+            Assertions.assertThat(result).isEqualTo(expectedResult);
+        }
+
+        private WlsExceptionDTO createWlsExceptionDTOWithCategory(final WlsExceptionCategory category) {
+            return createWlsExceptionDTOWithCategoryAndCode(category, "code");
+        }
+
+        private WlsExceptionDTO createWlsExceptionDTOWithCategoryAndCode(final WlsExceptionCategory category, final String code) {
+            return new WlsExceptionDTO(category, code, "service", "message");
+        }
+    }
+
+}

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/WlsResponseErrorHandlerTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/WlsResponseErrorHandlerTest.java
@@ -1,0 +1,126 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.errorhandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.FachlicheWlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.InfrastrukturelleWlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.SicherheitsWlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.TechnischeWlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.WlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExceptionCategory;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExceptionDTO;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.util.ExceptionKonstanten;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.client.ClientHttpResponse;
+
+@ExtendWith(MockitoExtension.class)
+class WlsResponseErrorHandlerTest {
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private ClientHttpResponse response;
+
+    @InjectMocks
+    private WlsResponseErrorHandler unitUnderTest;
+
+    @Nested
+    class HandleError {
+
+        @Test
+        void fachlicheExceptionCreatedFromResponse() throws Exception {
+            val mockedResponseBody = new ByteArrayInputStream("mocked response body as stream".getBytes());
+            Mockito.when(response.getBody()).thenReturn(mockedResponseBody);
+
+            val fachlicheWlsExceptionDTO = new WlsExceptionDTO(WlsExceptionCategory.F, "code", "serviceName", "message");
+            Mockito.when(objectMapper.readValue(mockedResponseBody, WlsExceptionDTO.class)).thenReturn(fachlicheWlsExceptionDTO);
+
+            val exceptionThrown = Assertions.catchThrowableOfType(() -> unitUnderTest.handleError(response), FachlicheWlsException.class);
+
+            assertAllWlsExceptionsAreSetExceptCategory(exceptionThrown, fachlicheWlsExceptionDTO);
+        }
+
+        @Test
+        void technischeExceptionCreatedFromResponse() throws Exception {
+            val mockedResponseBody = new ByteArrayInputStream("mocked response body as stream".getBytes());
+            Mockito.when(response.getBody()).thenReturn(mockedResponseBody);
+
+            val fachlicheWlsExceptionDTO = new WlsExceptionDTO(WlsExceptionCategory.T, "code", "serviceName", "message");
+            Mockito.when(objectMapper.readValue(mockedResponseBody, WlsExceptionDTO.class)).thenReturn(fachlicheWlsExceptionDTO);
+
+            val exceptionThrown = Assertions.catchThrowableOfType(() -> unitUnderTest.handleError(response), TechnischeWlsException.class);
+
+            assertAllWlsExceptionsAreSetExceptCategory(exceptionThrown, fachlicheWlsExceptionDTO);
+        }
+
+        @Test
+        void securityExceptionCreatedFromResponse() throws Exception {
+            val mockedResponseBody = new ByteArrayInputStream("mocked response body as stream".getBytes());
+            Mockito.when(response.getBody()).thenReturn(mockedResponseBody);
+
+            val fachlicheWlsExceptionDTO = new WlsExceptionDTO(WlsExceptionCategory.S, "code", "serviceName", "message");
+            Mockito.when(objectMapper.readValue(mockedResponseBody, WlsExceptionDTO.class)).thenReturn(fachlicheWlsExceptionDTO);
+
+            val exceptionThrown = Assertions.catchThrowableOfType(() -> unitUnderTest.handleError(response), SicherheitsWlsException.class);
+
+            assertAllWlsExceptionsAreSetExceptCategory(exceptionThrown, fachlicheWlsExceptionDTO);
+        }
+
+        @Test
+        void infrastrukturExceptionCreatedFromResponse() throws Exception {
+            val mockedResponseBody = new ByteArrayInputStream("mocked response body as stream".getBytes());
+            Mockito.when(response.getBody()).thenReturn(mockedResponseBody);
+
+            val fachlicheWlsExceptionDTO = new WlsExceptionDTO(WlsExceptionCategory.I, "code", "serviceName", "message");
+            Mockito.when(objectMapper.readValue(mockedResponseBody, WlsExceptionDTO.class)).thenReturn(fachlicheWlsExceptionDTO);
+
+            val exceptionThrown = Assertions.catchThrowableOfType(() -> unitUnderTest.handleError(response), InfrastrukturelleWlsException.class);
+
+            assertAllWlsExceptionsAreSetExceptCategory(exceptionThrown, fachlicheWlsExceptionDTO);
+        }
+
+        @Test
+        void exceptionDuringCreationOfExceptionFromResponse() throws Exception {
+            val exceptionThrownByMappingResponse = new IOException("something strange happened");
+            Mockito.when(response.getBody()).thenThrow(exceptionThrownByMappingResponse);
+
+            val exceptionThrown = Assertions.catchThrowableOfType(() -> unitUnderTest.handleError(response), TechnischeWlsException.class);
+
+            val expectedExceptionMessage = ExceptionKonstanten.MESSAGE_UNBEKANNTER_FEHLER + "\nWegen: " + exceptionThrownByMappingResponse.getClass()
+                    + " mit:\n" + exceptionThrownByMappingResponse.getMessage();
+            val expectedException = TechnischeWlsException.withCode(ExceptionKonstanten.CODE_ALLGEMEIN_UNBEKANNT)
+                    .inService(ExceptionKonstanten.SERVICE_UNBEKANNT).withCause(exceptionThrownByMappingResponse)
+                    .buildWithMessage(expectedExceptionMessage);
+
+            assertWlsExceptionPropertiesAreEqual(exceptionThrown, expectedException);
+        }
+
+        private void assertAllWlsExceptionsAreSetExceptCategory(final WlsException exceptionToCheck, final WlsExceptionDTO dataToBeSet) {
+            //category muss nicht geprüft werden da diese durch die Exception-Klasse gesetzt wird (siehe deren Konstruktor)
+            Assertions.assertThat(exceptionToCheck.getCode()).isEqualTo(dataToBeSet.code());
+            Assertions.assertThat(exceptionToCheck.getMessage()).isEqualTo(dataToBeSet.message());
+            Assertions.assertThat(exceptionToCheck.getServiceName()).isEqualTo(dataToBeSet.service());
+            Assertions.assertThat(exceptionToCheck.getCause()).isNull();
+        }
+
+        private void assertWlsExceptionPropertiesAreEqual(final WlsException actual, final WlsException expected) {
+            Assertions.assertThat(actual.getCause()).isEqualTo(expected.getCause());
+            Assertions.assertThat(actual.getCode()).isEqualTo(expected.getCode());
+            Assertions.assertThat(actual.getCategory()).isEqualTo(expected.getCategory());
+            Assertions.assertThat(actual.getServiceName()).isEqualTo(expected.getServiceName());
+            Assertions.assertThat(actual.getMessage()).isEqualTo(expected.getMessage());
+
+        }
+    }
+
+}

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/DTOMapperTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/DTOMapperTest.java
@@ -1,0 +1,56 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model;
+
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.FachlicheWlsException;
+import java.util.stream.Stream;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mapstruct.factory.Mappers;
+
+class DTOMapperTest {
+
+    private final DTOMapper unitUnderTest = Mappers.getMapper(DTOMapper.class);
+
+    @Nested
+    class ToDTO {
+
+        @Test
+        void nullInNullOut() {
+            Assertions.assertThat(unitUnderTest.toDTO(null)).isNull();
+        }
+
+        @Test
+        void toDTO() {
+            val code = "089";
+            val serviceName = "dto mapper test";
+            val message = "lets check the mapping";
+            val source = FachlicheWlsException.withCode(code).inService(serviceName).buildWithMessage(message);
+            val expectedResult = new WlsExceptionDTO(WlsExceptionCategory.F, code, serviceName, message);
+
+            val result = unitUnderTest.toDTO(source);
+
+            Assertions.assertThat(result).isEqualTo(expectedResult);
+        }
+
+    }
+
+    @ParameterizedTest(name = "expected: {0} input: {1}")
+    @MethodSource
+    void toDTOCategory(final WlsExceptionCategory expectedResult,
+            final de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory categoryToMap) {
+        Assertions.assertThat(unitUnderTest.toDTOCategory(categoryToMap)).isEqualTo(expectedResult);
+    }
+
+    private static Stream<Arguments> toDTOCategory() {
+        return Stream.of(
+                Arguments.of(WlsExceptionCategory.F, de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory.FACHLICH),
+                Arguments.of(WlsExceptionCategory.I, de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory.INFRASTRUKTUR),
+                Arguments.of(WlsExceptionCategory.S, de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory.SECURITY),
+                Arguments.of(WlsExceptionCategory.T, de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory.TECHNISCH),
+                Arguments.of(null, null));
+    }
+}

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/WlsExceptionDTOTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/WlsExceptionDTOTest.java
@@ -1,0 +1,85 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model;
+
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.testutils.LoggerExtension;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.util.ExceptionKonstanten;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class WlsExceptionDTOTest {
+
+    @Test
+    void onlyHasOneConstructor() {
+        Assertions.assertThat(WlsExceptionDTO.class.getConstructors().length).withFailMessage("es sollte nur den überschrieben Konstruktur geben").isEqualTo(1);
+    }
+
+    @Test
+    void isNullSafe() {
+        val result = new WlsExceptionDTO(null, null, null, null);
+
+        val expectedResult = new WlsExceptionDTO(WlsExceptionCategory.T, ExceptionKonstanten.CODE_ALLGEMEIN_UNBEKANNT, ExceptionKonstanten.SERVICE_UNBEKANNT,
+                ExceptionKonstanten.MESSAGE_UNBEKANNTER_FEHLER);
+
+        Assertions.assertThat(result).isEqualTo(expectedResult);
+    }
+
+    @Test
+    void parametersAreSetToCorrectProperty() {
+        val category = WlsExceptionCategory.I;
+        val code = "089233";
+        val service = "WLS3.0 TestService";
+        val message = "Lorem ipsum";
+
+        val result = new WlsExceptionDTO(category, code, service, message);
+
+        Assertions.assertThat(result.category()).isEqualTo(category);
+        Assertions.assertThat(result.code()).isEqualTo(code);
+        Assertions.assertThat(result.message()).isEqualTo(message);
+        Assertions.assertThat(result.service()).isEqualTo(service);
+    }
+
+    @Nested
+    class TestLoggingEvents {
+
+        @RegisterExtension
+        public LoggerExtension loggerExtension = new LoggerExtension();
+
+        @Test
+        void noLoggEventsOnCorrectUsedConstructor() {
+            new WlsExceptionDTO(WlsExceptionCategory.T, "code", "service", "message");
+
+            Assertions.assertThat(loggerExtension.getFormattedMessages().isEmpty()).isTrue();
+        }
+
+        @Test
+        void warnOnCategoryIsNull() {
+            new WlsExceptionDTO(null, "code", "service", "message");
+
+            Assertions.assertThat(loggerExtension.getFormattedMessages().size()).isEqualTo(1);
+        }
+
+        @Test
+        void warnOnCodeIsNull() {
+            new WlsExceptionDTO(WlsExceptionCategory.T, null, "service", "message");
+
+            Assertions.assertThat(loggerExtension.getFormattedMessages().size()).isEqualTo(1);
+        }
+
+        @Test
+        void warnOnServiceIsNull() {
+            new WlsExceptionDTO(WlsExceptionCategory.T, "code", null, "message");
+
+            Assertions.assertThat(loggerExtension.getFormattedMessages().size()).isEqualTo(1);
+        }
+
+        @Test
+        void warnOnMessageIsNull() {
+            new WlsExceptionDTO(WlsExceptionCategory.T, "code", "service", null);
+
+            Assertions.assertThat(loggerExtension.getFormattedMessages().size()).isEqualTo(1);
+        }
+    }
+
+}

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/testutils/LoggerExtension.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/testutils/LoggerExtension.java
@@ -3,7 +3,6 @@ package de.muenchen.oss.wahllokalsystem.wls.common.exception.testutils;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -16,20 +15,16 @@ public class LoggerExtension implements BeforeEachCallback, AfterEachCallback {
     private final Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
 
     @Override
-    public void afterEach(ExtensionContext extensionContext) throws Exception {
+    public void afterEach(ExtensionContext extensionContext) {
         listAppender.stop();
         listAppender.list.clear();
         logger.detachAppender(listAppender);
     }
 
     @Override
-    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+    public void beforeEach(ExtensionContext extensionContext) {
         logger.addAppender(listAppender);
         listAppender.start();
-    }
-
-    public List<ILoggingEvent> getEvents() {
-        return Collections.unmodifiableList(listAppender.list);
     }
 
     public List<String> getFormattedMessages() {

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/testutils/LoggerExtension.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/testutils/LoggerExtension.java
@@ -1,0 +1,38 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.testutils;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.LoggerFactory;
+
+public class LoggerExtension implements BeforeEachCallback, AfterEachCallback {
+
+    private final ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    private final Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
+        listAppender.stop();
+        listAppender.list.clear();
+        logger.detachAppender(listAppender);
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        logger.addAppender(listAppender);
+        listAppender.start();
+    }
+
+    public List<ILoggingEvent> getEvents() {
+        return Collections.unmodifiableList(listAppender.list);
+    }
+
+    public List<String> getFormattedMessages() {
+        return listAppender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
+    }
+}

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/util/ServiceIDFormatterSpringContextTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/util/ServiceIDFormatterSpringContextTest.java
@@ -1,0 +1,18 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.util;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = ServiceIDFormatter.class, properties = "service.info.oid=My app name")
+class ServiceIDFormatterSpringContextTest {
+
+    @Autowired
+    ServiceIDFormatter serviceIDFormatter;
+
+    @Test
+    void checkPropertyForServiceNameIsUsed() {
+        Assertions.assertThat(serviceIDFormatter.getId()).contains("My app name");
+    }
+}

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/util/ServiceIDFormatterTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/util/ServiceIDFormatterTest.java
@@ -1,0 +1,16 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.util;
+
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ServiceIDFormatterTest {
+
+    @Test
+    void getId() {
+        val appName = "app name";
+        val unitUnderTest = new ServiceIDFormatter(appName);
+
+        Assertions.assertThat(unitUnderTest.getId()).isEqualTo(appName);
+    }
+}

--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -106,9 +106,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.3.1</version>
                     <configuration>
                         <configLocation>checkstyle.xml</configLocation>
+                        <excludeGeneratedSources>true</excludeGeneratedSources>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
❗ Erfordert PR:
- #51 zu Mapstruct Depdendency

* Beschreibung *
- Umsetzung des Exceptionmoduls
- Habe beim Erzeugen der Exception die Alternative gewählt: FluentAPI mit Factory. Dadurch wird sichergestellt dass mindest Category, Code und Message einer Exception durch Entwickler gefüllt werden
- die HttpStatusCode habe ich aus den Konstanten in den Handler verlagert da sie nur dort benötigt werden. Der Handler sollte der SinglePointOfTruth sein bei der Erzeugung der Restantwort, somit für den HttpStatus verantwortlich.
- wenn es zu einer zu testenden Methode mehrere Testfälle gab so habe ich diese in einer nested Testsuit zusammengefasst
- Hebung von checkstyle damit [`excludeGeneratedSources`](https://maven.apache.org/plugins/maven-checkstyle-plugin/check-mojo.html#excludeGeneratedSources) verwendet werden kann

Issue:
#18