### PR TITLE
Fix wls-release workflow und Verifizierung 181

### DIFF
--- a/.github/workflows/dispatch-wls-common-mvn-release.yml
+++ b/.github/workflows/dispatch-wls-common-mvn-release.yml
@@ -40,7 +40,7 @@ jobs:
           mvn -B -ntp release:prepare release:perform -f wls-common/pom.xml
           -DreleaseVersion=${{ github.event.inputs.release-version }} 
           -DdevelopmentVersion=${{ github.event.inputs.development-version }} 
-          -Dtag=wls-common/${{ github.event.inputs.version }}
+          -Dtag=wls-common/${{ github.event.inputs.release-version }}
           -Darguments="-DskipTests"
         env:
           SIGN_KEY_PASS: ${{ secrets.gpg_passphrase }}
@@ -50,7 +50,7 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: wls-common/${{ github.event.inputs.version }}
+          tag_name: wls-common/${{ github.event.inputs.release-version }}
           draft: false
           prerelease: false
           generate_release_notes: false

--- a/wls-common/exception/pom.xml
+++ b/wls-common/exception/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.1-RC2</version>
     </parent>
 
     <artifactId>exception</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1-RC2</version>
     <description>Übergreifende Exception Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,8 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-    </scm>
+      <tag>wls-common/1.0.1-RC2</tag>
+  </scm>
 
     <dependencies>
         <dependency>

--- a/wls-common/exception/pom.xml
+++ b/wls-common/exception/pom.xml
@@ -13,6 +13,12 @@
     <description>Übergreifende Exception Aspekte</description>
     <url>${wls.github.url}</url>
 
+    <scm>
+        <url>${wls.github.url}</url>
+        <connection>${wls.github.scm.connection}</connection>
+        <developerConnection>${wls.github.scm.connection}</developerConnection>
+    </scm>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/wls-common/exception/pom.xml
+++ b/wls-common/exception/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.1-RC1</version>
     </parent>
 
     <artifactId>exception</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1-RC1</version>
     <description>Übergreifende Exception Aspekte</description>
     <url>${wls.github.url}</url>
 

--- a/wls-common/exception/pom.xml
+++ b/wls-common/exception/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-RC2</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>exception</artifactId>
-    <version>1.0.1-RC2</version>
+    <version>1.0.1-SNAPSHOT</version>
     <description>Übergreifende Exception Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>wls-common/1.0.1-RC2</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/wls-common/exception/pom.xml
+++ b/wls-common/exception/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-RC1</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>exception</artifactId>
-    <version>1.0.1-RC1</version>
+    <version>1.0.1-SNAPSHOT</version>
     <description>Übergreifende Exception Aspekte</description>
     <url>${wls.github.url}</url>
 

--- a/wls-common/monitoring/pom.xml
+++ b/wls-common/monitoring/pom.xml
@@ -13,6 +13,12 @@
     <description>Übergreifende Monitoring Aspekte</description>
     <url>${wls.github.url}</url>
 
+    <scm>
+        <url>${wls.github.url}</url>
+        <connection>${wls.github.scm.connection}</connection>
+        <developerConnection>${wls.github.scm.connection}</developerConnection>
+    </scm>
+
     <build>
         <plugins>
             <plugin>

--- a/wls-common/monitoring/pom.xml
+++ b/wls-common/monitoring/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-RC2</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>monitoring</artifactId>
-    <version>1.0.1-RC2</version>
+    <version>1.0.1-SNAPSHOT</version>
     <description>Übergreifende Monitoring Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>wls-common/1.0.1-RC2</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/wls-common/monitoring/pom.xml
+++ b/wls-common/monitoring/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-RC1</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>monitoring</artifactId>
-    <version>1.0.1-RC1</version>
+    <version>1.0.1-SNAPSHOT</version>
     <description>Übergreifende Monitoring Aspekte</description>
     <url>${wls.github.url}</url>
 

--- a/wls-common/monitoring/pom.xml
+++ b/wls-common/monitoring/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.1-RC1</version>
     </parent>
 
     <artifactId>monitoring</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1-RC1</version>
     <description>Übergreifende Monitoring Aspekte</description>
     <url>${wls.github.url}</url>
 

--- a/wls-common/monitoring/pom.xml
+++ b/wls-common/monitoring/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.1-RC2</version>
     </parent>
 
     <artifactId>monitoring</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1-RC2</version>
     <description>Übergreifende Monitoring Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,8 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-    </scm>
+      <tag>wls-common/1.0.1-RC2</tag>
+  </scm>
 
     <build>
         <plugins>

--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.1-RC1</version>
+    <version>1.0.1-SNAPSHOT</version>
     <name>wls-common</name>
     <packaging>pom</packaging>
     <description>Serviceübergreifende Aspekte</description>
@@ -70,7 +70,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-common/</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <profiles>

--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.1-RC1</version>
+    <version>1.0.1-SNAPSHOT</version>
     <name>wls-common</name>
     <packaging>pom</packaging>
     <description>Serviceübergreifende Aspekte</description>
@@ -70,7 +70,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-common/1.0.1-RC1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <profiles>

--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -31,6 +31,7 @@
         <org.projectlombok.mapstructbinding.version>0.2.0</org.projectlombok.mapstructbinding.version>
         <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
         <wls.github.url>https://github.com/it-at-m/Wahllokalsystem</wls.github.url>
+        <wls.github.scm.connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</wls.github.scm.connection>
     </properties>
 
     <modules>
@@ -67,9 +68,9 @@
 
 
     <scm>
-        <url>https://github.com/it-at-m/Wahllokalsystem</url>
-        <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
-        <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
+        <url>${wls.github.url}</url>
+        <connection>${wls.github.scm.connection}</connection>
+        <developerConnection>${wls.github.scm.connection}</developerConnection>
         <tag>HEAD</tag>
     </scm>
 

--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.1-RC2</version>
+    <version>1.0.1-SNAPSHOT</version>
     <name>wls-common</name>
     <packaging>pom</packaging>
     <description>Serviceübergreifende Aspekte</description>
@@ -71,7 +71,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-        <tag>wls-common/1.0.1-RC2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <profiles>

--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1-RC1</version>
     <name>wls-common</name>
     <packaging>pom</packaging>
     <description>Serviceübergreifende Aspekte</description>
@@ -70,7 +70,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-common/1.0.1-RC1</tag>
     </scm>
 
     <profiles>

--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1-RC2</version>
     <name>wls-common</name>
     <packaging>pom</packaging>
     <description>Serviceübergreifende Aspekte</description>
@@ -71,7 +71,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-common/1.0.1-RC2</tag>
     </scm>
 
     <profiles>

--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1-RC1</version>
     <name>wls-common</name>
     <packaging>pom</packaging>
     <description>Serviceübergreifende Aspekte</description>
@@ -70,7 +70,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-common/</tag>
     </scm>
 
     <profiles>

--- a/wls-common/security/pom.xml
+++ b/wls-common/security/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-RC1</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>security</artifactId>
-    <version>1.0.1-RC1</version>
+    <version>1.0.1-SNAPSHOT</version>
     <description>Uebergreifende Security Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>exception</artifactId>
-            <version>1.0.1-RC1</version>
+            <version>1.0.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/wls-common/security/pom.xml
+++ b/wls-common/security/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.1-RC1</version>
     </parent>
 
     <artifactId>security</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1-RC1</version>
     <description>Uebergreifende Security Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>exception</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.1-RC1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/wls-common/security/pom.xml
+++ b/wls-common/security/pom.xml
@@ -13,6 +13,12 @@
     <description>Uebergreifende Security Aspekte</description>
     <url>${wls.github.url}</url>
 
+    <scm>
+        <url>${wls.github.url}</url>
+        <connection>${wls.github.scm.connection}</connection>
+        <developerConnection>${wls.github.scm.connection}</developerConnection>
+    </scm>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/wls-common/security/pom.xml
+++ b/wls-common/security/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-RC2</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>security</artifactId>
-    <version>1.0.1-RC2</version>
+    <version>1.0.1-SNAPSHOT</version>
     <description>Uebergreifende Security Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>wls-common/1.0.1-RC2</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>exception</artifactId>
-            <version>1.0.1-RC2</version>
+            <version>1.0.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/wls-common/security/pom.xml
+++ b/wls-common/security/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.1-RC2</version>
     </parent>
 
     <artifactId>security</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1-RC2</version>
     <description>Uebergreifende Security Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,8 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-    </scm>
+      <tag>wls-common/1.0.1-RC2</tag>
+  </scm>
 
     <dependencies>
         <dependency>
@@ -39,7 +40,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>exception</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.1-RC2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
# Beschreibung:

- ursprünglich sollte es nur eine Verifizierung sein
- dabei wurde ein Fehler bei den verwendeten Inputs entdeckt der gefixt wurde 
- zusätzlich Fix von Props bei `scm`-Element 
  -  URL
  -  `developerConnection` und `connection`

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

- [x] neue Version [auffindbar](https://central.sonatype.com/namespace/de.muenchen.oss.wahllokalsystem.wls-common)

# Referenzen[^1]:

Verwandt mit Issue #

Closes #181 
Closes #198

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
