### PR TITLE
MD-File als ADR-Template

### DIFF
--- a/docs/src/technik/adr/adr-template.md
+++ b/docs/src/technik/adr/adr-template.md
@@ -1,0 +1,15 @@
+# Titel
+
+## Status
+
+<adr-status status='proposed'></adr-status>
+
+## Kontext
+
+## Entscheidung
+
+## Konsequenzen
+
+### positiv
+
+### negativ


### PR DESCRIPTION
# Beschreibung:

- ein Markdown-File mit den wichtigsten Überschriften für ADR
- empfinde ich als nützlicher anstatt ein bestenden ADR zu nehmen, zu kopieren und dann die Texte zu löschen

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->
- keine expliziten DoDs aus meiner Sicht

# Referenzen[^1]:

Verwandt mit Issue #203 (trigger für die Idee)

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
