### PR TITLE
Fix für unsubstituted-variable Fehler in Http-Requests

### DIFF
--- a/wls-basisdaten-service/src/test/resources/http-client.env.json
+++ b/wls-basisdaten-service/src/test/resources/http-client.env.json
@@ -1,5 +1,7 @@
 {
   "nonDocker": {
+    "token_type": "",
+    "auth_token": "",
     "WLS_BASISDATEN_SERVICE_URL": "http://localhost:39151",
     "SSO_URL": "http://kubernetes.docker.internal:8100"
   }

--- a/wls-briefwahl-service/src/test/resources/http_requests/http-client.env.json
+++ b/wls-briefwahl-service/src/test/resources/http_requests/http-client.env.json
@@ -1,9 +1,13 @@
 {
   "docker": {
+    "token_type": "",
+    "auth_token": "",
     "WLS_BRIEFWAHL_SERVICE_URL": "http://localhost:8202",
     "SSO_URL": "http://kubernetes.docker.internal:8100"
   },
   "nonDocker": {
+    "token_type": "",
+    "auth_token": "",
     "WLS_BRIEFWAHL_SERVICE_URL": "http://localhost:39147",
     "SSO_URL": "http://kubernetes.docker.internal:8100"
   }

--- a/wls-broadcast-service/src/test/resources/http_requests/http-client.env.json
+++ b/wls-broadcast-service/src/test/resources/http_requests/http-client.env.json
@@ -1,9 +1,13 @@
 {
   "docker": {
+    "token_type": "",
+    "auth_token": "",
     "WLS_BROADCAST_SERVICE_URL": "http://localhost:8200",
     "SSO_URL": "http://kubernetes.docker.internal:8100"
   },
   "nonDocker": {
+    "token_type": "",
+    "auth_token": "",
     "WLS_BROADCAST_SERVICE_URL": "http://localhost:39146",
     "SSO_URL": "http://kubernetes.docker.internal:8100"
   }

--- a/wls-eai-service/src/test/resources/httpRequests/http-client.env.json
+++ b/wls-eai-service/src/test/resources/httpRequests/http-client.env.json
@@ -1,9 +1,13 @@
 {
   "docker": {
+    "token_type": "",
+    "auth_token": "",
     "WLS_EAI_SERVICE_URL": "http://localhost:8300",
     "SSO_URL": "http://kubernetes.docker.internal:8100"
   },
   "nonDocker": {
+    "token_type": "",
+    "auth_token": "",
     "WLS_EAI_SERVICE_URL": "http://localhost:39149",
     "SSO_URL": "http://kubernetes.docker.internal:8100"
   }

--- a/wls-infomanagement-service/src/test/resources/http.request/http-client.env.json
+++ b/wls-infomanagement-service/src/test/resources/http.request/http-client.env.json
@@ -1,9 +1,13 @@
 {
   "docker": {
+    "token_type": "",
+    "auth_token": "",
     "WLS_INFOMANAGEMENT_SERVICE_URL": "http://localhost:8201",
     "SSO_URL": "http://kubernetes.docker.internal:8100"
   },
   "nonDocker": {
+    "token_type": "",
+    "auth_token": "",
     "WLS_INFOMANAGEMENT_SERVICE_URL": "http://localhost:39148",
     "SSO_URL": "http://localhost:8100"
   }

--- a/wls-vorfaelleundvorkommnisse-service/src/test/resources/http-client.env.json
+++ b/wls-vorfaelleundvorkommnisse-service/src/test/resources/http-client.env.json
@@ -1,9 +1,13 @@
 {
   "docker": {
+    "token_type": "",
+    "auth_token": "",
     "WLS_VORFAELLEUNDVORKOMMNISSE_SERVICE_URL": "http://localhost:8204",
     "SSO_URL": "http://kubernetes.docker.internal:8100"
   },
   "nonDocker": {
+    "token_type": "",
+    "auth_token": "",
     "WLS_VORFAELLEUNDVORKOMMNISSE_SERVICE_URL": "http://localhost:39156",
     "SSO_URL": "http://kubernetes.docker.internal:8100"
   }

--- a/wls-wahlvorbereitung-service/src/test/resources/http_requests/http-client.env.json
+++ b/wls-wahlvorbereitung-service/src/test/resources/http_requests/http-client.env.json
@@ -1,9 +1,13 @@
 {
   "docker": {
+    "token_type": "",
+    "auth_token": "",
     "WLS_WAHLVORBEREITUNG_SERVICE_URL": "http://localhost:8203",
     "SSO_URL": "http://kubernetes.docker.internal:8100"
   },
   "nonDocker": {
+    "token_type": "",
+    "auth_token": "",
     "WLS_WAHLVORBEREITUNG_SERVICE_URL": "http://localhost:39150",
     "SSO_URL": "http://localhost:8100"
   }


### PR DESCRIPTION
# Beschreibung:

Lösung des Problems dass die Variablen `token_type` und `auth_token` nicht gesetzt sind wenn man gegen einen Service geht der im `no-security` Profil läuft.

Die Hauptursache war dass man zuvor sich keinen Token von Keycloak hat ausstellen lassen. Um nicht immer gegen den Keycloak gehen zu müssen habe ich einen Leeren Default-Wert für die Variablen gesetzt. Stellt man die Anfrage gegen Keylcoak wird der Wert mit den Daten der Antwort überschrieben.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

- [X] Testing: Je Service habe ich eine Anfrage gestellt mit dem Fix, Der Service lief in no-security. Abschließend habe ich mir für nur einen Service einen Token ausstellen lassen und geprüft dass dieser Teil der Anfrage ist.

# Referenzen[^1]:

Verwandt mit Issue #

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
