### PR TITLE
Briefwahl-Service - add dockerfile

### DIFF
--- a/wls-briefwahl-service/Dockerfile
+++ b/wls-briefwahl-service/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/ubi8/openjdk-17:latest
+
+COPY target/*.jar /deployments/spring-boot-application.jar


### PR DESCRIPTION
# Beschreibung:
Das dockerfile fehlte weshalb auf dem dev-Branch der Build failte

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] Test: lokal ging der Build mit dem Dockerfile durch. Es konnte den Service aufrufen und den Info-Endpunkt verifizieren

# Referenzen[^1]:

Verwandt mit Issue #

Closes #119 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
