### PR TITLE
Fix Versionspattern in GithubImageWorkflow

### DIFF
--- a/.github/workflows/callable-create-github-container-image.yml
+++ b/.github/workflows/callable-create-github-container-image.yml
@@ -58,10 +58,10 @@ jobs:
           # - full semver: 1.2.3-RC2
           # - latest
           tags: |
-            type=match,pattern=(${{ inputs.service }})/v(\d).\d.\d,group=2,enable=${{ inputs.tag != '' }}
-            type=match,pattern=(${{ inputs.service }})/v(\d.\d).\d,group=2,enable=${{ inputs.tag != '' }}
-            type=match,pattern=(${{ inputs.service }})/v(\d.\d.\d),group=2,enable=${{ inputs.tag != '' }}
-            type=match,pattern=(${{ inputs.service }})/v(.*),group=2,enable=${{ inputs.tag != '' }}
+            type=match,pattern=(${{ inputs.service }})/(\d).\d.\d,group=2,enable=${{ inputs.tag != '' }}
+            type=match,pattern=(${{ inputs.service }})/(\d.\d).\d,group=2,enable=${{ inputs.tag != '' }}
+            type=match,pattern=(${{ inputs.service }})/(\d.\d.\d),group=2,enable=${{ inputs.tag != '' }}
+            type=match,pattern=(${{ inputs.service }})/(.*),group=2,enable=${{ inputs.tag != '' }}
             type=raw,value=latest,enable=${{ inputs.tag != '' }}
             type=raw,value=latest-dev
 


### PR DESCRIPTION
# Beschreibung:

Im Rahmen von #199 wurde das `v` vor der Version eines Microservices im Tag entfernt: `service/v1.0.0` -> `service/1.0.0`. Das wurde aber nicht beachtet beim Workflow der die Tags zu den Images zusammenstellt. Dort war das `v` noch enthalten. Somit wurden bei neuen Releases keine zusätzlichen Versionstags gesetzt.

Auszug aus Workflow-Log:

```

Run docker/metadata-action@v5
Context info
  eventName: workflow_dispatch
  sha: 962bf87da3b933889c8f396dabc572454d6716b3
  ref: refs/tags/wls-broadcast-service/1.0.0-RC1
  workflow: dispatch microserivce maven release
  action: meta
  actor: MrSebastian
  runNumber: 5
  runId: 9271433817
Processing images input
Processing tags input
  type=match,pattern=(wls-broadcast-service)/v(\d).\d.\d,group=2,enable=true,value=,priority=800
  type=match,pattern=(wls-broadcast-service)/v(\d.\d).\d,group=2,enable=true,value=,priority=800
  type=match,pattern=(wls-broadcast-service)/v(\d.\d.\d),group=2,enable=true,value=,priority=800
  type=match,pattern=(wls-broadcast-service)/v(.*),group=2,enable=true,value=,priority=800
  type=raw,value=latest,enable=true,priority=200
  type=raw,value=latest-dev,enable=true,priority=200
Processing flavor input
Warning: (wls-broadcast-service)/v(\d).\d.\d does not match wls-broadcast-service/1.0.0-RC1.
Warning: (wls-broadcast-service)/v(\d.\d).\d does not match wls-broadcast-service/1.0.0-RC1.
Warning: (wls-broadcast-service)/v(\d.\d.\d) does not match wls-broadcast-service/1.0.0-RC1.
Warning: (wls-broadcast-service)/v(.*) does not match wls-broadcast-service/1.0.0-RC1.
```

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

keine expliziten DoD zu erledigen.

# Referenzen[^1]:

Verwandt mit Issue #199

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
