### PR TITLE
Flyway Skripte für TheEntity für die Kompatibiltät wieder da

### DIFF
--- a/wls-briefwahl-service/src/main/resources/db/migrations/h2/V0_1__createTableTheEntity.sql
+++ b/wls-briefwahl-service/src/main/resources/db/migrations/h2/V0_1__createTableTheEntity.sql
@@ -1,0 +1,5 @@
+CREATE TABLE theEntity
+(
+    id            varchar2(36) NOT NULL primary key,
+    textAttribute varchar2(8)  NOT NULL
+)

--- a/wls-briefwahl-service/src/main/resources/db/migrations/h2/V9_0__dropTableTheEntity.sql
+++ b/wls-briefwahl-service/src/main/resources/db/migrations/h2/V9_0__dropTableTheEntity.sql
@@ -1,0 +1,1 @@
+DROP TABLE theEntity

--- a/wls-briefwahl-service/src/main/resources/db/migrations/oracle/V0_1__createTableTheEntity.sql
+++ b/wls-briefwahl-service/src/main/resources/db/migrations/oracle/V0_1__createTableTheEntity.sql
@@ -1,0 +1,5 @@
+CREATE TABLE theEntity
+(
+    id            varchar2(36) NOT NULL primary key,
+    textAttribute varchar2(8)  NOT NULL
+)

--- a/wls-briefwahl-service/src/main/resources/db/migrations/oracle/V9_0__dropTableTheEntity.sql
+++ b/wls-briefwahl-service/src/main/resources/db/migrations/oracle/V9_0__dropTableTheEntity.sql
@@ -1,0 +1,1 @@
+DROP TABLE theEntity


### PR DESCRIPTION
# Beschreibung:

Flyway Skripte `createTheEntity`  und `dropTheEntity` für die Kompatibilität mit bei jedem lokal angelegten Datenbank-Schemas und mit der Server Oracle-DB wiederhergestellt.

Closes #201

