### PR TITLE
set max-http-request-header-size 32KB on default profile

### DIFF
--- a/wls-basisdaten-service/src/main/resources/application.yml
+++ b/wls-basisdaten-service/src/main/resources/application.yml
@@ -36,6 +36,7 @@ server:
     include-stacktrace: never
     whitelabel:
       enabled: false
+  max-http-request-header-size: 32KB
 
 # Config for spring actuator endpoints
 management:

--- a/wls-briefwahl-service/src/main/resources/application.yml
+++ b/wls-briefwahl-service/src/main/resources/application.yml
@@ -37,6 +37,7 @@ server:
     include-stacktrace: never
     whitelabel:
       enabled: false
+  max-http-request-header-size: 32KB
 
 service:
   info:

--- a/wls-broadcast-service/src/main/resources/application.yml
+++ b/wls-broadcast-service/src/main/resources/application.yml
@@ -22,6 +22,7 @@ server:
     include-stacktrace: never
     whitelabel:
       enabled: false
+  max-http-request-header-size: 32KB
 
 # Config for spring actuator endpoints
 management:

--- a/wls-eai-service/src/main/resources/application.yml
+++ b/wls-eai-service/src/main/resources/application.yml
@@ -36,6 +36,7 @@ server:
     include-stacktrace: never
     whitelabel:
       enabled: false
+  max-http-request-header-size: 32KB
 
 # Config for spring actuator endpoints
 management:

--- a/wls-ergebnismeldung-service/src/main/resources/application.yml
+++ b/wls-ergebnismeldung-service/src/main/resources/application.yml
@@ -36,6 +36,7 @@ server:
     include-stacktrace: never
     whitelabel:
       enabled: false
+  max-http-request-header-size: 32KB
 
 # Config for spring actuator endpoints
 management:

--- a/wls-infomanagement-service/src/main/resources/application.yml
+++ b/wls-infomanagement-service/src/main/resources/application.yml
@@ -36,6 +36,7 @@ server:
     include-stacktrace: never
     whitelabel:
       enabled: false
+  max-http-request-header-size: 32KB
 
 service:
   info:

--- a/wls-monitoring-service/src/main/resources/application.yml
+++ b/wls-monitoring-service/src/main/resources/application.yml
@@ -36,6 +36,7 @@ server:
     include-stacktrace: never
     whitelabel:
       enabled: false
+  max-http-request-header-size: 32KB
 
 # Config for spring actuator endpoints
 management:

--- a/wls-wahlvorbereitung-service/src/main/resources/application.yml
+++ b/wls-wahlvorbereitung-service/src/main/resources/application.yml
@@ -41,6 +41,7 @@ server:
     include-stacktrace: never
     whitelabel:
       enabled: false
+  max-http-request-header-size: 32KB
 
 # Config for spring actuator endpoints
 management:

--- a/wls-wahlvorstand-service/src/main/resources/application.yml
+++ b/wls-wahlvorstand-service/src/main/resources/application.yml
@@ -36,6 +36,7 @@ server:
     include-stacktrace: never
     whitelabel:
       enabled: false
+  max-http-request-header-size: 32KB
 
 # Config for spring actuator endpoints
 management:


### PR DESCRIPTION
# Beschreibung:

- bei initialisierten Services für das default-Profil den Wert gesetzt

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] Erfolg bei folgenden Services überprüft da diese Controller haben:
  -  Briefwahlservice
  - Broadcastservice
  - EAIservice
  - Infomanagementservice
  - Wahlvorbereitungsservice

# Referenzen[^1]:

Verwandt mit Issue #

Closes #318 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
