### PR TITLE
Wls common 1.1.0 released

### DIFF
--- a/wls-common/exception/pom.xml
+++ b/wls-common/exception/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>exception</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0</version>
     <description>Übergreifende Exception Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>HEAD</tag>
+      <tag>wls-common/1.1.0</tag>
   </scm>
 
     <dependencies>

--- a/wls-common/exception/pom.xml
+++ b/wls-common/exception/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>exception</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0-SNAPSHOT</version>
     <description>Übergreifende Exception Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>wls-common/1.1.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/wls-common/monitoring/pom.xml
+++ b/wls-common/monitoring/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>monitoring</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0-SNAPSHOT</version>
     <description>Übergreifende Monitoring Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>wls-common/1.1.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/wls-common/monitoring/pom.xml
+++ b/wls-common/monitoring/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>monitoring</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0</version>
     <description>Übergreifende Monitoring Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>HEAD</tag>
+      <tag>wls-common/1.1.0</tag>
   </scm>
 
     <build>

--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0</version>
     <name>wls-common</name>
     <packaging>pom</packaging>
     <description>Serviceübergreifende Aspekte</description>
@@ -72,7 +72,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-common/1.1.0</tag>
     </scm>
 
     <profiles>

--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
     <artifactId>parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0-SNAPSHOT</version>
     <name>wls-common</name>
     <packaging>pom</packaging>
     <description>Serviceübergreifende Aspekte</description>
@@ -72,7 +72,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-        <tag>wls-common/1.1.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <profiles>

--- a/wls-common/security/pom.xml
+++ b/wls-common/security/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>security</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0</version>
     <description>Uebergreifende Security Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>HEAD</tag>
+      <tag>wls-common/1.1.0</tag>
   </scm>
 
     <dependencies>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>exception</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/wls-common/security/pom.xml
+++ b/wls-common/security/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>security</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0-SNAPSHOT</version>
     <description>Uebergreifende Security Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>wls-common/1.1.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>exception</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/wls-common/testing/pom.xml
+++ b/wls-common/testing/pom.xml
@@ -1,17 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>testing</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0</version>
     <description>Übergreifende Aspekte für das Testing</description>
     <url>${wls.github.url}</url>
 
@@ -19,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-common/1.1.0</tag>
     </scm>
 
     <dependencies>

--- a/wls-common/testing/pom.xml
+++ b/wls-common/testing/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>testing</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0-SNAPSHOT</version>
     <description>Übergreifende Aspekte für das Testing</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-        <tag>wls-common/1.1.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencies>


### PR DESCRIPTION
# Beschreibung:

- hier sind die Artefakte zu finden: https://central.sonatype.com/namespace/de.muenchen.oss.wahllokalsystem.wls-common
- Releasenotes: https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-common%2F1.1.0

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

# Referenzen[^1]:

Verwandt mit Issue #

Closes #255
Closes #254

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
