### PR TITLE
375 springdoc openapigenerate connection refused connect

### DIFF
--- a/wls-briefwahl-service/src/main/resources/application.yml
+++ b/wls-briefwahl-service/src/main/resources/application.yml
@@ -31,7 +31,7 @@ realm: wls_realm
 
 server:
   shutdown: "graceful"
-  port: 39146
+  port: 8080
   error:
     include-exception: false
     include-stacktrace: never


### PR DESCRIPTION
# Beschreibung:

in application.yml war ein falscher Port gesetzt. Das Openapi-Plugin benötigt den Default-Port 8080 um openapi.json zu generieren 

Closes #375
