### PR TITLE
Fix Datenbankanbindung für Keycloak

### DIFF
--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -32,10 +32,10 @@ services:
       - KEYCLOAK_ADMIN=${KEYCLOAK_ADMIN}
       - KEYCLOAK_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWORD}
       - KC_HOSTNAME_STRICT=${KEYCLOAK_HOSTNAME_STRICT}
-      - DB=${KEYCLOAK_DB_TYPE}
-      - DB_URL=jdbc:postgresql://wls-db-postgres-keycloak:5432/${KEYCLOAK_DB}
-      - DB_USERNAME=${KEYCLOAK_DB_USER}
-      - DB_PASSWORD=${KEYCLOAK_DB_PASSWORD}
+      - KC_DB=${KEYCLOAK_DB_TYPE}
+      - KC_DB_URL=jdbc:postgresql://wls-db-postgres-keycloak:5432/${KEYCLOAK_DB}
+      - KC_DB_USERNAME=${KEYCLOAK_DB_USER}
+      - KC_DB_PASSWORD=${KEYCLOAK_DB_PASSWORD}
       - KC_HTTP_RELATIVE_PATH=auth
     ports:
       - 8100:8080


### PR DESCRIPTION
# Beschreibung:

Es waren ein paar Umgebungsvariablen falsch gesetzt.  
Erfolgt wurde verifiziert in dem nach folgenden Schritte die Daten vom WLS-Realm weiterhin im Keycloak einsehbar waren:
- löschen des alten Keycloak containers
- erstellen des Keycloakcontainers
- ausführen von init-Keycloak-Container
- Verifizierung dass der WLS-Realm und Benutzer vorhanden sind
- Löschen des Keycloakcontainers
- erstellen des Keycloakcontainers

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

keine zusätzlichen DoD aus meiner Sicht relevant

# Referenzen[^1]:

Verwandt mit Issue #

Closes #245

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
