### PR TITLE
fix keycloak migration failure - remove duplicated roles for read Wahl/Wahltag

### DIFF
--- a/stack/keycloak/migration/add-authorities-basisdaten-wahlbezirke.yml
+++ b/stack/keycloak/migration/add-authorities-basisdaten-wahlbezirke.yml
@@ -12,24 +12,6 @@ changes:
       clientId: ${SSO_CLIENT_ID}
 
   - addRole:
-      name: Basisdaten_READ_Wahltag
-      clientRole: true
-      clientId: ${SSO_CLIENT_ID}
-  - assignRoleToGroup:
-      group: allBasisdatenAuthorities
-      role: Basisdaten_READ_Wahltag
-      clientId: ${SSO_CLIENT_ID}
-
-  - addRole:
-      name: Basisdaten_READ_Wahl
-      clientRole: true
-      clientId: ${SSO_CLIENT_ID}
-  - assignRoleToGroup:
-      group: allBasisdatenAuthorities
-      role: Basisdaten_READ_Wahl
-      clientId: ${SSO_CLIENT_ID}
-
-  - addRole:
       name: Basisdaten_READ_Wahlbezirk
       clientRole: true
       clientId: ${SSO_CLIENT_ID}


### PR DESCRIPTION
# Beschreibung:

Die Rechte `READ_WAHL` und `READ_WAHLTAG` gab es zwei mal. Ich habe sie aus dem File zu `wahlbezirke` entfernt da diese Rechte/Rollen bereits im File zu den `wahlen` konfiguriert werden. Der Context `wahlen` ist aus meiner Sicht der bessere.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] keycloak migration mit frischen wls_realm erfolgreich durchgeführt
- [X] Doku aktualisiert - nichts zu tun
- [X] Swagger-API vollständig - nichts zu tun
- [X] Unit-Tests gepflegt - nichts zu tun
- [X] Integrationstests gepflegt - nichts zu tun
- [X] Beispiel-Requests gepflegt - nichts zu tun

# Referenzen[^1]:

Closes #400

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
