### PR TITLE
Setzen vom Label renovate durch den renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "addLabels": [
+    "renovate"
   ]
 }


### PR DESCRIPTION
Der Renovate-Bot erzeugt PRs sobald es neue Versionen gibt die wir übernehmen könnten. Damit diese leichter auffindbar sind (auch im Rückblick) und wir nicht über eine Namenssuche gehen müssen hier ein PR der dafür sorgt das Renovate das Label `renovate` bei seinen PRs setzt.