### PR TITLE
Fix Update pull_request_template.md - remove duplicate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,6 @@
 - [ ] Unit-Tests gepflegt
 - [ ] Integrationstests gepflegt
 - [ ] Beispiel-Requests gepflegt
-- [ ] Doku aktualisiert
 
 <!-- Dokumentation -->
 ### Dokumentation


### PR DESCRIPTION
# Beschreibung:

im Abschnitt `Backend` war `Doku aktualisiert` zwei mal enthalten. Duplikat wurde entfernt

# Referenzen[^1]:

Verwandt mit Issue #37

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
