### PR TITLE
update pom und erstellungt workflow in Vorbereitung auf wls-common release

### DIFF
--- a/.github/workflows/dispatch-wls-common-mvn-release.yml
+++ b/.github/workflows/dispatch-wls-common-mvn-release.yml
@@ -1,0 +1,60 @@
+name: dispatch wls-common release with deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to release from ?"
+        required: true
+        default: "main"
+      release-version:
+        description: "Release version ?"
+        required: true
+      release-tag:
+        description: "Release tag ?"
+        required: true
+      development-version:
+        description: "Next Development version ?"
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      - name: Setup git user
+        uses: fregante/setup-git-user@v2
+      - name: Set up JDK 17 and OSSRH auth / GPG signing
+        uses: actions/setup-java@v3
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: "maven"
+          server-id: "central"
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.gpg_private_key }}
+          gpg-passphrase: SIGN_KEY_PASS
+      - name: Perform maven release
+        run: >
+          mvn -B -ntp release:prepare release:perform -f wls-common/pom.xml
+          -DreleaseVersion=${{ github.event.inputs.release-version }} 
+          -DdevelopmentVersion=${{ github.event.inputs.development-version }} 
+          -Dtag=${{ github.event.inputs.release-tag }} 
+          -Darguments="-DskipTests"
+        env:
+          SIGN_KEY_PASS: ${{ secrets.gpg_passphrase }}
+          CENTRAL_USERNAME: ${{ secrets.sonatype_username }}
+          CENTRAL_PASSWORD: ${{ secrets.sonatype_password }}
+      - name: Create GitHub Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.inputs.release-tag }}
+          draft: false
+          prerelease: false
+          generate_release_notes: false
+

--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -11,6 +11,49 @@
     <name>wls-common</name>
     <packaging>pom</packaging>
     <description>Serviceübergreifende Aspekte</description>
+    <url>https://github.com/it-at-m/Wahllokalsystem</url>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>MrSebastian</name>
+            <organization>Landeshauptstadt München</organization>
+            <url>https://github.com/MrSebastian</url>
+            <roles>
+                <role>initiator</role>
+                <role>developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <name>Nic12345678</name>
+            <organization>Landeshauptstadt München</organization>
+            <url>https://github.com/Nic12345678</url>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <name>dragonfly28</name>
+            <organization>Landeshauptstadt München</organization>
+            <url>https://github.com/dragonfly28</url>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <name>GerhardPx</name>
+            <organization>Landeshauptstadt München</organization>
+            <url>https://github.com/GerhardPx</url>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+    </developers>
 
 
     <properties>

--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -111,6 +111,51 @@
         <tag>HEAD</tag>
     </scm>
 
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <!-- Central Portal Publishing Plugin -->
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <tokenAuth>true</tokenAuth>
+                            <autoPublish>true</autoPublish>
+                            <deploymentName>${project.groupId}:${project.artifactId}:${project.version}</deploymentName>
+                        </configuration>
+                    </plugin>
+                    <!-- GPG plugin -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <configuration>
+                            <skip>${skipGpg}</skip>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- Prevent `gpg` from using pinentry programs -->
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <pluginManagement>
             <plugins>
@@ -168,6 +213,23 @@
                             <version>9.3</version>
                         </dependency>
                     </dependencies>
+                </plugin>
+
+                <!-- release specific plugins -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>3.0.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>3.0.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.4.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -267,4 +267,12 @@
         </plugins>
     </build>
 
+    <distributionManagement>
+        <!-- Central Repository -->
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+
 </project>

--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -19,43 +19,6 @@
         </license>
     </licenses>
 
-    <developers>
-        <developer>
-            <name>MrSebastian</name>
-            <organization>Landeshauptstadt München</organization>
-            <url>https://github.com/MrSebastian</url>
-            <roles>
-                <role>initiator</role>
-                <role>developer</role>
-            </roles>
-        </developer>
-        <developer>
-            <name>Nic12345678</name>
-            <organization>Landeshauptstadt München</organization>
-            <url>https://github.com/Nic12345678</url>
-            <roles>
-                <role>developer</role>
-            </roles>
-        </developer>
-        <developer>
-            <name>dragonfly28</name>
-            <organization>Landeshauptstadt München</organization>
-            <url>https://github.com/dragonfly28</url>
-            <roles>
-                <role>developer</role>
-            </roles>
-        </developer>
-        <developer>
-            <name>GerhardPx</name>
-            <organization>Landeshauptstadt München</organization>
-            <url>https://github.com/GerhardPx</url>
-            <roles>
-                <role>developer</role>
-            </roles>
-        </developer>
-    </developers>
-
-
     <properties>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -274,5 +237,41 @@
             <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
+
+    <developers>
+        <developer>
+            <name>MrSebastian</name>
+            <organization>Landeshauptstadt München</organization>
+            <url>https://github.com/MrSebastian</url>
+            <roles>
+                <role>initiator</role>
+                <role>developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <name>Nic12345678</name>
+            <organization>Landeshauptstadt München</organization>
+            <url>https://github.com/Nic12345678</url>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <name>dragonfly28</name>
+            <organization>Landeshauptstadt München</organization>
+            <url>https://github.com/dragonfly28</url>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <name>GerhardPx</name>
+            <organization>Landeshauptstadt München</organization>
+            <url>https://github.com/GerhardPx</url>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+    </developers>
 
 </project>


### PR DESCRIPTION
# Beschreibung:

- Erstellung Workflow für wls-common mvn release
- vorhanden mvn-release kann nicht wieder verwendet werden da auch ein Deploy erfolgt was bei anderen Workflow nicht der Fall ist. Eine Auftrennung halte ich aktuell nicht für notwendig da wls-common aktuell das einzige Projekt ist das ein deploy eines Artefakts erfordert

## Definition of Done (DoD):
aus meiner Sicht gibt es hier keine expliziten DoDs

# Referenzen[^1]:

#22 
❗ (noch kein Close da nach dem PR noch Release gebaut werden muss)

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
