### PR TITLE
security local config in application.yml gelegt

### DIFF
--- a/wls-broadcast-service/src/main/resources/application-local.yml
+++ b/wls-broadcast-service/src/main/resources/application-local.yml
@@ -1,20 +1,2 @@
 server:
   port: 39146
-spring:
-
-  # Spring JPA
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          jwk-set-uri: http://kubernetes.docker.internal:8100/auth/realms/${realm}/protocol/openid-connect/certs
-
-
-# Define the local keycloak realm here
-realm: wls_realm
-
-security:
-  # possible values: none, all, changing (With changing, only changing requests such as POST, PUT, DELETE are logged)
-  logging.requests: all
-  oauth2:
-    resource.user-info-uri: http://kubernetes.docker.internal:8100/auth/realms/${realm}/protocol/openid-connect/userinfo

--- a/wls-broadcast-service/src/main/resources/application.yml
+++ b/wls-broadcast-service/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+# Define the local keycloak realm here
+realm: wls_realm
+
 spring:
   application.name: @project.artifactId@
   banner.location: banner.txt
@@ -9,6 +12,19 @@ spring:
     locations:
       - classpath:db/migrations/{vendor}
   h2.console.enabled: false
+
+  # Spring JPA
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: http://kubernetes.docker.internal:8100/auth/realms/${realm}/protocol/openid-connect/certs
+
+security:
+  # possible values: none, all, changing (With changing, only changing requests such as POST, PUT, DELETE are logged)
+  logging.requests: all
+  oauth2:
+    resource.user-info-uri: http://kubernetes.docker.internal:8100/auth/realms/${realm}/protocol/openid-connect/userinfo
 
 service:
   info:

--- a/wls-broadcast-service/src/main/resources/application.yml
+++ b/wls-broadcast-service/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
       - classpath:db/migrations/{vendor}
   h2.console.enabled: false
 
-  # Spring JPA
+  # OAuth-Security
   security:
     oauth2:
       resourceserver:


### PR DESCRIPTION
# Beschreibung:
beim hinzufügen der OpenApi ist aufgefallen, dass der Broadcast Service nicht mehr startet: https://github.com/it-at-m/Wahllokalsystem/actions/runs/9903925423/job/27362220030, weil die Security-Config nur in der local .yml war. Das wurde jetzt analog zu den anderen Services in die application.yml gelegt.

Keine DOD zu tun.

# Referenzen[^1]:

Verwandt mit Issue #320 
