### PR TITLE
Entfernung v-Prefix vor der Versionsnummer eines Tags

### DIFF
--- a/.github/workflows/dispatch-microservice-mvn-release.yml
+++ b/.github/workflows/dispatch-microservice-mvn-release.yml
@@ -35,7 +35,7 @@ jobs:
           mvn -B -ntp release:prepare -f ${{ github.event.inputs.service }}/pom.xml
           -DreleaseVersion=${{ github.event.inputs.release-version }} 
           -DdevelopmentVersion=${{ github.event.inputs.development-version }} 
-          -Dtag=${{ github.event.inputs.service }}/v${{ github.event.inputs.release-version }}
+          -Dtag=${{ github.event.inputs.service }}/${{ github.event.inputs.release-version }}
           -Darguments="-DskipTests"
 
   build-github-release:
@@ -46,7 +46,7 @@ jobs:
     uses:
       ./.github/workflows/callable-create-github-release-from-tag.yml
     with:
-      tag: ${{ github.event.inputs.service }}/v${{ github.event.inputs.release-version }}
+      tag: ${{ github.event.inputs.service }}/${{ github.event.inputs.release-version }}
       service: ${{ github.event.inputs.service }}
 
   build-github-container-image:
@@ -57,5 +57,5 @@ jobs:
     uses:
       ./.github/workflows/callable-create-github-container-image.yml
     with:
-      tag: ${{ github.event.inputs.service }}/v${{ github.event.inputs.release-version }}
+      tag: ${{ github.event.inputs.service }}/${{ github.event.inputs.release-version }}
       service: ${{ github.event.inputs.service }}


### PR DESCRIPTION
# Beschreibung:

- Schema für git-Tags vereinheitlicht auf `<service>/<version>`
- wls-common arbeitete bereits nach dem Schema
- Workflow für die Microservices wurde entsprechend angepasst

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

# Referenzen[^1]:

Verwandt mit Issue #

Closes #199 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
