### PR TITLE
226 verbesserung nutzbarkeit eai service

### DIFF
--- a/stack/.env
+++ b/stack/.env
@@ -28,3 +28,7 @@ WLS_BRIEFWAHL_SERVICE_KEYCLOAK_URL=http://kubernetes.docker.internal:8100/auth/r
 WLS_WAHLVORBEREITUNG_SERVICE_PROFILE=local,db-oracle,dummy.nobezirkid.check
 WLS_WAHLVORBEREITUNG_SERVICE_DB_URL=jdbc:oracle:thin:@//wls-db-oracle:1521/XEPDB1
 WLS_WAHLVORBEREITUNG_SERVICE_KEYCLOAK_URL=http://kubernetes.docker.internal:8100/auth/realms/${SSO_REALM}/protocol/openid-connect
+
+WLS_EAI_SERVICE_PROFILE=local,db-oracle,db-dummydata
+WLS_EAI_SERVICE_DB_URL=jdbc:oracle:thin:@//wls-db-oracle:1521/XEPDB1
+WLS_EAI_SERVICE_KEYCLOAK_URL=http://kubernetes.docker.internal:8100/auth/realms/${SSO_REALM}/protocol/openid-connect

--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -77,6 +77,25 @@ services:
       - services
       - keycloak
 
+  wls-eai-service:
+    container_name: wls-eai-service
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-eai-service:latest
+    depends_on:
+      - wls-db-oracle
+    env_file:
+      - .env
+    environment:
+      - SPRING_PROFILES_ACTIVE=${WLS_EAI_SERVICE_PROFILE}
+      - SPRING_DATASOURCE_URL=${WLS_EAI_SERVICE_DB_URL}
+      - SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK-SET-URI=${WLS_EAI_SERVICE_KEYCLOAK_URL}/certs
+      - SECURITY_OAUTH2_RESOURCE_USER-INFO-URI=${WLS_EAI_SERVICE_KEYCLOAK_URL}/userinfo
+      - SERVER_PORT=8080
+    ports:
+      - 8300:8080
+    networks:
+      - services
+      - keycloak
+
   ## Keycloak
   wls-keycloak:
     container_name: wls-keycloak

--- a/wls-eai-service/runLocal.bat
+++ b/wls-eai-service/runLocal.bat
@@ -1,1 +1,1 @@
-mvn clean spring-boot:run -Dspring-boot.run.jvmArguments="-Dspring.profiles.active=local"
+mvn clean spring-boot:run -Dspring-boot.run.jvmArguments="-Dspring.profiles.active=local,db-dummydata"

--- a/wls-eai-service/runLocal.sh
+++ b/wls-eai-service/runLocal.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-mvn clean spring-boot:run -Dspring-boot.run.jvmArguments="-Dspring.profiles.active=local"
+mvn clean spring-boot:run -Dspring-boot.run.jvmArguments="-Dspring.profiles.active=local,db-dummydata"

--- a/wls-eai-service/runLocalNoSecurity.bat
+++ b/wls-eai-service/runLocalNoSecurity.bat
@@ -1,1 +1,1 @@
-mvn clean spring-boot:run -Dspring-boot.run.jvmArguments="-Dspring.profiles.active=local,no-security"
+mvn clean spring-boot:run -Dspring-boot.run.jvmArguments="-Dspring.profiles.active=local,no-security,db-dummydata"

--- a/wls-eai-service/runLocalNoSecurity.sh
+++ b/wls-eai-service/runLocalNoSecurity.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-mvn clean spring-boot:run -Dspring-boot.run.jvmArguments="-Dspring.profiles.active=local,no-security"
+mvn clean spring-boot:run -Dspring-boot.run.jvmArguments="-Dspring.profiles.active=local,no-security,db-dummydata"

--- a/wls-eai-service/src/main/resources/application-local.yml
+++ b/wls-eai-service/src/main/resources/application-local.yml
@@ -1,2 +1,2 @@
 server:
-  port: 39146
+  port: 39149

--- a/wls-eai-service/src/main/resources/application.yml
+++ b/wls-eai-service/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
   profiles:
     group:
       local:
-        - db-oracle
+        - db-h2
   flyway:
     locations:
       - classpath:db/migrations/{vendor}

--- a/wls-eai-service/src/test/resources/httpRequests/http-client.env.json
+++ b/wls-eai-service/src/test/resources/httpRequests/http-client.env.json
@@ -4,7 +4,7 @@
     "SSO_URL": "http://kubernetes.docker.internal:8100"
   },
   "nonDocker": {
-    "WLS_EAI_SERVICE_URL": "http://localhost:39146",
+    "WLS_EAI_SERVICE_URL": "http://localhost:39149",
     "SSO_URL": "http://kubernetes.docker.internal:8100"
   }
 }


### PR DESCRIPTION
# Beschreibung:
- Port auf 39149 bei local umgestellt
- in `docker-compose.yml` EAI-Service mit aufgenommen
  - ich habe mich für Port 8300 entschieden da ich wir so die 82XX-Ports für die fachlichen Service verwenden können, wozu ich den EAI-Service nicht zähle
- bei den `run-`-Skripte wurde das Profil `db-dummydata` ergänzt damit beim Verwenden des Services auch Testdaten zur Verfügung stehen. Da man zur Laufzeit keine Daten ergänzen kann ist dies notwendig
- h2 wird jetzt bei `local` verwendet

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] Doku aktualisiert - nichts zu tun, aber wir sollten mal ;) ein Getting-Startet schreiben -> Issue #352 
- [X] Swagger-API vollständig - keine Anpassung notwendig
- [X] Unit-Tests gepflegt - keine Änderung an Code
- [X] Integrationstests gepflegt - keine Änderung an Code
- [X] Beispiel-Requests gepflegt - Port in Config für Requests aktualisiert

# Referenzen[^1]:

Verwandt mit Issue #

Closes #226

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
