### PR TITLE
361 wahlbriefauthorities der falsche gruppe zugeordnet

### DIFF
--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -120,7 +120,7 @@ services:
 
   wls-init-keycloak:
     container_name: wls-init-keycloak
-    image: klg71/keycloakmigration
+    image: klg71/keycloakmigration:0.2.61
     depends_on:
       - wls-keycloak
     env_file:

--- a/stack/keycloak/migration/add_authorities-briefwahl-wahlbriefdaten.yml
+++ b/stack/keycloak/migration/add_authorities-briefwahl-wahlbriefdaten.yml
@@ -7,7 +7,7 @@ changes:
       clientRole: true
       clientId: ${SSO_CLIENT_ID}
   - assignRoleToGroup:
-      group: allWahlvorbereitungAuthorities
+      group: allBriefwahlAuthorities
       role: Briefwahl_BUSINESSACTION_GetWahlbriefdaten
       clientId: ${SSO_CLIENT_ID}
 
@@ -16,7 +16,7 @@ changes:
       clientRole: true
       clientId: ${SSO_CLIENT_ID}
   - assignRoleToGroup:
-      group: allWahlvorbereitungAuthorities
+      group: allBriefwahlAuthorities
       role: Briefwahl_BUSINESSACTION_PostWahlbriefdaten
       clientId: ${SSO_CLIENT_ID}
 
@@ -25,7 +25,7 @@ changes:
       clientRole: true
       clientId: ${SSO_CLIENT_ID}
   - assignRoleToGroup:
-      group: allWahlvorbereitungAuthorities
+      group: allBriefwahlAuthorities
       role: Briefwahl_WRITE_Wahlbriefdaten
       clientId: ${SSO_CLIENT_ID}
 
@@ -34,6 +34,6 @@ changes:
       clientRole: true
       clientId: ${SSO_CLIENT_ID}
   - assignRoleToGroup:
-      group: allWahlvorbereitungAuthorities
+      group: allBriefwahlAuthorities
       role: Briefwahl_DELETE_Wahlbriefdaten
       clientId: ${SSO_CLIENT_ID}


### PR DESCRIPTION
# Beschreibung:

*Beschreben Sie hier die wesentlichen Aufgaben, die damit erledigt wurden und geben sie Hinweise zum Review.*

 -  [x] Direkte Korrektur in  `add_authorities-briefwahl-wahlbriefdaten.yml` 
  - Neuaufsetzen Keycloak erforderlich
  - Ticket #248 wird in diesem Zusammenhang wieder neu eröffnet 


Closes #361 

