### PR TITLE
Fixes an Workflows in Bezug auf Build von wls-broadcast-service

### DIFF
--- a/.github/workflows/dispatch-microservice-mvn-release.yml
+++ b/.github/workflows/dispatch-microservice-mvn-release.yml
@@ -32,7 +32,7 @@ jobs:
           cache-dependency-path: '${{ github.event.inputs.service }}/pom.xml'
       - name: Perform maven release
         run: >
-          mvn -B -ntp release:prepare -f backend/pom.xml
+          mvn -B -ntp release:prepare -f ${{ github.event.inputs.service }}/pom.xml
           -DreleaseVersion=${{ github.event.inputs.release-version }} 
           -DdevelopmentVersion=${{ github.event.inputs.development-version }} 
           -Dtag=${{ github.event.inputs.service }}/v${{ github.event.inputs.release-version }}

--- a/.github/workflows/dispatch-microservice-mvn-release.yml
+++ b/.github/workflows/dispatch-microservice-mvn-release.yml
@@ -13,9 +13,6 @@ on:
         required: true
         description: service/directory to build (wls-broadcast-service, ...)
 
-env:
-  gitTag: ${{ github.event.inputs.service }}/v${{ github.event.inputs.release-version }}
-
 jobs:
   run-mvn-release-prepare:
     runs-on: ubuntu-latest
@@ -38,7 +35,7 @@ jobs:
           mvn -B -ntp release:prepare -f backend/pom.xml
           -DreleaseVersion=${{ github.event.inputs.release-version }} 
           -DdevelopmentVersion=${{ github.event.inputs.development-version }} 
-          -Dtag=${{ env.gitTag }}
+          -Dtag=${{ github.event.inputs.service }}/v${{ github.event.inputs.release-version }}
           -Darguments="-DskipTests -B -ntp"
 
   build-github-release:
@@ -49,7 +46,7 @@ jobs:
     uses:
       ./.github/workflows/callable-create-github-release-from-tag.yml
     with:
-      tag: ${{ env.gitTag }}
+      tag: ${{ github.event.inputs.service }}/v${{ github.event.inputs.release-version }}
       service: ${{ github.event.inputs.service }}
 
   build-github-container-image:
@@ -60,5 +57,5 @@ jobs:
     uses:
       ./.github/workflows/callable-create-github-container-image.yml
     with:
-      tag: ${{ env.gitTag }}
+      tag: ${{ github.event.inputs.service }}/v${{ github.event.inputs.release-version }}
       service: ${{ github.event.inputs.service }}

--- a/.github/workflows/dispatch-microservice-mvn-release.yml
+++ b/.github/workflows/dispatch-microservice-mvn-release.yml
@@ -36,7 +36,7 @@ jobs:
           -DreleaseVersion=${{ github.event.inputs.release-version }} 
           -DdevelopmentVersion=${{ github.event.inputs.development-version }} 
           -Dtag=${{ github.event.inputs.service }}/v${{ github.event.inputs.release-version }}
-          -Darguments="-DskipTests -B -ntp"
+          -Darguments="-DskipTests"
 
   build-github-release:
     permissions:

--- a/wls-broadcast-service/pom.xml
+++ b/wls-broadcast-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-broadcast-service</artifactId>
-    <version>0.0.1-ALPHA1</version>
+    <version>0.0.1-SNAPSHOT</version>
     <name>wls_broadcast_service</name>
 
     <properties>
@@ -253,7 +253,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-broadcast-service/v0.0.1-ALPHA1</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-broadcast-service/pom.xml
+++ b/wls-broadcast-service/pom.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-broadcast-service</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.1-ALPHA1</version>
     <name>wls_broadcast_service</name>
 
     <properties>
@@ -255,7 +253,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-broadcast-service/v0.0.1-ALPHA1</tag>
     </scm>
 
 
@@ -378,8 +376,8 @@
                         <eclipse>
                             <file>itm-java-codeformat/java_codestyle_formatter.xml</file>
                         </eclipse>
-                        <trimTrailingWhitespace/>
-                        <endWithNewline/>
+                        <trimTrailingWhitespace />
+                        <endWithNewline />
                     </java>
                 </configuration>
                 <executions>


### PR DESCRIPTION
# Beschreibung:
- Änderung an der POM kamen durch `maven-release-plugin`
  - Versionsänderung ist nicht sichtbar das es bei `0.0.1-SNAPSHOT` blieb
- im Workflow hat die Env-Var auf Root-Ebene nicht funktioniert. Muss wohl ein fester Wert sein
- Das Batch und `ntp`-Argument im Release war falsch

## Definition of Done (DoD):
mir sind keine expliziten DoD hier bekannt

# Referenzen[^1]:

Closes #15 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
