### PR TITLE
Erstellung aufrufbarer Workflow um ein Image zu bauen

### DIFF
--- a/.github/workflows/dispatch-create-github-container-image.yml
+++ b/.github/workflows/dispatch-create-github-container-image.yml
@@ -26,8 +26,6 @@ jobs:
   build-github-container-image:
     permissions:
       packages: write
-    needs:
-      - run-mvn-release-prepare
     uses:
       ./.github/workflows/callable-create-github-container-image.yml
     with:

--- a/.github/workflows/dispatch-create-github-container-image.yml
+++ b/.github/workflows/dispatch-create-github-container-image.yml
@@ -3,9 +3,9 @@ name: dispatch build github container image
 on:
   workflow_dispatch:
     inputs:
-      git-ref:
+      tag:
         required: false
-        description: 'optional: branch/tag/ref to use for build; default: github.ref'
+        description: 'optional: gittag'
       service:
         required: true
         type: choice
@@ -29,5 +29,5 @@ jobs:
     uses:
       ./.github/workflows/callable-create-github-container-image.yml
     with:
-      tag: ${{ github.event.inputs.git-ref }}
+      tag: ${{ github.event.inputs.tag }}
       service: ${{ github.event.inputs.service }}

--- a/.github/workflows/dispatch-create-github-container-image.yml
+++ b/.github/workflows/dispatch-create-github-container-image.yml
@@ -1,0 +1,35 @@
+name: dispatch build github container image
+
+on:
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        required: false
+        description: 'optional: branch/tag/ref to use for build; default: github.ref'
+      service:
+        required: true
+        type: choice
+        description: service/directory to build (wls-broadcast-service, ...)
+        options:
+          - wls-auth-service
+          - wls-basisdaten-service
+          - wls-briefwahl-service
+          - wls-broadcast-service
+          - wls-eai-service
+          - wls-ergebnismeldung-service
+          - wls-infomanagement-service
+          - wls-monitoring-service
+          - wls-wahlvorbereitung-service
+          - wls-wahlvorstand-service
+
+jobs:
+  build-github-container-image:
+    permissions:
+      packages: write
+    needs:
+      - run-mvn-release-prepare
+    uses:
+      ./.github/workflows/callable-create-github-container-image.yml
+    with:
+      tag: ${{ github.event.inputs.git-ref }}
+      service: ${{ github.event.inputs.service }}

--- a/.github/workflows/dispatch-create-github-container-image.yml
+++ b/.github/workflows/dispatch-create-github-container-image.yml
@@ -3,9 +3,6 @@ name: dispatch build github container image
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        required: false
-        description: 'optional: gittag'
       service:
         required: true
         type: choice
@@ -21,6 +18,9 @@ on:
           - wls-monitoring-service
           - wls-wahlvorbereitung-service
           - wls-wahlvorstand-service
+      tag:
+        required: false
+        description: 'optional: gittag'
 
 jobs:
   build-github-container-image:


### PR DESCRIPTION
# Beschreibung:

Man kann die GitRef angeben und den Service auswählen zu dem das Image gebaut werden soll. Es wird der gleiche Workflow verwendet der auch beim push auf dev oder bei einem Release für einen Tag verwendet wird.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

# Workflow
- [x] ausprobiert: dazu muss der Defaultbranch geändert werden
  - ich habe neue EAI-Images erstellt zu dem Branch und Tag. Es wurden die jeweiligen Image-Tags gesetzt

# Referenzen[^1]:

Verwandt mit Issue #

Closes #356

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
