### PR TITLE
Mapstruct Dependency + AnnotationProcessor bei Briefwahlservice ergänzt

### DIFF
--- a/wls-briefwahl-service/pom.xml
+++ b/wls-briefwahl-service/pom.xml
@@ -38,6 +38,7 @@
         <org.projectlombok.lombok.version>1.18.30</org.projectlombok.lombok.version>
         <org.projectlombok.mapstructbinding.version>0.2.0</org.projectlombok.mapstructbinding.version>
         <org.springdoc.version>2.5.0</org.springdoc.version>
+        <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
     </properties>
 
     <dependencyManagement>
@@ -318,11 +319,24 @@
                             <version>${org.projectlombok.lombok.version}</version>
                         </path>
                         <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${org.mapstruct.version}</version>
+                        </path>
+                        <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok-mapstruct-binding</artifactId>
                             <version>${org.projectlombok.mapstructbinding.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <compilerArg>
+                            -Amapstruct.defaultComponentModel=spring
+                        </compilerArg>
+                        <compilerArg>
+                            -Amapstruct.unmappedTargetPolicy=ERROR
+                        </compilerArg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
# Beschreibung:

- Wird vermutlich auch bei dem anderen Implementierungs-Issue zum Briefwahl-Service benötigt

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->
- aus meiner Sicht keine zusätzliche Todos für DoD erforderlich

# Referenzen[^1]:

Verwandt mit Issue #157

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
