### PR TITLE
Kein Input für Git-Tag bei Release von wls-common

### DIFF
--- a/.github/workflows/dispatch-wls-common-mvn-release.yml
+++ b/.github/workflows/dispatch-wls-common-mvn-release.yml
@@ -10,9 +10,6 @@ on:
       release-version:
         description: "Release version ?"
         required: true
-      release-tag:
-        description: "Release tag ?"
-        required: true
       development-version:
         description: "Next Development version ?"
         required: true
@@ -43,7 +40,7 @@ jobs:
           mvn -B -ntp release:prepare release:perform -f wls-common/pom.xml
           -DreleaseVersion=${{ github.event.inputs.release-version }} 
           -DdevelopmentVersion=${{ github.event.inputs.development-version }} 
-          -Dtag=${{ github.event.inputs.release-tag }} 
+          -Dtag=wls-common/${{ github.event.inputs.version }}
           -Darguments="-DskipTests"
         env:
           SIGN_KEY_PASS: ${{ secrets.gpg_passphrase }}
@@ -53,7 +50,7 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.inputs.release-tag }}
+          tag_name: wls-common/${{ github.event.inputs.version }}
           draft: false
           prerelease: false
           generate_release_notes: false


### PR DESCRIPTION
# Beschreibung:

- Input für Tag entfernt
- Tagname wird aus `wls-common` und Input für Version gebildet (wie bei den Services)

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

# Referenzen[^1]:

Verwandt mit Issue #

Closes #198

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
