### PR TITLE
141 fix wahlen können gelesen und geschrieben werden

### DIFF
--- a/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/clients/DummyClientImpl.java
+++ b/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/clients/DummyClientImpl.java
@@ -69,9 +69,9 @@ public class DummyClientImpl
     @Override
     public List<WahlModel> getWahlen(final WahltagWithNummer wahltagWithNummer) throws WlsException {
         return List.of(
-                new WahlModel("wahl1", "0", 1L, 1L, wahltagWithNummer.wahltag(), BTW, new Farbe(0, 1, 2), "1"),
-                new WahlModel("wahl2", "1", 2L, 1L, wahltagWithNummer.wahltag(), EUW, new Farbe(3, 4, 5), "1"),
-                new WahlModel("wahl3", "2", 3L, 1L, wahltagWithNummer.wahltag(), LTW, new Farbe(6, 7, 8), "1"));
+                new WahlModel("wahl1", "remoteWahl 0", 1L, 1L, wahltagWithNummer.wahltag(), BTW, new Farbe(0, 1, 2), "1"),
+                new WahlModel("wahl2", "remoteWahl 1", 2L, 1L, wahltagWithNummer.wahltag(), EUW, new Farbe(3, 4, 5), "1"),
+                new WahlModel("wahl3", "remoteWahl 2", 3L, 1L, wahltagWithNummer.wahltag(), LTW, new Farbe(6, 7, 8), "1"));
     }
 
     @Override

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/domain/WahlRepositoryTest.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/domain/WahlRepositoryTest.java
@@ -92,7 +92,7 @@ class WahlRepositoryTest {
     }
 
     @Test
-    void savingNewWahlenOverridesExistingWithSameId(){
+    void savingNewWahlenOverridesExistingWithSameId() {
         repository.deleteAll();
         val wahltagDateToFind = LocalDate.of(2024, 9, 3);
         val wahlenToSave_First = List.of(

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/domain/WahlRepositoryTest.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/domain/WahlRepositoryTest.java
@@ -91,6 +91,24 @@ class WahlRepositoryTest {
         }
     }
 
+    @Test
+    void savingNewWahlenOverridesExistingWithSameId(){
+        repository.deleteAll();
+        val wahltagDateToFind = LocalDate.of(2024, 9, 3);
+        val wahlenToSave_First = List.of(
+                new Wahl("wahltagID1", "name1_first", 1, 1, wahltagDateToFind, Wahlart.BTW, null, "0"),
+                new Wahl("wahltagID2", "name2_first", 1, 1, wahltagDateToFind, Wahlart.BTW, null, "1"));
+        val wahlenToSave_Second = List.of(
+                new Wahl("wahltagID1", "name1_second", 1, 1, wahltagDateToFind.plusDays(1), Wahlart.BTW, null, "0"),
+                new Wahl("wahltagID2", "name2_second", 1, 1, wahltagDateToFind.minusDays(1), Wahlart.BTW, null, "1"));
+        repository.saveAll(wahlenToSave_First);
+        repository.saveAll(wahlenToSave_Second);
+
+        val foundWahlen = repository.findAll();
+
+        Assertions.assertThat(foundWahlen).containsExactlyInAnyOrderElementsOf(wahlenToSave_Second);
+    }
+
     private List<Wahl> createWahlenList() {
         val wahl1 = new Wahl("wahlID1", "name1", 3L, 1L, LocalDate.now().minusMonths(1), Wahlart.BAW, new Farbe(1, 1, 1), "1");
         val wahl2 = new Wahl("wahlID2", "name2", 2L, 2L, LocalDate.now().plusMonths(1), Wahlart.EUW, new Farbe(2, 2, 2), "2");

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/rest/wahlen/WahlenControllerIntegrationTest.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/rest/wahlen/WahlenControllerIntegrationTest.java
@@ -190,7 +190,7 @@ public class WahlenControllerIntegrationTest {
         void newDataIsSet() throws Exception {
             var searchingForWahltag = new Wahltag("wahltagID", LocalDate.now(), "beschreibung5", "1");
             wahltagRepository.save(searchingForWahltag);
-            val newData = createControllerListOfWahlDTO(searchingForWahltag);
+            val newData = createControllerListOfWahlDTO(searchingForWahltag, "");
 
             SecurityUtils.runWith(Authorities.REPOSITORY_WRITE_WAHL, Authorities.SERVICE_POST_WAHLEN);
             val request = MockMvcRequestBuilders.post("/businessActions/wahlen/" + searchingForWahltag.getWahltagID()).with(csrf())
@@ -209,24 +209,33 @@ public class WahlenControllerIntegrationTest {
         void existingWahlenAreReplaced() throws Exception {
             var searchingForWahltag = new Wahltag("wahltagID", LocalDate.now(), "beschreibung6", "1");
             wahltagRepository.save(searchingForWahltag);
-            val newData = createControllerListOfWahlDTO(searchingForWahltag);
+            val oldData = createControllerListOfWahlDTO(searchingForWahltag, "");
             SecurityUtils.runWith(Authorities.REPOSITORY_WRITE_WAHL, Authorities.SERVICE_POST_WAHLEN, Authorities.REPOSITORY_READ_WAHL);
-            val request = MockMvcRequestBuilders.post("/businessActions/wahlen/" + searchingForWahltag.getWahltagID()).with(csrf())
+            val request_first = MockMvcRequestBuilders.post("/businessActions/wahlen/" + searchingForWahltag.getWahltagID()).with(csrf())
                     .contentType(MediaType.APPLICATION_JSON).content(
-                            objectMapper.writeValueAsString(newData));
-            api.perform(request).andExpect(status().isOk());
-
-            val expectedPostedWahlen = wahlModelMapper.fromListOfWahlModeltoListOfWahlEntities(dtoMapper.fromListOfWahlDTOtoListOfWahlModel(newData));
+                            objectMapper.writeValueAsString(oldData));
+            api.perform(request_first).andExpect(status().isOk());
+            val expectedPostedWahlen_old = wahlModelMapper.fromListOfWahlModeltoListOfWahlEntities(dtoMapper.fromListOfWahlDTOtoListOfWahlModel(oldData));
             val oldSavedWahlen = wahlRepository.findAll();
 
-            Assertions.assertThat(oldSavedWahlen).isEqualTo(expectedPostedWahlen);
+            Assertions.assertThat(oldSavedWahlen).isEqualTo(expectedPostedWahlen_old);
+
+            val newWahlen = createControllerListOfWahlDTO(searchingForWahltag, "newWahlen");
+            val request_second = MockMvcRequestBuilders.post("/businessActions/wahlen/" + searchingForWahltag.getWahltagID()).with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON).content(
+                            objectMapper.writeValueAsString(newWahlen));
+            api.perform(request_second).andExpect(status().isOk());
+            val expectedPostedWahlen_new = wahlModelMapper.fromListOfWahlModeltoListOfWahlEntities(dtoMapper.fromListOfWahlDTOtoListOfWahlModel(newWahlen));
+            val newSavedWahlen = wahlRepository.findAll();
+
+            Assertions.assertThat(newSavedWahlen).isEqualTo(expectedPostedWahlen_new);
         }
 
         @Test
         void fachlicheWlsExceptionWhenRequestIsInvalid() throws Exception {
             var searchingForWahltag = new Wahltag("wahltagID", LocalDate.now(), "beschreibung7", "1");
             wahltagRepository.save(searchingForWahltag);
-            val newData = createControllerListOfWahlDTO(searchingForWahltag);
+            val newData = createControllerListOfWahlDTO(searchingForWahltag, "");
 
             SecurityUtils.runWith(Authorities.REPOSITORY_WRITE_WAHL, Authorities.SERVICE_POST_WAHLEN, Authorities.REPOSITORY_READ_WAHL);
             val request = MockMvcRequestBuilders.post("/businessActions/wahlen/" + "     ").with(csrf()).contentType(MediaType.APPLICATION_JSON).content(
@@ -260,7 +269,7 @@ public class WahlenControllerIntegrationTest {
     class ResetWahlen {
 
         @Test
-        void existingWahlenAreReplaced() throws Exception {
+        void existingWahlenAreReseted() throws Exception {
             SecurityUtils.runWith(Authorities.REPOSITORY_WRITE_WAHL);
             val oldRepositoryWahlen = createWahlEntities();
             wahlRepository.saveAll(oldRepositoryWahlen);
@@ -303,12 +312,12 @@ public class WahlenControllerIntegrationTest {
         return Set.of(wahl1, wahl2, wahl3).stream().filter(wahl -> (wahl.getWahltag().equals(searchingForWahltag.getWahltag()))).collect(Collectors.toSet());
     }
 
-    private List<de.muenchen.oss.wahllokalsystem.basisdatenservice.rest.wahlen.WahlDTO> createControllerListOfWahlDTO(Wahltag searchingForWahltag) {
-        val wahl1 = new de.muenchen.oss.wahllokalsystem.basisdatenservice.rest.wahlen.WahlDTO("wahlID1", "name1", 3L, 1L, searchingForWahltag.getWahltag(),
+    private List<de.muenchen.oss.wahllokalsystem.basisdatenservice.rest.wahlen.WahlDTO> createControllerListOfWahlDTO(Wahltag searchingForWahltag, final String namePraefix) {
+        val wahl1 = new de.muenchen.oss.wahllokalsystem.basisdatenservice.rest.wahlen.WahlDTO("wahlID1", namePraefix + "name1", 3L, 1L, searchingForWahltag.getWahltag(),
                 Wahlart.BAW, new Farbe(1, 1, 1), "1");
-        val wahl2 = new de.muenchen.oss.wahllokalsystem.basisdatenservice.rest.wahlen.WahlDTO("wahlID2", "name2", 3L, 1L, searchingForWahltag.getWahltag(),
+        val wahl2 = new de.muenchen.oss.wahllokalsystem.basisdatenservice.rest.wahlen.WahlDTO("wahlID2", namePraefix + "name2", 3L, 1L, searchingForWahltag.getWahltag(),
                 Wahlart.BAW, new Farbe(1, 1, 1), "2");
-        val wahl3 = new de.muenchen.oss.wahllokalsystem.basisdatenservice.rest.wahlen.WahlDTO("wahlID3", "name3", 3L, 1L, LocalDate.now().plusMonths(2),
+        val wahl3 = new de.muenchen.oss.wahllokalsystem.basisdatenservice.rest.wahlen.WahlDTO("wahlID3", namePraefix + "name3", 3L, 1L, LocalDate.now().plusMonths(2),
                 Wahlart.BAW, new Farbe(1, 1, 1), "3");
 
         return Stream.of(wahl1, wahl2, wahl3).filter(wahl -> (wahl.wahltag().equals(searchingForWahltag.getWahltag()))).collect(Collectors.toList());

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/rest/wahlen/WahlenControllerIntegrationTest.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/rest/wahlen/WahlenControllerIntegrationTest.java
@@ -312,12 +312,16 @@ public class WahlenControllerIntegrationTest {
         return Set.of(wahl1, wahl2, wahl3).stream().filter(wahl -> (wahl.getWahltag().equals(searchingForWahltag.getWahltag()))).collect(Collectors.toSet());
     }
 
-    private List<de.muenchen.oss.wahllokalsystem.basisdatenservice.rest.wahlen.WahlDTO> createControllerListOfWahlDTO(Wahltag searchingForWahltag, final String namePraefix) {
-        val wahl1 = new de.muenchen.oss.wahllokalsystem.basisdatenservice.rest.wahlen.WahlDTO("wahlID1", namePraefix + "name1", 3L, 1L, searchingForWahltag.getWahltag(),
+    private List<de.muenchen.oss.wahllokalsystem.basisdatenservice.rest.wahlen.WahlDTO> createControllerListOfWahlDTO(Wahltag searchingForWahltag,
+            final String namePraefix) {
+        val wahl1 = new de.muenchen.oss.wahllokalsystem.basisdatenservice.rest.wahlen.WahlDTO("wahlID1", namePraefix + "name1", 3L, 1L,
+                searchingForWahltag.getWahltag(),
                 Wahlart.BAW, new Farbe(1, 1, 1), "1");
-        val wahl2 = new de.muenchen.oss.wahllokalsystem.basisdatenservice.rest.wahlen.WahlDTO("wahlID2", namePraefix + "name2", 3L, 1L, searchingForWahltag.getWahltag(),
+        val wahl2 = new de.muenchen.oss.wahllokalsystem.basisdatenservice.rest.wahlen.WahlDTO("wahlID2", namePraefix + "name2", 3L, 1L,
+                searchingForWahltag.getWahltag(),
                 Wahlart.BAW, new Farbe(1, 1, 1), "2");
-        val wahl3 = new de.muenchen.oss.wahllokalsystem.basisdatenservice.rest.wahlen.WahlDTO("wahlID3", namePraefix + "name3", 3L, 1L, LocalDate.now().plusMonths(2),
+        val wahl3 = new de.muenchen.oss.wahllokalsystem.basisdatenservice.rest.wahlen.WahlDTO("wahlID3", namePraefix + "name3", 3L, 1L,
+                LocalDate.now().plusMonths(2),
                 Wahlart.BAW, new Farbe(1, 1, 1), "3");
 
         return Stream.of(wahl1, wahl2, wahl3).filter(wahl -> (wahl.wahltag().equals(searchingForWahltag.getWahltag()))).collect(Collectors.toList());

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/rest/wahlen/WahlenControllerIntegrationTest.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/rest/wahlen/WahlenControllerIntegrationTest.java
@@ -211,20 +211,20 @@ public class WahlenControllerIntegrationTest {
             wahltagRepository.save(searchingForWahltag);
             val oldData = createControllerListOfWahlDTO(searchingForWahltag, "");
             SecurityUtils.runWith(Authorities.REPOSITORY_WRITE_WAHL, Authorities.SERVICE_POST_WAHLEN, Authorities.REPOSITORY_READ_WAHL);
-            val request_first = MockMvcRequestBuilders.post("/businessActions/wahlen/" + searchingForWahltag.getWahltagID()).with(csrf())
+            val requestFirst = MockMvcRequestBuilders.post("/businessActions/wahlen/" + searchingForWahltag.getWahltagID()).with(csrf())
                     .contentType(MediaType.APPLICATION_JSON).content(
                             objectMapper.writeValueAsString(oldData));
-            api.perform(request_first).andExpect(status().isOk());
+            api.perform(requestFirst).andExpect(status().isOk());
             val expectedPostedWahlen_old = wahlModelMapper.fromListOfWahlModeltoListOfWahlEntities(dtoMapper.fromListOfWahlDTOtoListOfWahlModel(oldData));
             val oldSavedWahlen = wahlRepository.findAll();
 
             Assertions.assertThat(oldSavedWahlen).isEqualTo(expectedPostedWahlen_old);
 
             val newWahlen = createControllerListOfWahlDTO(searchingForWahltag, "newWahlen");
-            val request_second = MockMvcRequestBuilders.post("/businessActions/wahlen/" + searchingForWahltag.getWahltagID()).with(csrf())
+            val requestSecond = MockMvcRequestBuilders.post("/businessActions/wahlen/" + searchingForWahltag.getWahltagID()).with(csrf())
                     .contentType(MediaType.APPLICATION_JSON).content(
                             objectMapper.writeValueAsString(newWahlen));
-            api.perform(request_second).andExpect(status().isOk());
+            api.perform(requestSecond).andExpect(status().isOk());
             val expectedPostedWahlen_new = wahlModelMapper.fromListOfWahlModeltoListOfWahlEntities(dtoMapper.fromListOfWahlDTOtoListOfWahlModel(newWahlen));
             val newSavedWahlen = wahlRepository.findAll();
 

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/services/wahlen/WahlenServiceTest.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/services/wahlen/WahlenServiceTest.java
@@ -131,39 +131,39 @@ class WahlenServiceTest {
             val wahltagID = "wahltagID";
             var searchingForWahltag = new WahltagModel(wahltagID, LocalDate.now().plusMonths(1), "beschreibung1", "1");
 
-            List<WahlModel> mockedListOfModels_first = createWahlModels("first");
-            List<Wahl> mockedListOfEntities_first = createWahlEntities("first");
-            val wahlenToWrite_first = new WahlenWriteModel(wahltagID, mockedListOfModels_first);
-            Mockito.when(wahlModelMapper.fromListOfWahlModeltoListOfWahlEntities(mockedListOfModels_first)).thenReturn(mockedListOfEntities_first);
-            Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.postWahlen(wahlenToWrite_first));
-            Mockito.verify(wahlenValidator).validWahlenWriteModelOrThrow(new WahlenWriteModel(wahltagID, mockedListOfModels_first));
-            Mockito.verify(wahlRepository).saveAll(mockedListOfEntities_first);
+            List<WahlModel> mockedListOfModelsFirst = createWahlModels("first");
+            List<Wahl> mockedListOfEntitiesFirst = createWahlEntities("first");
+            val wahlenToWriteFirst = new WahlenWriteModel(wahltagID, mockedListOfModelsFirst);
+            Mockito.when(wahlModelMapper.fromListOfWahlModeltoListOfWahlEntities(mockedListOfModelsFirst)).thenReturn(mockedListOfEntitiesFirst);
+            Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.postWahlen(wahlenToWriteFirst));
+            Mockito.verify(wahlenValidator).validWahlenWriteModelOrThrow(new WahlenWriteModel(wahltagID, mockedListOfModelsFirst));
+            Mockito.verify(wahlRepository).saveAll(mockedListOfEntitiesFirst);
             Mockito.doNothing().when(wahlenValidator).validWahlenCriteriaOrThrow(wahltagID);
             Mockito.when(wahltageService.getWahltagByID(wahltagID)).thenReturn(searchingForWahltag);
             Mockito.when(wahlRepository.existsByWahltag(searchingForWahltag.wahltag())).thenReturn(true);
-            Mockito.when(wahlRepository.findByWahltagOrderByReihenfolge(searchingForWahltag.wahltag())).thenReturn(mockedListOfEntities_first);
-            Mockito.when(wahlModelMapper.fromListOfWahlEntityToListOfWahlModel(mockedListOfEntities_first)).thenReturn(mockedListOfModels_first);
+            Mockito.when(wahlRepository.findByWahltagOrderByReihenfolge(searchingForWahltag.wahltag())).thenReturn(mockedListOfEntitiesFirst);
+            Mockito.when(wahlModelMapper.fromListOfWahlEntityToListOfWahlModel(mockedListOfEntitiesFirst)).thenReturn(mockedListOfModelsFirst);
 
-            val expectedResult_first = wahlModelMapper.fromListOfWahlEntityToListOfWahlModel(mockedListOfEntities_first);
-            val result_first = unitUnderTest.getWahlen(wahltagID);
+            val expectedResultFirst = wahlModelMapper.fromListOfWahlEntityToListOfWahlModel(mockedListOfEntitiesFirst);
+            val resultFirst = unitUnderTest.getWahlen(wahltagID);
             Assertions.assertThatCode(() -> unitUnderTest.getWahlen(wahltagID)).doesNotThrowAnyException();
-            Assertions.assertThat(result_first).isEqualTo(expectedResult_first);
+            Assertions.assertThat(resultFirst).isEqualTo(expectedResultFirst);
 
-            List<WahlModel> mockedListOfModels_second = createWahlModels("second");
-            List<Wahl> mockedListOfEntities_second = createWahlEntities("second");
-            val wahlenToWrite_second = new WahlenWriteModel(wahltagID, mockedListOfModels_second);
-            Mockito.when(wahlModelMapper.fromListOfWahlModeltoListOfWahlEntities(mockedListOfModels_second)).thenReturn(mockedListOfEntities_second);
-            Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.postWahlen(wahlenToWrite_second));
-            Mockito.verify(wahlenValidator).validWahlenWriteModelOrThrow(new WahlenWriteModel(wahltagID, mockedListOfModels_second));
-            Mockito.verify(wahlRepository).saveAll(mockedListOfEntities_second);
+            List<WahlModel> mockedListOfModelsSecond = createWahlModels("second");
+            List<Wahl> mockedListOfEntitiesSecond = createWahlEntities("second");
+            val wahlenToWriteSecond = new WahlenWriteModel(wahltagID, mockedListOfModelsSecond);
+            Mockito.when(wahlModelMapper.fromListOfWahlModeltoListOfWahlEntities(mockedListOfModelsSecond)).thenReturn(mockedListOfEntitiesSecond);
+            Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.postWahlen(wahlenToWriteSecond));
+            Mockito.verify(wahlenValidator).validWahlenWriteModelOrThrow(new WahlenWriteModel(wahltagID, mockedListOfModelsSecond));
+            Mockito.verify(wahlRepository).saveAll(mockedListOfEntitiesSecond);
 
-            Mockito.when(wahlRepository.findByWahltagOrderByReihenfolge(searchingForWahltag.wahltag())).thenReturn(mockedListOfEntities_second);
-            Mockito.when(wahlModelMapper.fromListOfWahlEntityToListOfWahlModel(mockedListOfEntities_second)).thenReturn(mockedListOfModels_second);
+            Mockito.when(wahlRepository.findByWahltagOrderByReihenfolge(searchingForWahltag.wahltag())).thenReturn(mockedListOfEntitiesSecond);
+            Mockito.when(wahlModelMapper.fromListOfWahlEntityToListOfWahlModel(mockedListOfEntitiesSecond)).thenReturn(mockedListOfModelsSecond);
 
-            val expectedResult_second = wahlModelMapper.fromListOfWahlEntityToListOfWahlModel(mockedListOfEntities_second);
-            val result_second = unitUnderTest.getWahlen(wahltagID);
+            val expectedResultSecond = wahlModelMapper.fromListOfWahlEntityToListOfWahlModel(mockedListOfEntitiesSecond);
+            val resultSecond = unitUnderTest.getWahlen(wahltagID);
             Assertions.assertThatCode(() -> unitUnderTest.getWahlen(wahltagID)).doesNotThrowAnyException();
-            Assertions.assertThat(result_second).isEqualTo(expectedResult_second);
+            Assertions.assertThat(resultSecond).isEqualTo(expectedResultSecond);
 
             Mockito.verifyNoInteractions(wahlenClient);
         }

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/services/wahlen/WahlenServiceTest.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/services/wahlen/WahlenServiceTest.java
@@ -127,7 +127,7 @@ class WahlenServiceTest {
         }
 
         @Test
-        void postingNewWahlenOverridesExistingWithSameId(){
+        void postingNewWahlenOverridesExistingWithSameId() {
             val wahltagID = "wahltagID";
             var searchingForWahltag = new WahltagModel(wahltagID, LocalDate.now().plusMonths(1), "beschreibung1", "1");
 

--- a/wls-basisdaten-service/src/test/resources/wahlen.http
+++ b/wls-basisdaten-service/src/test/resources/wahlen.http
@@ -18,6 +18,12 @@ GET {{ SSO_URL }}/auth/realms/wls_realm/protocol/openid-connect/userinfo
 Authorization: {{ token_type }} {{ auth_token }}
 
 ### POST Wahlen
+## If you want to POST Wahlen to override existing Wahlen with the intention to find them later with getWahlen
+## please take account of the value of posted properties "wahltag", because getWahlen is searching by wahltagID and
+## the date of the wahltag corresponding to this wahltagID is the search parameter for the Wahl in Repo. If there is no
+## Wahl with this "wahltag", then you will recive the response from remote client, so you could think that the old Wahl
+## could have not been overwritten in the step before. Actualy they were replaced, but if they do not have the date of
+## the Wahltag, than indeed is the expected response, the response from remote client.
 POST {{ WLS_BASISDATEN_SERVICE_URL }}//businessActions/wahlen/wahltagID1
 Authorization: {{ token_type }} {{ auth_token }}
 Content-Type: application/json
@@ -25,10 +31,10 @@ Content-Type: application/json
 [
   {
     "wahlID": "wahl1",
-    "name": "0",
+    "name": "aName_1",
     "reihenfolge": 1,
     "waehlerverzeichnisnummer": 1,
-    "wahltag": "2024-06-06",
+    "wahltag": "2024-07-20",
     "wahlart": "BTW",
     "farbe": {
       "r": 0,

--- a/wls-basisdaten-service/src/test/resources/wahlen.http
+++ b/wls-basisdaten-service/src/test/resources/wahlen.http
@@ -18,12 +18,18 @@ GET {{ SSO_URL }}/auth/realms/wls_realm/protocol/openid-connect/userinfo
 Authorization: {{ token_type }} {{ auth_token }}
 
 ### POST Wahlen
-## If you want to POST Wahlen to override existing Wahlen with the intention to find them later with getWahlen
-## please take account of the value of posted properties "wahltag", because getWahlen is searching by wahltagID and
-## the date of the wahltag corresponding to this wahltagID is the search parameter for the Wahl in Repo. If there is no
-## Wahl with this "wahltag", then you will recive the response from remote client, so you could think that the old Wahl
-## could have not been overwritten in the step before. Actualy they were replaced, but if they do not have the date of
-## the Wahltag, than indeed is the expected response, the response from remote client.
+## Hier wird das Datum des Wahltages mit der wahltagID1 gesetzt (today - 2 months) - siehe DummyClient
+< {%
+    const today = new Date();
+    let dd = today.getDate();
+    const mm = today.getMonth();
+    let yyyy_2MonthsBefore = (mm < 2) ? new Date().getFullYear() - 1 : new Date().getFullYear();
+    let mm_2MonthsBefore = (mm % 12) - 1;
+    if (dd < 10) dd = '0' + dd;
+    if (mm_2MonthsBefore < 10) mm_2MonthsBefore = '0' + mm_2MonthsBefore;
+    const dateOfWahltagID1 = ('"' + yyyy_2MonthsBefore + '-' + mm_2MonthsBefore + '-' + dd + '"');
+    request.variables.set("dateOfWahltagID1", dateOfWahltagID1);
+%}
 POST {{ WLS_BASISDATEN_SERVICE_URL }}//businessActions/wahlen/wahltagID1
 Authorization: {{ token_type }} {{ auth_token }}
 Content-Type: application/json
@@ -34,7 +40,7 @@ Content-Type: application/json
     "name": "aName_1",
     "reihenfolge": 1,
     "waehlerverzeichnisnummer": 1,
-    "wahltag": "2024-07-20",
+    "wahltag": {{ dateOfWahltagID1 }},
     "wahlart": "BTW",
     "farbe": {
       "r": 0,
@@ -48,7 +54,7 @@ Content-Type: application/json
     "name": "1",
     "reihenfolge": 2,
     "waehlerverzeichnisnummer": 1,
-    "wahltag": "2024-06-06",
+    "wahltag": {{ dateOfWahltagID1 }},
     "wahlart": "EUW",
     "farbe": {
       "r": 3,
@@ -62,7 +68,7 @@ Content-Type: application/json
     "name": "2-",
     "reihenfolge": 3,
     "waehlerverzeichnisnummer": 1,
-    "wahltag": "2024-06-06",
+    "wahltag": {{ dateOfWahltagID1 }},
     "wahlart": "LTW",
     "farbe": {
       "r": 6,


### PR DESCRIPTION
# Beschreibung:

Anlass dieses Fix-Issues war, dass im Rahmen des Demo-Termins für #141 wir feststellten, dass zwar zuerst die Wahlen vom Remote gelesen und ins Repo geschrieben wurden, aber nach dem Post-Wahlen mit Wahlen mit den gleichen WahlIDs
 wie die davor gespeicherten, ein erneutes GetWahlen wieder die alten Wahlen zurück lieferte, anstelle der neulich gespeicherten, wie man erwartet hätte.

Wenn diese Beobachtung korrekt gewesen wäre, stellte dies einen Fehler dar.

# Ergebnis der Analyse

Unsere Schlussfolgerung war ein Trugschluss. Die zuletzt gespeicherten Wahlen überschrieben doch diejenigen mit gleicher wahlID im Repo nur, dass die gelieferten Wahlen nach dem letzten GetWahlen nicht aus dem Repo kamen sondern vom Remote-Client. Wir haben dabei übersehen, dass die zuletzt gespeicherten Wahlen, die wir als Antwort erwartet hätten, einen anderen "wahltag" also ein anderes Wahltagdatum hatten, als das Datum des Wahltages dessen ID wir im letzten getWahlen(wahltagID) als Abfrageparameter sandten. Somit hat zurecht der Service nichts im Repo für den WahltagID gefunden und er hat erneut vom Remote-Client geladen.

## Durchgeführte Optimierungen

Tests wurden ergänzt und im http-wahlen File ein Kommentar eingetragen.
