### PR TITLE
Optimierung von Test zu Spring Profiles in wls-common:security

### DIFF
--- a/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/ProfilesTest.java
+++ b/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/ProfilesTest.java
@@ -4,9 +4,8 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ActiveProfiles;
 
 class ProfilesTest {
@@ -38,8 +37,7 @@ class ProfilesTest {
         }
     }
 
-    @Configuration
-    @ComponentScan("de.muenchen.oss.wahllokalsystem.wls.common.security") //all BezirkIDPermissionEvaluator impl classes should be found
+    @SpringBootApplication //all BezirkIDPermissionEvaluator impl classes should be found
     public static class TestConfiguration {
 
     }

--- a/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/ProfilesTest.java
+++ b/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/ProfilesTest.java
@@ -6,13 +6,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ActiveProfiles;
 
 class ProfilesTest {
 
-    @SpringBootTest(classes = { DummyBezirkIdPermissionEvaluatorImpl.class, BezirkIDPermissionEvaluatorImpl.class })
+    @SpringBootTest(classes = TestConfiguration.class)
     @ActiveProfiles(Profiles.NO_BEZIRKS_ID_CHECK)
-    @ComponentScan
     @Nested
     class NoBezirksIdCheck {
 
@@ -25,8 +25,7 @@ class ProfilesTest {
         }
     }
 
-    @SpringBootTest(classes = { DummyBezirkIdPermissionEvaluatorImpl.class, BezirkIDPermissionEvaluatorImpl.class })
-    @ComponentScan
+    @SpringBootTest(classes = TestConfiguration.class)
     @Nested
     class NoSpecialProfile {
 
@@ -37,5 +36,11 @@ class ProfilesTest {
         void evaluatorIsInstanceOfBezirkIDPermissionEvaluator() {
             Assertions.assertThat(permissionEvaluator).isExactlyInstanceOf(BezirkIDPermissionEvaluatorImpl.class);
         }
+    }
+
+    @Configuration
+    @ComponentScan("de.muenchen.oss.wahllokalsystem.wls.common.security") //all BezirkIDPermissionEvaluator impl classes should be found
+    public static class TestConfiguration {
+
     }
 }


### PR DESCRIPTION
# Beschreibung:
- Optimierung des Tests damit er die Implementierungen selber findet
- hat den Vorteil dass wenn man eine Implementierung erweitert und die Profile nicht pflegt auf Fehler hingewiesen wird

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [X] Unit-Tests gepflegt
- [x] Integrationstests gepflegt

# Referenzen[^1]: 

Verwandt mit Issue #19 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
