### PR TITLE
remove response body on 404

### DIFF
--- a/wls-eai-service/src/main/java/de/muenchen/oss/wahllokalsystem/eaiservice/configuration/SwaggerConfiguration.java
+++ b/wls-eai-service/src/main/java/de/muenchen/oss/wahllokalsystem/eaiservice/configuration/SwaggerConfiguration.java
@@ -61,7 +61,7 @@ public class SwaggerConfiguration {
         if (operation.getResponses() != null) {
             addRequestBodyValidationErrorToAPI(operation, components);
         }
-        addNotFoundErrorToAPI(operation, components);
+        addNotFoundErrorToAPI(operation);
         addInternalErrorToAPI(operation, components);
         addUnhandledCommunicationErrorToAPI(operation, components);
     }
@@ -72,10 +72,9 @@ public class SwaggerConfiguration {
                 .content(new Content().addMediaType(APPLICATION_JSON_VALUE, createWlsExceptionDTOMediaType(components))));
     }
 
-    private void addNotFoundErrorToAPI(Operation operation, Components components) {
+    private void addNotFoundErrorToAPI(Operation operation) {
         operation.getResponses().addApiResponse("404", new ApiResponse()
-                .description("no resource found")
-                .content(new Content().addMediaType(APPLICATION_JSON_VALUE, createWlsExceptionDTOMediaType(components))));
+                .description("resource not found"));
     }
 
     private void addInternalErrorToAPI(Operation operation, Components components) {


### PR DESCRIPTION
# Beschreibung:

Im Zuge der Umsetzung von #152 kam auf das aus meiner Sicht kein Responsebody bei einem 404 erforderlich ist. Alle Informationen sollten dem Client bekannt sein. Daher würde ich aus der Doku den entsprechenden Body entfernen.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [X] Swagger-API vollständig

# Referenzen[^1]:

Verwandt mit Issue #152

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
