### PR TITLE
fix SecurityConfig: dont permitAll on all paths

### DIFF
--- a/wls-broadcast-service/src/main/java/de/muenchen/oss/wahllokalsystem/configuration/SecurityConfiguration.java
+++ b/wls-broadcast-service/src/main/java/de/muenchen/oss/wahllokalsystem/configuration/SecurityConfiguration.java
@@ -37,17 +37,17 @@ public class SecurityConfiguration {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .authorizeHttpRequests((requests) -> requests.requestMatchers(AntPathRequestMatcher.antMatcher("/**"),
-                        // allow access to /actuator/info
-                        AntPathRequestMatcher.antMatcher("/actuator/info"),
-                        // allow access to /actuator/health for OpenShift Health Check
-                        AntPathRequestMatcher.antMatcher("/actuator/health"),
-                        // allow access to /actuator/health/liveness for OpenShift Liveness Check
-                        AntPathRequestMatcher.antMatcher("/actuator/health/liveness"),
-                        // allow access to /actuator/health/readiness for OpenShift Readiness Check
-                        AntPathRequestMatcher.antMatcher("/actuator/health/readiness"),
-                        // allow access to /actuator/metrics for Prometheus monitoring in OpenShift
-                        AntPathRequestMatcher.antMatcher("/actuator/metrics"))
+                .authorizeHttpRequests((requests) -> requests.requestMatchers(
+                                // allow access to /actuator/info
+                                AntPathRequestMatcher.antMatcher("/actuator/info"),
+                                // allow access to /actuator/health for OpenShift Health Check
+                                AntPathRequestMatcher.antMatcher("/actuator/health"),
+                                // allow access to /actuator/health/liveness for OpenShift Liveness Check
+                                AntPathRequestMatcher.antMatcher("/actuator/health/liveness"),
+                                // allow access to /actuator/health/readiness for OpenShift Readiness Check
+                                AntPathRequestMatcher.antMatcher("/actuator/health/readiness"),
+                                // allow access to /actuator/metrics for Prometheus monitoring in OpenShift
+                                AntPathRequestMatcher.antMatcher("/actuator/metrics"))
                         .permitAll())
                 .authorizeHttpRequests((requests) -> requests.requestMatchers("/**")
                         .authenticated())

--- a/wls-broadcast-service/src/main/java/de/muenchen/oss/wahllokalsystem/configuration/SecurityConfiguration.java
+++ b/wls-broadcast-service/src/main/java/de/muenchen/oss/wahllokalsystem/configuration/SecurityConfiguration.java
@@ -38,16 +38,16 @@ public class SecurityConfiguration {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests((requests) -> requests.requestMatchers(
-                                // allow access to /actuator/info
-                                AntPathRequestMatcher.antMatcher("/actuator/info"),
-                                // allow access to /actuator/health for OpenShift Health Check
-                                AntPathRequestMatcher.antMatcher("/actuator/health"),
-                                // allow access to /actuator/health/liveness for OpenShift Liveness Check
-                                AntPathRequestMatcher.antMatcher("/actuator/health/liveness"),
-                                // allow access to /actuator/health/readiness for OpenShift Readiness Check
-                                AntPathRequestMatcher.antMatcher("/actuator/health/readiness"),
-                                // allow access to /actuator/metrics for Prometheus monitoring in OpenShift
-                                AntPathRequestMatcher.antMatcher("/actuator/metrics"))
+                        // allow access to /actuator/info
+                        AntPathRequestMatcher.antMatcher("/actuator/info"),
+                        // allow access to /actuator/health for OpenShift Health Check
+                        AntPathRequestMatcher.antMatcher("/actuator/health"),
+                        // allow access to /actuator/health/liveness for OpenShift Liveness Check
+                        AntPathRequestMatcher.antMatcher("/actuator/health/liveness"),
+                        // allow access to /actuator/health/readiness for OpenShift Readiness Check
+                        AntPathRequestMatcher.antMatcher("/actuator/health/readiness"),
+                        // allow access to /actuator/metrics for Prometheus monitoring in OpenShift
+                        AntPathRequestMatcher.antMatcher("/actuator/metrics"))
                         .permitAll())
                 .authorizeHttpRequests((requests) -> requests.requestMatchers("/**")
                         .authenticated())

--- a/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/configuration/SecuringWebAppTest.java
+++ b/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/configuration/SecuringWebAppTest.java
@@ -1,0 +1,54 @@
+package de.muenchen.oss.wahllokalsystem.configuration;
+
+import static de.muenchen.oss.wahllokalsystem.TestConstants.SPRING_TEST_PROFILE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import de.muenchen.oss.wahllokalsystem.MicroServiceApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(classes = MicroServiceApplication.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@AutoConfigureObservability
+@ActiveProfiles(profiles = { SPRING_TEST_PROFILE })
+class SecuringWebAppTest {
+
+    @Autowired
+    MockMvc api;
+
+    @Test
+    public void accessSecuredResourceRootThenUnauthorized() throws Exception {
+        api.perform(get("/"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void accessSecuredResourceActuatorThenUnauthorized() throws Exception {
+        api.perform(get("/actuator"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void accessUnsecuredResourceActuatorHealthThenOk() throws Exception {
+        api.perform(get("/actuator/health"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void accessUnsecuredResourceActuatorInfoThenOk() throws Exception {
+        api.perform(get("/actuator/info"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void accessUnsecuredResourceActuatorMetricsThenOk() throws Exception {
+        api.perform(get("/actuator/metrics"))
+                .andExpect(status().isOk());
+    }
+
+}

--- a/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/configuration/SecuringWebAppTest.java
+++ b/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/configuration/SecuringWebAppTest.java
@@ -22,7 +22,7 @@ class SecuringWebAppTest {
     MockMvc api;
 
     @Test
-    public void accessSecuredResourceRootThenUnauthorized() throws Exception {
+    void accessSecuredResourceRootThenUnauthorized() throws Exception {
         api.perform(get("/"))
                 .andExpect(status().isUnauthorized());
     }
@@ -40,13 +40,13 @@ class SecuringWebAppTest {
     }
 
     @Test
-    public void accessUnsecuredResourceActuatorInfoThenOk() throws Exception {
+    void accessUnsecuredResourceActuatorInfoThenOk() throws Exception {
         api.perform(get("/actuator/info"))
                 .andExpect(status().isOk());
     }
 
     @Test
-    public void accessUnsecuredResourceActuatorMetricsThenOk() throws Exception {
+    void accessUnsecuredResourceActuatorMetricsThenOk() throws Exception {
         api.perform(get("/actuator/metrics"))
                 .andExpect(status().isOk());
     }

--- a/wls-broadcast-service/src/test/resources/application-test.yml
+++ b/wls-broadcast-service/src/test/resources/application-test.yml
@@ -1,0 +1,39 @@
+spring:
+
+  # Spring data rest
+  data:
+    rest:
+      # Definition of page size for PagingAndSortingRepository
+      max-page-size: 0x7fffffff
+      default-page-size: 0x7fffffff
+      return-body-on-update: true
+      return-body-on-create: true
+
+  # Spring JPA
+  h2.console.enabled: true
+  jpa:
+    database: H2
+    hibernate:
+      # always drop and create the db should be the best
+      # configuration for local (development) mode. this
+      # is also the default, that spring offers by convention.
+      # but here explicite:
+      ddl-auto: create-drop
+      naming.physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    # Logging for database operation
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: http://localhost
+
+security:
+  # possible values: none, all, changing (With changing, only changing requests such as POST, PUT, DELETE are logged)
+  logging.requests: all
+  oauth2:
+    resource.user-info-uri: http://localhost
+


### PR DESCRIPTION
# Beschreibung:

In unserer Referenzarchitektur wurde ein Security-Fix eingebracht, der auch in unserem Service berücksichtigt werden muss.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###

nichts weiter zu tun für dieses Issue

- [x] Doku aktualisiert
- [x] Swagger-API vollständig
- [x] Unit-Tests gepflegt
- [x] Integrationstests gepflegt
- [x] Beispiel-Requests gepflegt
- [x] Doku aktualisiert


# Referenzen[^1]:

Verwandt mit Issue #

Closes #70

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
