### PR TITLE
365 konfiguration von local und beispielrequests passen nicht zusammen

### DIFF
--- a/wls-briefwahl-service/src/main/resources/application.yml
+++ b/wls-briefwahl-service/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: http://localhost:8100/auth/realms/${realm}/protocol/openid-connect/certs
+          jwk-set-uri: http://kubernetes.docker.internal:8100/auth/realms/${realm}/protocol/openid-connect/certs
 
 
 
@@ -23,7 +23,7 @@ security:
   # possible values: none, all, changing (With changing, only changing requests such as POST, PUT, DELETE are logged)
   logging.requests: all
   oauth2:
-    resource.user-info-uri: http://localhost:8100/auth/realms/${realm}/protocol/openid-connect/userinfo
+    resource.user-info-uri: http://kubernetes.docker.internal:8100/auth/realms/${realm}/protocol/openid-connect/userinfo
 
 
 # Define the local keycloak realm here


### PR DESCRIPTION
# Beschreibung:

- application.yml angepasst damit Erstellung und Prüfung des Tokens durch denselben Hostnamen erfolgt

Closes #365

