### PR TITLE
Fix Buildwarnung ${groupId} is deprecated

### DIFF
--- a/wls-basisdaten-service/pom.xml
+++ b/wls-basisdaten-service/pom.xml
@@ -398,8 +398,8 @@
                             <generatorName>java</generatorName>
                             <library>resttemplate</library>
 
-                            <apiPackage>${groupId}.basisdatenservice.eai.aou.client</apiPackage>
-                            <modelPackage>${groupId}.basisdatenservice.eai.aou.model</modelPackage>
+                            <apiPackage>${project.groupId}.basisdatenservice.eai.aou.client</apiPackage>
+                            <modelPackage>${project.groupId}.basisdatenservice.eai.aou.model</modelPackage>
 
                             <generateApiTests>false</generateApiTests>
                             <generateModelTests>false</generateModelTests>


### PR DESCRIPTION
# Beschreibung:

Hier der Logauszug:

```
[WARNING] Some problems were encountered while building the effective model for de.muenchen.oss.wahllokalsystem:wls-basisdaten-service:jar:0.0.1-SNAPSHOT
[WARNING] The expression ${groupId} is deprecated. Please use ${project.groupId} instead.
[WARNING] The expression ${groupId} is deprecated. Please use ${project.groupId} instead.
```

Entsprechend wurde die Property ersetzt

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

keine expliziten DoDs

# Referenzen[^1]:

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
