### PR TITLE
Fix Trigger und Publish-Ordner für GithubPages-Action

### DIFF
--- a/.github/workflows/release-doc.yaml
+++ b/.github/workflows/release-doc.yaml
@@ -30,4 +30,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/dist
+          publish_dir: ./docs/.vitepress/dist

--- a/.github/workflows/release-doc.yaml
+++ b/.github/workflows/release-doc.yaml
@@ -6,6 +6,7 @@ on:
       - dev
     paths:
       - 'docs/**'
+      - '.github/workflows/release-doc.yaml'
 
 jobs:
   build:


### PR DESCRIPTION
**Description**

Fix der Konfig für github-Pages-Action. Es war das falsche Directory angegeben weshalb nichts gepublished wurde. Das Workflow-File wurde mit aufgenommen bei den paths damit der Workflow auch getriggert wird wenn keine inhaltlichen Anpassen an der Doku, sondern nur am Workflow, erfolgen.

**Reference**

#13
