### PR TITLE
148 redesign Vorschläge und Vorlagen save - use cascade type

### DIFF
--- a/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/domain/referendumvorlagen/Referendumvorlagen.java
+++ b/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/domain/referendumvorlagen/Referendumvorlagen.java
@@ -3,6 +3,7 @@ package de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.referendumvorla
 import static java.sql.Types.VARCHAR;
 
 import de.muenchen.oss.wahllokalsystem.wls.common.security.domain.BezirkUndWahlID;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -45,7 +46,7 @@ public class Referendumvorlagen {
     @NotNull
     private String stimmzettelgebietID;
 
-    @OneToMany(mappedBy = "referendumvorlagen", orphanRemoval = true)
+    @OneToMany(mappedBy = "referendumvorlagen", orphanRemoval = true, cascade = CascadeType.PERSIST)
     @NotNull
     private Set<Referendumvorlage> referendumvorlagen = new HashSet<>();
 

--- a/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/domain/wahlvorschlag/Wahlvorschlaege.java
+++ b/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/domain/wahlvorschlag/Wahlvorschlaege.java
@@ -3,6 +3,7 @@ package de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.wahlvorschlag;
 import static java.sql.Types.VARCHAR;
 
 import de.muenchen.oss.wahllokalsystem.wls.common.security.domain.BezirkUndWahlID;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -50,7 +51,7 @@ public class Wahlvorschlaege {
     @ToString.Include
     private String stimmzettelgebietID;
 
-    @OneToMany(mappedBy = "wahlvorschlaeage", orphanRemoval = true)
+    @OneToMany(mappedBy = "wahlvorschlaeage", orphanRemoval = true, cascade = CascadeType.PERSIST)
     @NotNull
     @Size(min = 1)
     private Set<Wahlvorschlag> wahlvorschlaege = new LinkedHashSet<>();

--- a/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/domain/wahlvorschlag/Wahlvorschlag.java
+++ b/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/domain/wahlvorschlag/Wahlvorschlag.java
@@ -2,6 +2,7 @@ package de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.wahlvorschlag;
 
 import static java.sql.Types.VARCHAR;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -60,7 +61,7 @@ public class Wahlvorschlag {
     @ToString.Include
     private boolean erhaeltStimmen;
 
-    @OneToMany(mappedBy = "wahlvorschlag", orphanRemoval = true)
+    @OneToMany(mappedBy = "wahlvorschlag", orphanRemoval = true, cascade = CascadeType.PERSIST)
     @NotNull
     private Set<Kandidat> kandidaten = new LinkedHashSet<>();
 

--- a/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/services/referendumvorlagen/ReferendumvorlagenService.java
+++ b/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/services/referendumvorlagen/ReferendumvorlagenService.java
@@ -1,7 +1,5 @@
 package de.muenchen.oss.wahllokalsystem.basisdatenservice.services.referendumvorlagen;
 
-import de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.referendumvorlagen.ReferendumvorlageRepository;
-import de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.referendumvorlagen.Referendumvorlagen;
 import de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.referendumvorlagen.ReferendumvorlagenRepository;
 import de.muenchen.oss.wahllokalsystem.wls.common.security.domain.BezirkUndWahlID;
 import lombok.RequiredArgsConstructor;
@@ -9,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @RequiredArgsConstructor
@@ -22,10 +19,7 @@ public class ReferendumvorlagenService {
 
     private final ReferendumvorlagenClient referendumvorlagenClient;
 
-    private final ReferendumvorlageRepository referendumvorlageRepository;
     private final ReferendumvorlagenRepository referendumvorlagenRepository;
-
-    private final TransactionTemplate transactionTemplate;
 
     @PreAuthorize("hasAuthority('Basisdaten_BUSINESSACTION_GetReferendumvorlagen')")
     public ReferendumvorlagenModel getReferendumvorlagen(final ReferendumvorlagenReferenceModel referendumvorlagenReferenceModel) {
@@ -48,19 +42,12 @@ public class ReferendumvorlagenService {
         val importedReferendumvorlagen = referendumvorlagenClient.getReferendumvorlagen(referendumvorlagenReferenceModel);
 
         val entitiesToSave = referendumvorlagenModelMapper.toEntity(importedReferendumvorlagen, referendumBezirkUndWahlID);
-        saveReferendumvorlagen(entitiesToSave);
-
-        return importedReferendumvorlagen;
-    }
-
-    private void saveReferendumvorlagen(final Referendumvorlagen referendumvorlagenToSave) {
         try {
-            transactionTemplate.executeWithoutResult(transactionStatus -> {
-                referendumvorlagenRepository.save(referendumvorlagenToSave);
-                referendumvorlageRepository.saveAll(referendumvorlagenToSave.getReferendumvorlagen());
-            });
+            referendumvorlagenRepository.save(entitiesToSave);
         } catch (final Exception e) {
             log.error("#getReferendumvorlagen: Fehler beim Cachen", e);
         }
+
+        return importedReferendumvorlagen;
     }
 }

--- a/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/services/wahlvorschlag/WahlvorschlaegeService.java
+++ b/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/services/wahlvorschlag/WahlvorschlaegeService.java
@@ -1,7 +1,6 @@
 package de.muenchen.oss.wahllokalsystem.basisdatenservice.services.wahlvorschlag;
 
 import de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.wahlvorschlag.KandidatRepository;
-import de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.wahlvorschlag.Wahlvorschlaege;
 import de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.wahlvorschlag.WahlvorschlaegeRepository;
 import de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.wahlvorschlag.WahlvorschlagRepository;
 import de.muenchen.oss.wahllokalsystem.wls.common.security.domain.BezirkUndWahlID;
@@ -37,7 +36,7 @@ public class WahlvorschlaegeService {
             log.debug("#getWahlvorschlaege: Für BezirkUndWahlID {} waren keine Wahlvorschlaege in der Datenbank", bezirkUndWahlID);
             val importedWahlvorschlaegeModel = wahlvorschlaegeClient.getWahlvorschlaege(bezirkUndWahlID);
             try {
-                val savedWahlvorschlaege = persistWahlvorschlagModel(importedWahlvorschlaegeModel);
+                val savedWahlvorschlaege = wahlvorschlaegeRepository.save(wahlvorschlaegeModelMapper.toEntity(importedWahlvorschlaegeModel));
                 return wahlvorschlaegeModelMapper.toModel(savedWahlvorschlaege);
             } catch (final Exception exception) {
                 log.error("#getWahlvorschlaege: Fehler beim Cachen", exception);
@@ -46,17 +45,6 @@ public class WahlvorschlaegeService {
         } else {
             return wahlvorschlaegeModelMapper.toModel(wahlvorschlaegeFromRepo.get());
         }
-    }
-
-    protected Wahlvorschlaege persistWahlvorschlagModel(final WahlvorschlaegeModel wahlvorschlaegeModel) {
-        val entityToCreate = wahlvorschlaegeModelMapper.toEntity(wahlvorschlaegeModel);
-        val createdEntity = wahlvorschlaegeRepository.save(entityToCreate);
-        entityToCreate.getWahlvorschlaege().forEach(wahlvorschlag -> {
-            wahlvorschlagRepository.save(wahlvorschlag);
-            kandidatRepository.saveAll(wahlvorschlag.getKandidaten());
-        });
-
-        return createdEntity;
     }
 
 }

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/rest/referendumvorlagen/ReferendumvorlagenControllerIntegrationTest.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/rest/referendumvorlagen/ReferendumvorlagenControllerIntegrationTest.java
@@ -2,7 +2,6 @@ package de.muenchen.oss.wahllokalsystem.basisdatenservice.rest.referendumvorlage
 
 import static de.muenchen.oss.wahllokalsystem.basisdatenservice.TestConstants.SPRING_NO_SECURITY_PROFILE;
 import static de.muenchen.oss.wahllokalsystem.basisdatenservice.TestConstants.SPRING_TEST_PROFILE;
-import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -179,29 +178,6 @@ public class ReferendumvorlagenControllerIntegrationTest {
 
             val expectedBodyDTO = new WlsExceptionDTO(WlsExceptionCategory.F, mockedWlsExceptionCode, mockedWlsExceptionService, mockedWlsExceptionMessage);
             Assertions.assertThat(responseBodyAsDTO).isEqualTo(expectedBodyDTO);
-        }
-
-        @Test
-        void alleReferendumdataIsStoredTransactional() throws Exception {
-            val wahlID = "wahlID";
-            val wahlbezirkID = "wahlbezirkID";
-
-            val eaiReferendumvorschlage = createClientReferendumvorlagenDTO();
-            defineStubForGetReferendumvorlage(eaiReferendumvorschlage, wahlID, wahlbezirkID, HttpStatus.OK);
-
-            val mockedSaveAllException = new RuntimeException("save all failed");
-            Mockito.doThrow(mockedSaveAllException).when(referendumvorlageRepository).saveAll(any());
-
-            val request = MockMvcRequestBuilders.get(BUSINESS_ACTIONS_REFERENDUMVORLAGEN + wahlID + "/" + wahlbezirkID);
-
-            val response = mockMvc.perform(request).andExpect(status().isOk()).andReturn();
-            val responseBodyAsDTO = objectMapper.readValue(response.getResponse().getContentAsByteArray(), ReferendumvorlagenDTO.class);
-
-            val expectedBodyDTO = referendumvorlagenDTOMapper.toDTO(referendumvorlagenClientMapper.toModel(eaiReferendumvorschlage));
-            Assertions.assertThat(responseBodyAsDTO).isEqualTo(expectedBodyDTO);
-
-            Assertions.assertThat(referendumvorlagenRepository.count()).isEqualTo(0);
-            Assertions.assertThat(referendumvorlageRepository.count()).isEqualTo(0);
         }
 
         private de.muenchen.oss.wahllokalsystem.basisdatenservice.eai.aou.model.ReferendumvorlagenDTO createClientReferendumvorlagenDTO() {

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/rest/referendumvorlagen/ReferendumvorlagenControllerIntegrationTest.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/rest/referendumvorlagen/ReferendumvorlagenControllerIntegrationTest.java
@@ -105,7 +105,7 @@ public class ReferendumvorlagenControllerIntegrationTest {
 
         @Test
         @Transactional
-        void returnExistingDataWithoutImport() throws Exception {
+        void should_persistData_when_importedViaClient() throws Exception {
             val wahlID = "wahlID";
             val wahlbezirkID = "wahlbezirkID";
 

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/services/referendumvorlagen/ReferendumvorlagenServiceTest.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/services/referendumvorlagen/ReferendumvorlagenServiceTest.java
@@ -3,7 +3,6 @@ package de.muenchen.oss.wahllokalsystem.basisdatenservice.services.referendumvor
 import static org.mockito.ArgumentMatchers.eq;
 
 import ch.qos.logback.classic.Level;
-import de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.referendumvorlagen.ReferendumvorlageRepository;
 import de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.referendumvorlagen.Referendumvorlagen;
 import de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.referendumvorlagen.ReferendumvorlagenRepository;
 import de.muenchen.oss.wahllokalsystem.basisdatenservice.utils.LoggerExtension;
@@ -11,7 +10,6 @@ import de.muenchen.oss.wahllokalsystem.wls.common.security.domain.BezirkUndWahlI
 import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Consumer;
 import lombok.val;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
@@ -21,11 +19,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.transaction.TransactionException;
-import org.springframework.transaction.TransactionStatus;
-import org.springframework.transaction.support.TransactionTemplate;
 
 @ExtendWith(MockitoExtension.class)
 class ReferendumvorlagenServiceTest {
@@ -40,18 +34,7 @@ class ReferendumvorlagenServiceTest {
     ReferendumvorlagenClient referendumvorlagenClient;
 
     @Mock
-    ReferendumvorlageRepository referendumvorlageRepository;
-
-    @Mock
     ReferendumvorlagenRepository referendumvorlagenRepository;
-
-    @Spy
-    TransactionTemplate transactionTemplate = new TransactionTemplate() {
-        @Override
-        public void executeWithoutResult(Consumer<TransactionStatus> action) throws TransactionException {
-            action.accept(Mockito.mock(TransactionStatus.class));
-        }
-    };
 
     @InjectMocks
     ReferendumvorlagenService unitUnderTest;
@@ -83,7 +66,6 @@ class ReferendumvorlagenServiceTest {
             Assertions.assertThat(result).isEqualTo(mockedClientRerefendumvorlagenModel);
 
             Mockito.verify(referendumvorlagenRepository).save(mockedMappendModelAsEntity);
-            Mockito.verify(referendumvorlageRepository).saveAll(Collections.emptySet());
         }
 
         @Test
@@ -103,7 +85,7 @@ class ReferendumvorlagenServiceTest {
             val result = unitUnderTest.getReferendumvorlagen(referendumvorlagenReference);
 
             Assertions.assertThat(result).isEqualTo(mockedRepoEntityAsModel);
-            Mockito.verifyNoMoreInteractions(referendumvorlageRepository, referendumvorlagenRepository, referendumvorlagenClient);
+            Mockito.verifyNoMoreInteractions(referendumvorlagenRepository, referendumvorlagenClient);
             Assertions.assertThat(loggerExtension.getLoggedEventsStream().filter(event -> event.getLevel() == Level.ERROR).count()).isEqualTo(0);
         }
 
@@ -129,7 +111,7 @@ class ReferendumvorlagenServiceTest {
 
             Assertions.assertThat(result).isEqualTo(mockedClientRerefendumvorlagenModel);
 
-            Mockito.verifyNoMoreInteractions(referendumvorlageRepository, referendumvorlagenRepository);
+            Mockito.verifyNoMoreInteractions(referendumvorlagenRepository);
             Assertions.assertThat(loggerExtension.getLoggedEventsStream().filter(event -> event.getLevel() == Level.ERROR).count()).isEqualTo(1);
         }
     }

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/services/wahlvorschlag/WahlvorschlaegeServiceTest.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/services/wahlvorschlag/WahlvorschlaegeServiceTest.java
@@ -4,11 +4,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 
 import de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.wahlvorschlag.Kandidat;
-import de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.wahlvorschlag.KandidatRepository;
 import de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.wahlvorschlag.Wahlvorschlaege;
 import de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.wahlvorschlag.WahlvorschlaegeRepository;
 import de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.wahlvorschlag.Wahlvorschlag;
-import de.muenchen.oss.wahllokalsystem.basisdatenservice.domain.wahlvorschlag.WahlvorschlagRepository;
 import de.muenchen.oss.wahllokalsystem.wls.common.security.domain.BezirkUndWahlID;
 import java.util.Optional;
 import java.util.Set;
@@ -28,10 +26,6 @@ class WahlvorschlaegeServiceTest {
 
     @Mock
     WahlvorschlaegeRepository wahlvorschlaegeRepository;
-    @Mock
-    WahlvorschlagRepository wahlvorschlagRepository;
-    @Mock
-    KandidatRepository kandidatRepository;
     @Mock
     WahlvorschlaegeModelMapper wahlvorschlaegeModelMapper;
     @Mock
@@ -82,10 +76,6 @@ class WahlvorschlaegeServiceTest {
 
             Assertions.assertThat(result).isSameAs(mockedMappedSavedEntity);
             Mockito.verify(wahlvorschlaegeRepository).save(mockedMappedEntity);
-            Mockito.verify(wahlvorschlagRepository).save(mockedWahlvorschlagEntity1);
-            Mockito.verify(wahlvorschlagRepository).save(mockedWahlvorschlagEntity2);
-            Mockito.verify(kandidatRepository).saveAll(mockedWahlvorschlagEntity1.getKandidaten());
-            Mockito.verify(kandidatRepository).saveAll(mockedWahlvorschlagEntity2.getKandidaten());
         }
 
         @Test


### PR DESCRIPTION
# Beschreibung:

Redesign des Speichervorgangs. Anstelle die Abhängigkeiten selber zu speichern wurde der `CascadeType.PERSIST` verwendet.

Es wurden nur die entsprechenden Codestellen angepasst und ein Test in diesem Context umbenannt dessen Beschreibung nicht ausreichend war.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [X] Doku aktualisiert - nichts zu tun
- [x] Swagger-API vollständig - keine Änderungen an der API
- [x] Unit-Tests gepflegt
- [x] Integrationstests gepflegt
- [X] Beispiel-Requests gepflegt - kein Update notwendig

# Referenzen[^1]:

Verwandt mit Issue:
- #418
- #458

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
