### PR TITLE
174 bereitstellung datenstrukturen

### DIFF
--- a/docs/src/features/auth-service/index.md
+++ b/docs/src/features/auth-service/index.md
@@ -5,3 +5,53 @@ Zuständig für die Authentifizierung und Verwaltung der Rechte der User des Sys
 ## Abhängigkeiten
 
 Der Service hat keine Abhängigkeiten zu anderen Services.
+
+## Datenmodell
+
+```mermaid
+
+erDiagram
+    User 1--0+ Authority : hat
+    Authority 1--0+ Permission : hat
+    User 1--|o LoginAttempt : unternahm
+    
+    User {
+        String username
+        boolean userEnabled
+        boolean accountNonLocked
+        String wahltagID
+        LocalDate wahltag
+        String wahlbezirkID
+        String wahlbezirkNummer
+        Wahlbezirksart wahlbezirksArt
+        String pin
+        String wbid_wahlnummer
+    }
+    
+    Authority {
+        String authority
+    }
+    
+    Permission {
+        String permission
+    }
+    
+    LoginAttempt {
+        int attempts
+        LocalDateTime lastModified
+    }
+```
+
+> [!IMPORTANT]
+> Der Benutzername liegt in der Datenbank nur verschlüsselt vor.
+
+
+## Konfigrationsparameter
+
+Alle Konfigurationsparameter beginnen mit dem Prefix `serviceauth`
+
+| Name | Beschreibung                                                                           | Default |
+| ---- |----------------------------------------------------------------------------------------| ------- |
+| crypto.encryptionPrefix | String vor dem verschlüssten Wert. Auf diese Weise sind verschlüsselte Werte erkennbar | ENCRYPTED: |
+| crypto.key | Schlüssel zum ver- und entschlüsseln                                                   | |
+| maxLoginAttempts | Maximale Anzahl an Fehlersuchen bis der Account gesperrt wird.                         | 5 |

--- a/wls-auth-service/pom.xml
+++ b/wls-auth-service/pom.xml
@@ -36,6 +36,7 @@
         <!-- Version muss mit der in den spring-boot-dependencies bereitgestellten Lombok-Version übereinstimmen -->
         <org.projectlombok.lombok.version>1.18.30</org.projectlombok.lombok.version>
         <org.projectlombok.mapstructbinding.version>0.2.0</org.projectlombok.mapstructbinding.version>
+        <org.mapstruct.version>1.6.2</org.mapstruct.version>
         <org.springdoc.version>2.6.0</org.springdoc.version>
     </properties>
 
@@ -174,6 +175,13 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
+        </dependency>
+
+        <!-- Mapping -->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${org.mapstruct.version}</version>
         </dependency>
 
         <!-- Testing -->
@@ -329,11 +337,24 @@
                             <version>${org.projectlombok.lombok.version}</version>
                         </path>
                         <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${org.mapstruct.version}</version>
+                        </path>
+                        <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok-mapstruct-binding</artifactId>
                             <version>${org.projectlombok.mapstructbinding.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <compilerArg>
+                            -Amapstruct.defaultComponentModel=spring
+                        </compilerArg>
+                        <compilerArg>
+                            -Amapstruct.unmappedTargetPolicy=ERROR
+                        </compilerArg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>

--- a/wls-auth-service/pom.xml
+++ b/wls-auth-service/pom.xml
@@ -166,6 +166,11 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>${org.springdoc.version}</version>
         </dependency>
+        <dependency>
+            <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
+            <artifactId>security</artifactId>
+            <version>1.1.0</version>
+        </dependency>
 
         <!-- Validation -->
         <dependency>

--- a/wls-auth-service/pom.xml
+++ b/wls-auth-service/pom.xml
@@ -319,6 +319,12 @@
                         <goals>
                             <goal>start</goal>
                         </goals>
+                        <configuration>
+                            <environmentVariables>
+                                <SPRING_PROFILES_ACTIVE>db-h2</SPRING_PROFILES_ACTIVE>
+                                <SERVICEAUTH.CRYPTO.KEY>secret</SERVICEAUTH.CRYPTO.KEY>
+                            </environmentVariables>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>post-integration-test</id>

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/MicroServiceApplication.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/MicroServiceApplication.java
@@ -18,7 +18,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @ComponentScan(
         basePackages = {
                 "org.springframework.data.jpa.convert.threeten",
-                "de.muenchen.oss.wahllokalsystem.authservice"
+                "de.muenchen.oss.wahllokalsystem.authservice",
+                "de.muenchen.oss.wahllokalsystem.wls.common.exception"
         }
 )
 @EntityScan(

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/EncryptionConfiguration.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/EncryptionConfiguration.java
@@ -1,0 +1,20 @@
+package de.muenchen.oss.wahllokalsystem.authservice.configuration;
+
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.util.ServiceIDFormatter;
+import de.muenchen.oss.wahllokalsystem.wls.common.security.EncryptionBuilder;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.NoSuchPaddingException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EncryptionConfiguration {
+
+    @Bean
+    public EncryptionBuilder encryptionBuilder(@Value("{serviceauth.crypto.key}") final String cryptoKey, final ServiceIDFormatter serviceIDFormatter)
+            throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException {
+        return new EncryptionBuilder(cryptoKey.getBytes(), serviceIDFormatter);
+    }
+}

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Authority.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Authority.java
@@ -9,11 +9,13 @@ import jakarta.persistence.ManyToMany;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Entity
 @Data
+@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(onlyExplicitlyIncluded = true)

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Authority.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Authority.java
@@ -6,7 +6,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
-import jakarta.persistence.Table;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -14,7 +13,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Entity
-@Table(name = "SECAUTHORITIES")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Authority.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Authority.java
@@ -1,0 +1,40 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package de.muenchen.oss.wahllokalsystem.authservice.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Table(name = "SECAUTHORITIES")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString(onlyExplicitlyIncluded = true)
+public class Authority extends BaseEntity {
+
+    @ToString.Exclude
+    private String authority;
+
+    @ManyToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH }, fetch = FetchType.EAGER)
+    @JoinTable(
+            name = "secauthorities_secpermissions", joinColumns = @JoinColumn(name = "authority_oid"), inverseJoinColumns = @JoinColumn(name = "permission_oid")
+    )
+    private Set<Permission> permissions;
+
+    @ManyToMany(mappedBy = "authorities", cascade = CascadeType.ALL)
+    private Set<User> users;
+}

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Authority.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Authority.java
@@ -12,6 +12,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.NaturalId;
 
 @Entity
 @Data
@@ -22,6 +23,7 @@ import lombok.ToString;
 public class Authority extends BaseEntity {
 
     @ToString.Exclude
+    @NaturalId
     private String authority;
 
     @ManyToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH }, fetch = FetchType.EAGER)

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Authority.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Authority.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package de.muenchen.oss.wahllokalsystem.authservice.domain;
 
 import jakarta.persistence.CascadeType;

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/AuthorityRepository.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/AuthorityRepository.java
@@ -12,7 +12,6 @@ public interface AuthorityRepository extends CrudRepository<Authority, UUID> {
     @Override
     Optional<Authority> findById(UUID oid);
 
-    @SuppressWarnings("unchecked")
     @Override
     Authority save(Authority Authority);
 

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/AuthorityRepository.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/AuthorityRepository.java
@@ -1,10 +1,11 @@
 package de.muenchen.oss.wahllokalsystem.authservice.domain;
 
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.repository.CrudRepository;
 
 public interface AuthorityRepository extends CrudRepository<Authority, UUID> {
 
-    Authority findByAuthority(String authority);
+    Optional<Authority> findByAuthority(String authority);
 
 }

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/AuthorityRepository.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/AuthorityRepository.java
@@ -1,0 +1,33 @@
+package de.muenchen.oss.wahllokalsystem.authservice.domain;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.repository.CrudRepository;
+
+public interface AuthorityRepository extends CrudRepository<Authority, UUID> {
+
+    @Override
+    Iterable<Authority> findAll();
+
+    @Override
+    Optional<Authority> findById(UUID oid);
+
+    @SuppressWarnings("unchecked")
+    @Override
+    Authority save(Authority Authority);
+
+    @Override
+    void deleteById(UUID oid);
+
+    @Override
+    void delete(Authority entity);
+
+    @Override
+    void deleteAll(Iterable<? extends Authority> entities);
+
+    @Override
+    void deleteAll();
+
+    Authority findByAuthority(String authority);
+
+}

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/AuthorityRepository.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/AuthorityRepository.java
@@ -1,31 +1,9 @@
 package de.muenchen.oss.wahllokalsystem.authservice.domain;
 
-import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.repository.CrudRepository;
 
 public interface AuthorityRepository extends CrudRepository<Authority, UUID> {
-
-    @Override
-    Iterable<Authority> findAll();
-
-    @Override
-    Optional<Authority> findById(UUID oid);
-
-    @Override
-    Authority save(Authority Authority);
-
-    @Override
-    void deleteById(UUID oid);
-
-    @Override
-    void delete(Authority entity);
-
-    @Override
-    void deleteAll(Iterable<? extends Authority> entities);
-
-    @Override
-    void deleteAll();
 
     Authority findByAuthority(String authority);
 

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttempt.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttempt.java
@@ -7,11 +7,13 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Entity
 @Data
+@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(onlyExplicitlyIncluded = true)

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttempt.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttempt.java
@@ -10,6 +10,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.NaturalId;
 
 @Entity
 @Data
@@ -19,6 +20,7 @@ import lombok.ToString;
 @ToString(onlyExplicitlyIncluded = true)
 public class LoginAttempt extends BaseEntity {
 
+    @NaturalId
     @NotNull
     @Pattern(regexp = "[a-zA-Z0-9_\\.-]*")
     @Size(min = 1)

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttempt.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttempt.java
@@ -1,0 +1,34 @@
+package de.muenchen.oss.wahllokalsystem.authservice.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Table(name = "LOGIN_ATTEMPTS")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString(onlyExplicitlyIncluded = true)
+public class LoginAttempt extends BaseEntity {
+
+    @NotNull
+    @Pattern(regexp = "[a-zA-Z0-9_\\.-]*")
+    @Size(min = 1)
+    @ToString.Include
+    private String username;
+
+    @NotNull
+    @ToString.Include
+    private int attempts;
+
+    @ToString.Include
+    private LocalDateTime lastModified;
+}

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttempt.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttempt.java
@@ -1,7 +1,6 @@
 package de.muenchen.oss.wahllokalsystem.authservice.domain;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -12,7 +11,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Entity
-@Table(name = "LOGIN_ATTEMPTS")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttemptRepository.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttemptRepository.java
@@ -1,0 +1,33 @@
+package de.muenchen.oss.wahllokalsystem.authservice.domain;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.repository.CrudRepository;
+
+public interface LoginAttemptRepository extends CrudRepository<LoginAttempt, UUID> {
+
+    Optional<LoginAttempt> findFirstByUsername(String username);
+
+    @Override
+    Iterable<LoginAttempt> findAll();
+
+    @Override
+    Optional<LoginAttempt> findById(UUID oid);
+
+    @SuppressWarnings("unchecked")
+    @Override
+    LoginAttempt save(LoginAttempt loginAttempts);
+
+    @Override
+    void deleteById(UUID oid);
+
+    @Override
+    void delete(LoginAttempt entity);
+
+    @Override
+    void deleteAll(Iterable<? extends LoginAttempt> entities);
+
+    @Override
+    void deleteAll();
+
+}

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttemptRepository.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttemptRepository.java
@@ -8,26 +8,4 @@ public interface LoginAttemptRepository extends CrudRepository<LoginAttempt, UUI
 
     Optional<LoginAttempt> findFirstByUsername(String username);
 
-    @Override
-    Iterable<LoginAttempt> findAll();
-
-    @Override
-    Optional<LoginAttempt> findById(UUID oid);
-
-    @SuppressWarnings("unchecked")
-    @Override
-    LoginAttempt save(LoginAttempt loginAttempts);
-
-    @Override
-    void deleteById(UUID oid);
-
-    @Override
-    void delete(LoginAttempt entity);
-
-    @Override
-    void deleteAll(Iterable<? extends LoginAttempt> entities);
-
-    @Override
-    void deleteAll();
-
 }

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttemptRepository.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttemptRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface LoginAttemptRepository extends CrudRepository<LoginAttempt, UUID> {
 
-    Optional<LoginAttempt> findFirstByUsername(String username);
+    Optional<LoginAttempt> findByUsername(String username);
 
 }

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Permission.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Permission.java
@@ -3,11 +3,13 @@ package de.muenchen.oss.wahllokalsystem.authservice.domain;
 import jakarta.persistence.Entity;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Entity
 @Data
+@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(onlyExplicitlyIncluded = true)

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Permission.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Permission.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package de.muenchen.oss.wahllokalsystem.authservice.domain;
 
 import jakarta.persistence.Entity;

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Permission.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Permission.java
@@ -1,14 +1,12 @@
 package de.muenchen.oss.wahllokalsystem.authservice.domain;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Entity
-@Table(name = "SECPERMISSIONS")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Permission.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Permission.java
@@ -1,0 +1,26 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package de.muenchen.oss.wahllokalsystem.authservice.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Table(name = "SECPERMISSIONS")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString(onlyExplicitlyIncluded = true)
+public class Permission extends BaseEntity {
+
+    @ToString.Include
+    private String permission;
+
+}

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/PermissionRepository.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/PermissionRepository.java
@@ -6,27 +6,5 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface PermissionRepository extends CrudRepository<Permission, UUID> {
 
-    @Override
-    Iterable<Permission> findAll();
-
-    @Override
-    Optional<Permission> findById(UUID oid);
-
-    @SuppressWarnings("unchecked")
-    @Override
-    Permission save(Permission Permission);
-
-    @Override
-    void deleteById(UUID oid);
-
-    @Override
-    void delete(Permission entity);
-
-    @Override
-    void deleteAll(Iterable<? extends Permission> entities);
-
-    @Override
-    void deleteAll();
-
     Optional<Permission> findByPermission(String permission);
 }

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/PermissionRepository.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/PermissionRepository.java
@@ -1,0 +1,32 @@
+package de.muenchen.oss.wahllokalsystem.authservice.domain;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.repository.CrudRepository;
+
+public interface PermissionRepository extends CrudRepository<Permission, UUID> {
+
+    @Override
+    Iterable<Permission> findAll();
+
+    @Override
+    Optional<Permission> findById(UUID oid);
+
+    @SuppressWarnings("unchecked")
+    @Override
+    Permission save(Permission Permission);
+
+    @Override
+    void deleteById(UUID oid);
+
+    @Override
+    void delete(Permission entity);
+
+    @Override
+    void deleteAll(Iterable<? extends Permission> entities);
+
+    @Override
+    void deleteAll();
+
+    Permission findByPermission(String permission);
+}

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/PermissionRepository.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/PermissionRepository.java
@@ -28,5 +28,5 @@ public interface PermissionRepository extends CrudRepository<Permission, UUID> {
     @Override
     void deleteAll();
 
-    Permission findByPermission(String permission);
+    Optional<Permission> findByPermission(String permission);
 }

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/User.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/User.java
@@ -19,6 +19,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.NaturalId;
 
 @Entity
 @Table(name = "Wlsuser") //user as table names is already in use by h2
@@ -29,6 +30,7 @@ import lombok.ToString;
 @ToString(onlyExplicitlyIncluded = true)
 public class User extends BaseEntity {
 
+    @NaturalId
     @NotNull
     @Size(min = 1)
     @ToString.Include

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/User.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/User.java
@@ -1,0 +1,75 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package de.muenchen.oss.wahllokalsystem.authservice.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Table(name = "SECUSERS")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString(onlyExplicitlyIncluded = true)
+public class User extends BaseEntity { //TODO Issue: da der Username nur einmal vorhanden sein darf könnten wir ihn auch zur ID machen
+
+    @NotNull
+    @Size(min = 1)
+    @ToString.Include
+    private String username;
+
+    @ToString.Include
+    private String password;
+
+    @Email
+    @ToString.Include
+    private String email;
+
+    @ToString.Include
+    private boolean userEnabled;
+
+    @ToString.Include
+    private boolean accountNonLocked;
+
+    @ToString.Include
+    private String wahltagID;
+
+    @ToString.Include
+    private LocalDate wahltag;
+
+    @ToString.Include
+    private String wahlbezirkID;
+
+    @ToString.Include
+    private String wahlbezirkNummer;
+
+    @ToString.Include
+    private Wahlbezirksart wahlbezirksArt;
+
+    @ToString.Include
+    private String pin;
+
+    @ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.PERSIST)
+    @JoinTable(name = "secusers_secauthorities", joinColumns = { @JoinColumn(name = "user_oid") }, inverseJoinColumns = { @JoinColumn(name = "authority_oid") })
+    private Set<Authority> authorities;
+
+    @ToString.Include
+    private String wbid_wahlnummer;
+}

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/User.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/User.java
@@ -16,16 +16,18 @@ import java.time.LocalDate;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Entity
 @Table(name = "Wlsuser") //user as table names is already in use by h2
 @Data
+@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(onlyExplicitlyIncluded = true)
-public class User extends BaseEntity { //TODO Issue: da der Username nur einmal vorhanden sein darf könnten wir ihn auch zur ID machen
+public class User extends BaseEntity {
 
     @NotNull
     @Size(min = 1)

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/User.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/User.java
@@ -2,6 +2,8 @@ package de.muenchen.oss.wahllokalsystem.authservice.domain;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
@@ -18,7 +20,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Entity
-@Table(name = "SECUSERS")
+@Table(name = "Wlsuser") //user as table names is already in use by h2
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -56,13 +58,14 @@ public class User extends BaseEntity { //TODO Issue: da der Username nur einmal 
     private String wahlbezirkNummer;
 
     @ToString.Include
+    @Enumerated(EnumType.STRING)
     private Wahlbezirksart wahlbezirksArt;
 
     @ToString.Include
     private String pin;
 
     @ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.PERSIST)
-    @JoinTable(name = "secusers_secauthorities", joinColumns = { @JoinColumn(name = "user_oid") }, inverseJoinColumns = { @JoinColumn(name = "authority_oid") })
+    @JoinTable(name = "Secusers_Secauthorities", joinColumns = { @JoinColumn(name = "user_oid") }, inverseJoinColumns = { @JoinColumn(name = "authority_oid") })
     private Set<Authority> authorities;
 
     @ToString.Include

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/User.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/User.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 import org.hibernate.annotations.NaturalId;
 
 @Entity
-@Table(name = "Wlsuser") //user as table names is already in use by h2
+@Table(name = "Wlsuser") //user as table name is already in use by h2
 @Data
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/User.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/User.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package de.muenchen.oss.wahllokalsystem.authservice.domain;
 
 import jakarta.persistence.CascadeType;

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepository.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepository.java
@@ -3,44 +3,20 @@ package de.muenchen.oss.wahllokalsystem.authservice.domain;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.CrudRepository;
 
-public interface UserRepository extends CrudRepository<User, UUID> {
+public interface UserRepository {
 
-    @Override
-    Collection<User> findAll();
+    Optional<User> findByUsername(final String username);
 
-    @Override
-    Optional<User> findById(UUID oid);
+    Collection<User> findByWahltagID(final String wahltagID);
 
-    @Override
-    User save(User User);
+    Optional<User> findById(final UUID oid);
 
-    @Override
-    void deleteById(UUID oid);
+    boolean exists(final String username);
 
-    @Override
-    void delete(User entity);
+    User save(final User user);
 
-    @Override
-    void deleteAll(Iterable<? extends User> entities);
+    Iterable<User> saveAll(final Iterable<User> users);
 
-    @Override
-    void deleteAll();
-
-    boolean existsByUsername(String username);
-
-    Optional<User> findByUsername(String username);
-
-    Optional<User> findFirstByUsername(String username);
-
-    long countUsersByUsername(String username);
-
-    @Query("select count(u) from User u where u.username = :username and u.accountNonLocked = false")
-    long countUsersLockedByUsername(String username);
-
-    void deleteUsersByWahltagID(String wahltagID);
-
-    Collection<User> findByWahltagID(String wahltagID);
+    void deleteUsersByWahltagID(final String wahltagid);
 }

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepository.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepository.java
@@ -1,0 +1,46 @@
+package de.muenchen.oss.wahllokalsystem.authservice.domain;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+
+public interface UserRepository extends CrudRepository<User, UUID> {
+
+    @Override
+    Collection<User> findAll();
+
+    @Override
+    Optional<User> findById(UUID oid);
+
+    @Override
+    User save(User User);
+
+    @Override
+    void deleteById(UUID oid);
+
+    @Override
+    void delete(User entity);
+
+    @Override
+    void deleteAll(Iterable<? extends User> entities);
+
+    @Override
+    void deleteAll();
+
+    boolean existsByUsername(String username);
+
+    Optional<User> findByUsername(String username);
+
+    Optional<User> findFirstByUsername(String username);
+
+    long countUsersByUsername(String username);
+
+    @Query("select count(u) from User u where u.username = :username and u.accountNonLocked = false")
+    long countUsersLockedByUsername(String username);
+
+    void deleteUsersByWahltagID(String wahltagID);
+
+    Collection<User> findByWahltagID(String wahltagID);
+}

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryCryptoFacade.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryCryptoFacade.java
@@ -1,0 +1,128 @@
+/**
+ *
+ */
+package de.muenchen.oss.wahllokalsystem.authservice.domain;
+
+import de.muenchen.oss.wahllokalsystem.authservice.service.EncryptionService;
+import jakarta.annotation.PostConstruct;
+import jakarta.transaction.Transactional;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class UserRepositoryCryptoFacade {
+
+    private static final int FIVE_MINUTES_IN_MILLIS = 5 * 60 * 1000; //TODO Issue: um dies Konfigurierbar zu machen
+
+    private final EncryptionService encryptionService;
+    private final UserRepository userRepository;
+
+    @PostConstruct
+    @Transactional
+    public void onInit() {
+        log.debug("POST-CONSTRUCT: Encrypting any unencrypted existing user names...");
+        encryptUsernames();
+        log.debug("POST-CONSTRUCT: Done encrypting any unencrypted existing user names.");
+    }
+
+    @Scheduled(fixedRate = FIVE_MINUTES_IN_MILLIS)
+    public void onSchedule() {
+        log.info("SCHEDULED: Encrypting any newly added unencrypted user names...");
+        encryptUsernames();
+        log.info("SCHEDULED: Done encrypting any newly added unencrypted user names.");
+    }
+
+    public Optional<User> findFirstByUsername(final String username) {
+        String encryptedUsername = encryptionService.encrypt(username);
+        val findFirstByUsername = userRepository.findFirstByUsername(encryptedUsername);
+        return findFirstByUsername.map(this::decrypt);
+    }
+
+    public Collection<User> findByWahltagID(final String wahltagID) {
+        Collection<User> findBy = userRepository.findByWahltagID(wahltagID);
+        return decrypt(findBy);
+    }
+
+    public Optional<User> findById(final UUID oid) {
+        val findOne = userRepository.findById(oid);
+        return findOne.map(this::decrypt);
+    }
+
+    public Iterable<User> saveAll(final Iterable<User> users) {
+        users.forEach(this::encrypt);
+
+        val savedUsers = userRepository.saveAll(users);
+
+        savedUsers.forEach(this::decrypt);
+        return savedUsers;
+    }
+
+    public User save(final User user) {
+        val encryptedUser = encrypt(user);
+        val saveUser = userRepository.save(encryptedUser);
+        return decrypt(saveUser);
+    }
+
+    public Optional<User> findByUsername(final String username) {
+        String encrypted = encryptionService.encrypt(username);
+        return userRepository.findByUsername(encrypted).map(this::decrypt);
+    }
+
+    public long countUsersByUsername(final String username) {
+        String encryptedUsername = encryptionService.encrypt(username);
+        return userRepository.countUsersByUsername(encryptedUsername);
+    }
+
+    public long countUsersLockedByUsername(final String username) {
+        val encrypted = encryptionService.encrypt(username);
+        return userRepository.countUsersLockedByUsername(encrypted);
+    }
+
+    public void deleteUsersByWahltagID(final String wahltagid) {
+        userRepository.deleteUsersByWahltagID(wahltagid);
+    }
+
+    private void encryptUsernames() {
+        val newEncryptedUsers = userRepository.findAll().stream()
+                .filter(user -> !encryptionService.isEncrypted(user.getUsername()))
+                .peek(this::encrypt)
+                .toList();
+
+        if (!newEncryptedUsers.isEmpty()) {
+            userRepository.saveAll(newEncryptedUsers);
+        }
+    }
+
+    private User encrypt(User user) {
+        if (user == null) return null;
+
+        val userNameToEncrypt = user.getUsername();
+        val encryptedUsername = encryptionService.encrypt(userNameToEncrypt);
+        user.setUsername(encryptedUsername);
+        log.debug("encrypting: <{}> --> <{}>", userNameToEncrypt, encryptedUsername);
+
+        return user;
+    }
+
+    private User decrypt(User user) {
+        val username = user.getUsername();
+        log.debug("decrypting user <{}>...", username);
+        if (username != null) {
+            encryptionService.decrypt(username);
+        }
+        return user;
+    }
+
+    private List<User> decrypt(final Collection<User> users) {
+        return users.stream().map(this::decrypt).toList();
+    }
+}

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryCryptoFacade.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryCryptoFacade.java
@@ -117,7 +117,7 @@ public class UserRepositoryCryptoFacade {
         val username = user.getUsername();
         log.debug("decrypting user <{}>...", username);
         if (username != null) {
-            encryptionService.decrypt(username);
+            user.setUsername(encryptionService.decrypt(username));
         }
         return user;
     }

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImpl.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImpl.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Component
 @Slf4j
-public class UserRepositoryCryptoFacade implements UserRepository {
+public class UserRepositoryImpl implements UserRepository {
 
     private static final int FIVE_MINUTES_IN_MILLIS = 5 * 60 * 1000; //TODO Issue: um dies Konfigurierbar zu machen
 

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImpl.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImpl.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class UserRepositoryImpl implements UserRepository {
 
-    private static final int FIVE_MINUTES_IN_MILLIS = 5 * 60 * 1000; //TODO Issue: um dies Konfigurierbar zu machen
+    private static final int FIVE_MINUTES_IN_MILLIS = 5 * 60 * 1000;
 
     private final CryptoService cryptoService;
     private final CrudUserRepository userRepository;

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Wahlbezirksart.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Wahlbezirksart.java
@@ -1,0 +1,5 @@
+package de.muenchen.oss.wahllokalsystem.authservice.domain;
+
+public enum Wahlbezirksart {
+    UWB, BWB
+}

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/CryptoService.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/CryptoService.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class EncryptionService {
+public class CryptoService {
 
     private final EncryptionBuilder encryptionBuilder;
 

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/EncryptionService.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/EncryptionService.java
@@ -1,0 +1,37 @@
+package de.muenchen.oss.wahllokalsystem.authservice.service;
+
+import de.muenchen.oss.wahllokalsystem.wls.common.security.EncryptionBuilder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EncryptionService {
+
+    private final EncryptionBuilder encryptionBuilder;
+
+    @Value("${serviceauth.crypto.encryptionPrefix}")
+    private String encryptedPrefix = "";
+
+    public boolean isEncrypted(final String value) {
+        return value.startsWith(encryptedPrefix);
+    }
+
+    public String encrypt(final String value) {
+        return encryptedPrefix + encryptionBuilder.encryptValue(value);
+    }
+
+    public String decrypt(final String value) {
+        if (value.startsWith(encryptedPrefix)) {
+            val encryptedSubstring = value.substring(encryptedPrefix.length());
+            return encryptionBuilder.decryptValue(encryptedSubstring);
+        } else {
+            log.warn("value was already decrypted");
+            return value;
+        }
+    }
+}

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/LoginAttemptModel.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/LoginAttemptModel.java
@@ -1,0 +1,13 @@
+package de.muenchen.oss.wahllokalsystem.authservice.service;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record LoginAttemptModel(
+        @NotNull UUID id,
+        @NotNull String username,
+        int attempts,
+        LocalDateTime lastModified
+) {
+}

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/LoginAttemptModelMapper.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/LoginAttemptModelMapper.java
@@ -1,0 +1,10 @@
+package de.muenchen.oss.wahllokalsystem.authservice.service;
+
+import de.muenchen.oss.wahllokalsystem.authservice.domain.LoginAttempt;
+import org.mapstruct.Mapper;
+
+@Mapper
+public interface LoginAttemptModelMapper {
+
+    LoginAttemptModel toModel(LoginAttempt loginAttempt);
+}

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserService.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserService.java
@@ -79,12 +79,10 @@ public class UserService {
     public Optional<LoginAttemptModel> getUserAttempts(String username) {
         log.debug("getUserAttempts({})", username);
 
-        val user = userRepository.findByUsername(username)
-                .orElseThrow(
-                        () -> {
-                            log.warn("No user found for given username.");
-                            return new IllegalArgumentException("User with username " + username + " not found.");
-                        });
+        if (!userRepository.exists(username)) {
+            log.warn("No user found for given username.");
+            throw new IllegalArgumentException("User with username " + username + " not found.");
+        }
 
         return loginAttemptRepository.findByUsername(username).map(loginAttemptModelMapper::toModel);
     }

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserService.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserService.java
@@ -5,7 +5,9 @@ import de.muenchen.oss.wahllokalsystem.authservice.domain.LoginAttemptRepository
 import de.muenchen.oss.wahllokalsystem.authservice.domain.UserRepository;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,6 +26,8 @@ public class UserService {
     private final LoginAttemptModelMapper loginAttemptModelMapper;
 
     @Value("${serviceauth.maxLoginAttempts}")
+    @Getter
+    @Setter
     private int maxLoginAttempts;
 
     @Transactional

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserService.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserService.java
@@ -1,0 +1,96 @@
+package de.muenchen.oss.wahllokalsystem.authservice.service;
+
+import de.muenchen.oss.wahllokalsystem.authservice.domain.LoginAttempt;
+import de.muenchen.oss.wahllokalsystem.authservice.domain.LoginAttemptRepository;
+import de.muenchen.oss.wahllokalsystem.authservice.domain.UserRepositoryCryptoFacade;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserService {
+
+    private final UserRepositoryCryptoFacade userRepository;
+
+    private final LoginAttemptRepository loginAttemptRepository;
+
+    private final LoginAttemptModelMapper loginAttemptModelMapper;
+
+    @Value("${serviceauth.maxLoginAttempts}")
+    private int maxLoginAttempts;
+
+    @Transactional
+    public void updateFailAttempts(final String username) {
+        log.debug("updateFailAttempts({})", username);
+
+        val user = userRepository.findByUsername(username).orElseThrow(() -> {
+            log.warn("No user found for given username. Skipping updateFailAttempts.");
+            return new IllegalArgumentException("User with username " + username + " not found.");
+        });
+
+        val foundUserLoginAttempt = loginAttemptRepository.findFirstByUsername(username);
+        if (foundUserLoginAttempt.isEmpty()) {
+            val newUserLoginAttempt = new LoginAttempt();
+            newUserLoginAttempt.setUsername(username);
+            newUserLoginAttempt.setAttempts(1);
+            loginAttemptRepository.save(newUserLoginAttempt);
+        } else {
+            val existingLoginAttempt = foundUserLoginAttempt.get();
+            int currentAttempts = existingLoginAttempt.getAttempts();
+            existingLoginAttempt.setAttempts(currentAttempts + 1);
+            existingLoginAttempt.setLastModified(LocalDateTime.now());
+            loginAttemptRepository.save(existingLoginAttempt);
+            // Wenn die Grenze überschritten ist den Benutzer sperren
+            if (existingLoginAttempt.getAttempts() + 1 > maxLoginAttempts) {
+                user.setAccountNonLocked(false);
+                userRepository.save(user);
+            }
+        }
+    }
+
+    @Transactional
+    public void resetFailAttempts(String username) {
+        log.debug("resetFailAttempts({})", username);
+
+        val user = userRepository.findByUsername(username).orElseThrow(() -> {
+            log.warn("No user found for given username.");
+            return new IllegalArgumentException("User with username " + username + " not found.");
+        });
+
+        val foundUserLoginAttempt = loginAttemptRepository.findFirstByUsername(username);
+        if (foundUserLoginAttempt.isPresent()) {
+            log.debug("Execute reset LoginAttempts for user!");
+            user.setAccountNonLocked(true);
+            userRepository.save(user);
+            val loginAttempEntity = foundUserLoginAttempt.get();
+            loginAttempEntity.setAttempts(0);
+            loginAttempEntity.setLastModified(null);
+            loginAttemptRepository.save(loginAttempEntity);
+        }
+    }
+
+    public Optional<LoginAttemptModel> getUserAttempts(String username) {
+        log.debug("getUserAttempts({})", username);
+
+        LoginAttempt attempts = null;
+        val user = userRepository.findByUsername(username)
+                .orElseThrow(
+                        () -> { //TODO Issue - wie wäre es mit EAGER-Loading über einen Request. Dazu muss aber der User mit den Attemps 0..N verbunden werden
+                            log.warn("No user found for given username.");
+                            return new IllegalArgumentException("User with username " + username + " not found.");
+                        });
+
+        return loginAttemptRepository.findFirstByUsername(username).map(loginAttemptModelMapper::toModel);
+    }
+
+    public boolean doesUserExist(final String username) {
+        return userRepository.findByUsername(username).isPresent();
+    }
+}

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserService.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserService.java
@@ -2,7 +2,7 @@ package de.muenchen.oss.wahllokalsystem.authservice.service;
 
 import de.muenchen.oss.wahllokalsystem.authservice.domain.LoginAttempt;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.LoginAttemptRepository;
-import de.muenchen.oss.wahllokalsystem.authservice.domain.UserRepositoryCryptoFacade;
+import de.muenchen.oss.wahllokalsystem.authservice.domain.UserRepository;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class UserService {
 
-    private final UserRepositoryCryptoFacade userRepository;
+    private final UserRepository userRepository;
 
     private final LoginAttemptRepository loginAttemptRepository;
 
@@ -92,5 +92,10 @@ public class UserService {
 
     public boolean doesUserExist(final String username) {
         return userRepository.findByUsername(username).isPresent();
+    }
+
+    public boolean isLocked(final String username) {
+        val user = userRepository.findByUsername(username);
+        return user.filter(value -> !value.isAccountNonLocked()).isPresent();
     }
 }

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserService.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserService.java
@@ -79,7 +79,6 @@ public class UserService {
     public Optional<LoginAttemptModel> getUserAttempts(String username) {
         log.debug("getUserAttempts({})", username);
 
-        LoginAttempt attempts = null;
         val user = userRepository.findByUsername(username)
                 .orElseThrow(
                         () -> {

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserService.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserService.java
@@ -82,7 +82,7 @@ public class UserService {
         LoginAttempt attempts = null;
         val user = userRepository.findByUsername(username)
                 .orElseThrow(
-                        () -> { //TODO Issue - wie wäre es mit EAGER-Loading über einen Request. Dazu muss aber der User mit den Attemps 0..N verbunden werden
+                        () -> {
                             log.warn("No user found for given username.");
                             return new IllegalArgumentException("User with username " + username + " not found.");
                         });

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserService.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserService.java
@@ -35,7 +35,7 @@ public class UserService {
             return new IllegalArgumentException("User with username " + username + " not found.");
         });
 
-        val foundUserLoginAttempt = loginAttemptRepository.findFirstByUsername(username);
+        val foundUserLoginAttempt = loginAttemptRepository.findByUsername(username);
         if (foundUserLoginAttempt.isEmpty()) {
             val newUserLoginAttempt = new LoginAttempt();
             newUserLoginAttempt.setUsername(username);
@@ -64,7 +64,7 @@ public class UserService {
             return new IllegalArgumentException("User with username " + username + " not found.");
         });
 
-        val foundUserLoginAttempt = loginAttemptRepository.findFirstByUsername(username);
+        val foundUserLoginAttempt = loginAttemptRepository.findByUsername(username);
         if (foundUserLoginAttempt.isPresent()) {
             log.debug("Execute reset LoginAttempts for user!");
             user.setAccountNonLocked(true);
@@ -87,7 +87,7 @@ public class UserService {
                             return new IllegalArgumentException("User with username " + username + " not found.");
                         });
 
-        return loginAttemptRepository.findFirstByUsername(username).map(loginAttemptModelMapper::toModel);
+        return loginAttemptRepository.findByUsername(username).map(loginAttemptModelMapper::toModel);
     }
 
     public boolean doesUserExist(final String username) {

--- a/wls-auth-service/src/main/resources/application-local.yml
+++ b/wls-auth-service/src/main/resources/application-local.yml
@@ -1,2 +1,6 @@
 server:
   port: 39152
+
+serviceauth:
+  crypto:
+    key: "please change me"

--- a/wls-auth-service/src/main/resources/application.yml
+++ b/wls-auth-service/src/main/resources/application.yml
@@ -57,6 +57,10 @@ management:
 info.application.name: @project.artifactId@
 info.application.version: @project.version@
 
+service:
+  info:
+    oid: AUTH-SERVICE
+
 serviceauth:
   crypto:
     encryptionPrefix: "ENCRYPTED:"

--- a/wls-auth-service/src/main/resources/application.yml
+++ b/wls-auth-service/src/main/resources/application.yml
@@ -64,3 +64,4 @@ service:
 serviceauth:
   crypto:
     encryptionPrefix: "ENCRYPTED:"
+  maxLoginAttempts: 5

--- a/wls-auth-service/src/main/resources/application.yml
+++ b/wls-auth-service/src/main/resources/application.yml
@@ -56,3 +56,7 @@ management:
       enabled: true
 info.application.name: @project.artifactId@
 info.application.version: @project.version@
+
+serviceauth:
+  crypto:
+    encryptionPrefix: "ENCRYPTED:"

--- a/wls-auth-service/src/main/resources/db/migrations/h2/V1_0__createBaseAuthTables.sql
+++ b/wls-auth-service/src/main/resources/db/migrations/h2/V1_0__createBaseAuthTables.sql
@@ -1,0 +1,66 @@
+CREATE TABLE Wlsuser
+(
+    id               VARCHAR(36),
+    username         VARCHAR(255) NOT NULL UNIQUE,
+    password         VARCHAR(255),
+    email            VARCHAR(255),
+    userEnabled      BOOLEAN,
+    accountNonLocked BOOLEAN,
+    wahltagID        VARCHAR(1000),
+    wahltag          TIMESTAMP,
+    wahlbezirkID     VARCHAR(1000),
+    wahlbezirkNummer VARCHAR(255),
+    wahlbezirksArt   VARCHAR(255),
+    wbid_wahlnummer  VARCHAR(4000),
+    pin              VARCHAR(255),
+
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE LoginAttempt
+(
+    id           VARCHAR(36),
+    username     VARCHAR(255) NOT NULL UNIQUE,
+    attempts     INTEGER,
+    lastModified TIMESTAMP,
+
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE Authority
+(
+    id        VARCHAR(36),
+    authority VARCHAR(255),
+
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE Permission
+(
+    id         VARCHAR(36),
+    permission VARCHAR(255),
+
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE Secusers_Secauthorities
+(
+    user_oid      VARCHAR(36),
+    authority_oid VARCHAR(36),
+
+    FOREIGN KEY (user_oid) REFERENCES Wlsuser (id),
+    FOREIGN KEY (authority_oid) REFERENCES Authority (id),
+
+    PRIMARY KEY (authority_oid, user_oid)
+);
+
+CREATE TABLE Secauthorities_Secpermissions
+(
+    authority_oid  VARCHAR(36),
+    permission_oid VARCHAR(36),
+
+    FOREIGN KEY (authority_oid) REFERENCES Authority (id),
+    FOREIGN KEY (permission_oid) REFERENCES Permission (id),
+
+    PRIMARY KEY (authority_oid, permission_oid)
+);

--- a/wls-auth-service/src/main/resources/db/migrations/h2/V1_0__createBaseAuthTables.sql
+++ b/wls-auth-service/src/main/resources/db/migrations/h2/V1_0__createBaseAuthTables.sql
@@ -30,7 +30,7 @@ CREATE TABLE LoginAttempt
 CREATE TABLE Authority
 (
     id        VARCHAR(36),
-    authority VARCHAR(255),
+    authority VARCHAR(255) UNIQUE,
 
     PRIMARY KEY (id)
 );

--- a/wls-auth-service/src/main/resources/db/migrations/oracle/V1_0__createBaseAuthTables.sql
+++ b/wls-auth-service/src/main/resources/db/migrations/oracle/V1_0__createBaseAuthTables.sql
@@ -1,0 +1,66 @@
+CREATE TABLE Wlsuser
+(
+    id               VARCHAR(36),
+    username         VARCHAR(255) NOT NULL UNIQUE,
+    password         VARCHAR(255),
+    email            VARCHAR(255),
+    userEnabled      NUMBER(1),
+    accountNonLocked NUMBER(1),
+    wahltagID        VARCHAR(1000),
+    wahltag          TIMESTAMP,
+    wahlbezirkID     VARCHAR(1000),
+    wahlbezirkNummer VARCHAR(255),
+    wahlbezirksArt   VARCHAR(255),
+    wbid_wahlnummer  VARCHAR(4000),
+    pin              VARCHAR(255),
+
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE LoginAttempt
+(
+    id           VARCHAR(36),
+    username     VARCHAR(255) NOT NULL UNIQUE,
+    attempts     NUMBER(19, 0),
+    lastModified TIMESTAMP,
+
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE Authority
+(
+    id        VARCHAR(36),
+    authority VARCHAR(255),
+
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE Permission
+(
+    id         VARCHAR(36),
+    permission VARCHAR(255),
+
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE Secusers_Secauthorities
+(
+    user_oid      VARCHAR(36),
+    authority_oid VARCHAR(36),
+
+    FOREIGN KEY (user_oid) REFERENCES Wlsuser (id),
+    FOREIGN KEY (authority_oid) REFERENCES Authority (id),
+
+    PRIMARY KEY (authority_oid, user_oid)
+);
+
+CREATE TABLE Secauthorities_Secpermissions
+(
+    authority_oid  VARCHAR(36),
+    permission_oid VARCHAR(36),
+
+    FOREIGN KEY (authority_oid) REFERENCES Authority (id),
+    FOREIGN KEY (permission_oid) REFERENCES Permission (id),
+
+    PRIMARY KEY (authority_oid, permission_oid)
+);

--- a/wls-auth-service/src/main/resources/db/migrations/oracle/V1_0__createBaseAuthTables.sql
+++ b/wls-auth-service/src/main/resources/db/migrations/oracle/V1_0__createBaseAuthTables.sql
@@ -30,7 +30,7 @@ CREATE TABLE LoginAttempt
 CREATE TABLE Authority
 (
     id        VARCHAR(36),
-    authority VARCHAR(255),
+    authority VARCHAR(255) UNIQUE,
 
     PRIMARY KEY (id)
 );

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/AuthorityRepositoryTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/AuthorityRepositoryTest.java
@@ -48,7 +48,6 @@ class AuthorityRepositoryTest {
 
             Assertions.assertThat(findByResult).isEmpty();
         }
-
     }
 
     private Authority createAuthorityWithAuthorityName(final String authorityName) {

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/AuthorityRepositoryTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/AuthorityRepositoryTest.java
@@ -31,22 +31,22 @@ class AuthorityRepositoryTest {
 
         @Test
         @Transactional
-        void should_returnAuthority_when_foundByAuthority() {
+        void should_returnOptionalWithAuthority_when_foundByAuthority() {
             val authorityString = "authorityToFind";
             val authorityToGet = authorityRepository.save(createAuthorityWithAuthorityName(authorityString));
 
             val findByResult = authorityRepository.findByAuthority(authorityString);
 
-            Assertions.assertThat(findByResult).isEqualTo(authorityToGet);
+            Assertions.assertThat(findByResult.get()).isEqualTo(authorityToGet);
         }
 
         @Test
-        void should_returnNull_when_notFoundByAuthority() {
+        void should_returnEmptyOptional_when_notFoundByAuthority() {
             authorityRepository.save(createAuthorityWithAuthorityName(UUID.randomUUID().toString()));
 
             val findByResult = authorityRepository.findByAuthority(UUID.randomUUID().toString());
 
-            Assertions.assertThat(findByResult).isNull();
+            Assertions.assertThat(findByResult).isEmpty();
         }
 
     }

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/AuthorityRepositoryTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/AuthorityRepositoryTest.java
@@ -1,0 +1,63 @@
+package de.muenchen.oss.wahllokalsystem.authservice.domain;
+
+import de.muenchen.oss.wahllokalsystem.authservice.MicroServiceApplication;
+import de.muenchen.oss.wahllokalsystem.authservice.TestConstants;
+import java.util.Collections;
+import java.util.UUID;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest(classes = MicroServiceApplication.class)
+@ActiveProfiles(TestConstants.SPRING_TEST_PROFILE)
+class AuthorityRepositoryTest {
+
+    @Autowired
+    AuthorityRepository authorityRepository;
+
+    @AfterEach
+    void tearDown() {
+        authorityRepository.deleteAll();
+    }
+
+    @Nested
+    class FindByAuthority {
+
+        @Test
+        @Transactional
+        void should_returnAuthority_when_foundByAuthority() {
+            val authorityString = "authorityToFind";
+            val authorityToGet = authorityRepository.save(createAuthorityWithAuthorityName(authorityString));
+
+            val findByResult = authorityRepository.findByAuthority(authorityString);
+
+            Assertions.assertThat(findByResult).isEqualTo(authorityToGet);
+        }
+
+        @Test
+        void should_returnNull_when_notFoundByAuthority() {
+            authorityRepository.save(createAuthorityWithAuthorityName(UUID.randomUUID().toString()));
+
+            val findByResult = authorityRepository.findByAuthority(UUID.randomUUID().toString());
+
+            Assertions.assertThat(findByResult).isNull();
+        }
+
+    }
+
+    private Authority createAuthorityWithAuthorityName(final String authorityName) {
+        val authority = new Authority();
+
+        authority.setAuthority(authorityName);
+        authority.setUsers(Collections.emptySet());
+        authority.setPermissions(Collections.emptySet());
+
+        return authority;
+    }
+}

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttemptRepositoryTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttemptRepositoryTest.java
@@ -1,0 +1,54 @@
+package de.muenchen.oss.wahllokalsystem.authservice.domain;
+
+import de.muenchen.oss.wahllokalsystem.authservice.MicroServiceApplication;
+import de.muenchen.oss.wahllokalsystem.authservice.TestConstants;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = MicroServiceApplication.class)
+@ActiveProfiles(TestConstants.SPRING_TEST_PROFILE)
+class LoginAttemptRepositoryTest {
+
+    @Autowired
+    LoginAttemptRepository loginAttemptRepository;
+
+    @AfterEach
+    void tearDown() {
+        loginAttemptRepository.deleteAll();
+    }
+
+    @Nested
+    class FindByUsername {
+
+        @Test
+        void should_returnLoginAttempt_when_attempWithUsernameExists() {
+            val username = "username";
+            val loginAttemptToFind = loginAttemptRepository.save(createLoginAttemptWithUsername(username));
+
+            val findByResult = loginAttemptRepository.findByUsername(username);
+
+            Assertions.assertThat(findByResult.get()).isEqualTo(loginAttemptToFind);
+        }
+
+        @Test
+        void should_returnEmptyOptional_when_noAttempWithUsernameExists() {
+            val findByResult = loginAttemptRepository.findByUsername("username");
+
+            Assertions.assertThat(findByResult).isEmpty();
+        }
+    }
+
+    private LoginAttempt createLoginAttemptWithUsername(final String username) {
+        val loginAttempt = new LoginAttempt();
+
+        loginAttempt.setUsername(username);
+
+        return loginAttempt;
+    }
+}

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/PermissionRepositoryTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/PermissionRepositoryTest.java
@@ -27,20 +27,20 @@ class PermissionRepositoryTest {
     class FindByPermission {
 
         @Test
-        void should_returnPermission_when_found() {
+        void should_returnOptionalWithPermission_when_found() {
             val permissionString = "permission";
             val permissionToFind = permissionRepository.save(createPermissionWithPermission(permissionString));
 
             val findByResult = permissionRepository.findByPermission(permissionString);
 
-            Assertions.assertThat(findByResult).isEqualTo(permissionToFind);
+            Assertions.assertThat(findByResult.get()).isEqualTo(permissionToFind);
         }
 
         @Test
-        void should_returnNull_when_notFound() {
+        void should_returnEmptyOptional_when_notFound() {
             val findByResult = permissionRepository.findByPermission("not-found");
 
-            Assertions.assertThat(findByResult).isNull();
+            Assertions.assertThat(findByResult).isEmpty();
         }
 
     }

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/PermissionRepositoryTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/PermissionRepositoryTest.java
@@ -42,7 +42,6 @@ class PermissionRepositoryTest {
 
             Assertions.assertThat(findByResult).isEmpty();
         }
-
     }
 
     private Permission createPermissionWithPermission(final String permission) {
@@ -52,7 +51,5 @@ class PermissionRepositoryTest {
 
         return permissionObject;
     }
-
-    ;
 
 }

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/PermissionRepositoryTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/PermissionRepositoryTest.java
@@ -1,0 +1,58 @@
+package de.muenchen.oss.wahllokalsystem.authservice.domain;
+
+import de.muenchen.oss.wahllokalsystem.authservice.MicroServiceApplication;
+import de.muenchen.oss.wahllokalsystem.authservice.TestConstants;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = MicroServiceApplication.class)
+@ActiveProfiles(TestConstants.SPRING_TEST_PROFILE)
+class PermissionRepositoryTest {
+
+    @Autowired
+    private PermissionRepository permissionRepository;
+
+    @AfterEach
+    void tearDown() {
+        permissionRepository.deleteAll();
+    }
+
+    @Nested
+    class FindByPermission {
+
+        @Test
+        void should_returnPermission_when_found() {
+            val permissionString = "permission";
+            val permissionToFind = permissionRepository.save(createPermissionWithPermission(permissionString));
+
+            val findByResult = permissionRepository.findByPermission(permissionString);
+
+            Assertions.assertThat(findByResult).isEqualTo(permissionToFind);
+        }
+
+        @Test
+        void should_returnNull_when_notFound() {
+            val findByResult = permissionRepository.findByPermission("not-found");
+
+            Assertions.assertThat(findByResult).isNull();
+        }
+
+    }
+
+    private Permission createPermissionWithPermission(final String permission) {
+        val permissionObject = new Permission();
+
+        permissionObject.setPermission(permission);
+
+        return permissionObject;
+    }
+
+    ;
+
+}

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplTest.java
@@ -68,7 +68,6 @@ class UserRepositoryImplTest {
 
             Mockito.verify(userRepository, times(0)).saveAll(any());
         }
-
     }
 
     @Nested
@@ -131,7 +130,6 @@ class UserRepositoryImplTest {
 
             Assertions.assertThat(unitUnderTest.findByWahltagID(wahltagID)).isEmpty();
         }
-
     }
 
     @Nested

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplTest.java
@@ -152,7 +152,6 @@ class UserRepositoryImplTest {
 
         @Test
         void should_returnEmptyOptional_when_foundNoUser() {
-
             val oid = UUID.randomUUID();
 
             Mockito.when(userRepository.findById(oid)).thenReturn(Optional.empty());

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplTest.java
@@ -272,7 +272,6 @@ class UserRepositoryImplTest {
             val encryptedUsername = "encryptedUsername";
 
             Mockito.when(cryptoService.encrypt(username)).thenReturn(encryptedUsername);
-
             Mockito.when(userRepository.findByUsername(encryptedUsername)).thenReturn(Optional.empty());
 
             val result = unitUnderTest.findByUsername(username);

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplTest.java
@@ -90,7 +90,7 @@ class UserRepositoryImplTest {
         }
 
         @Test
-        void should_saveEmptyList_when_usernameIsAlreadyEncrypted() {
+        void should_notSaveEmptyList_when_usernameIsAlreadyEncrypted() {
             val mockedUsersFromRepo = List.of(createUserWithUsername("user1"), createUserWithUsername("user2"));
 
             Mockito.when(userRepository.findAll()).thenReturn(mockedUsersFromRepo);

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplTest.java
@@ -1,0 +1,401 @@
+package de.muenchen.oss.wahllokalsystem.authservice.domain;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+
+import de.muenchen.oss.wahllokalsystem.authservice.service.EncryptionService;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.StreamSupport;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserRepositoryImplTest {
+
+    @Mock
+    EncryptionService encryptionService;
+
+    @Mock
+    CrudUserRepository userRepository;
+
+    @InjectMocks
+    UserRepositoryImpl unitUnderTest;
+
+    @Captor
+    ArgumentCaptor<List<User>> usersCaptor;
+
+    @Nested
+    class OnInit {
+
+        @Test
+        void should_updateWithNewUser_when_gotUsersFromRepository() {
+            val mockedEncryptedUsername = "encryptedUsername";
+            val mockedUsersFromRepo = List.of(createUserWithUsername("user1"), createUserWithUsername("user2"));
+
+            Mockito.when(userRepository.findAll()).thenReturn(mockedUsersFromRepo);
+            Mockito.when(encryptionService.encrypt("user1")).thenReturn(mockedEncryptedUsername);
+            Mockito.when(encryptionService.encrypt("user2")).thenReturn(mockedEncryptedUsername);
+            Mockito.when(encryptionService.isEncrypted(any())).thenReturn(false);
+
+            unitUnderTest.onInit();
+
+            Mockito.verify(userRepository).saveAll(usersCaptor.capture());
+            Assertions.assertThat(usersCaptor.getAllValues()).hasSize(1);
+            Assertions.assertThat(usersCaptor.getValue()).allSatisfy(user -> Assertions.assertThat(user.getUsername()).isEqualTo(mockedEncryptedUsername));
+        }
+
+        @Test
+        void should_notSaveEmptyList_when_usernameIsAlreadyEncrypted() {
+            val mockedUsersFromRepo = List.of(createUserWithUsername("user1"), createUserWithUsername("user2"));
+
+            Mockito.when(userRepository.findAll()).thenReturn(mockedUsersFromRepo);
+            Mockito.when(encryptionService.isEncrypted(any())).thenReturn(true);
+
+            unitUnderTest.onInit();
+
+            Mockito.verify(userRepository, times(0)).saveAll(any());
+        }
+
+    }
+
+    @Nested
+    class OnSchedule {
+        @Test
+        void should_updateWithNewUser_when_gotUsersFromRepository() {
+            val mockedEncryptedUsername = "encryptedUsername";
+            val mockedUsersFromRepo = List.of(createUserWithUsername("user1"), createUserWithUsername("user2"));
+
+            Mockito.when(userRepository.findAll()).thenReturn(mockedUsersFromRepo);
+            Mockito.when(encryptionService.encrypt("user1")).thenReturn(mockedEncryptedUsername);
+            Mockito.when(encryptionService.encrypt("user2")).thenReturn(mockedEncryptedUsername);
+            Mockito.when(encryptionService.isEncrypted(any())).thenReturn(false);
+
+            unitUnderTest.onSchedule();
+
+            Mockito.verify(userRepository).saveAll(usersCaptor.capture());
+            Assertions.assertThat(usersCaptor.getAllValues()).hasSize(1);
+            Assertions.assertThat(usersCaptor.getValue()).allSatisfy(user -> Assertions.assertThat(user.getUsername()).isEqualTo(mockedEncryptedUsername));
+        }
+
+        @Test
+        void should_saveEmptyList_when_usernameIsAlreadyEncrypted() {
+            val mockedUsersFromRepo = List.of(createUserWithUsername("user1"), createUserWithUsername("user2"));
+
+            Mockito.when(userRepository.findAll()).thenReturn(mockedUsersFromRepo);
+            Mockito.when(encryptionService.isEncrypted(any())).thenReturn(true);
+
+            unitUnderTest.onSchedule();
+
+            Mockito.verify(userRepository, times(0)).saveAll(any());
+        }
+    }
+
+    @Nested
+    class FindByWahltagID {
+
+        @Test
+        void should_decryptUsernames_when_foundUsers() {
+            val wahltagID = "wahltagID";
+
+            val decryptedUsername = "decryptedUsername";
+            val mockedUsersFromRepo = List.of(createUserWithUsername("user1"), createUserWithUsername("user2"));
+
+            Mockito.when(userRepository.findByWahltagID(wahltagID)).thenReturn(mockedUsersFromRepo);
+            Mockito.when(encryptionService.decrypt("user1")).thenReturn(decryptedUsername);
+            Mockito.when(encryptionService.decrypt("user2")).thenReturn(decryptedUsername);
+
+            val result = unitUnderTest.findByWahltagID(wahltagID);
+
+            Assertions.assertThat(result).hasSize(mockedUsersFromRepo.size());
+            Assertions.assertThat(result).allSatisfy(user -> Assertions.assertThat(user.getUsername()).isEqualTo(decryptedUsername));
+        }
+
+        @Test
+        void should_returnEmptyListwhen_foundNoUsers() {
+            val wahltagID = "wahltagID";
+
+            Mockito.when(userRepository.findByWahltagID(wahltagID)).thenReturn(Collections.emptyList());
+
+            Assertions.assertThat(unitUnderTest.findByWahltagID(wahltagID)).isEmpty();
+        }
+
+    }
+
+    @Nested
+    class FindById {
+
+        @Test
+        void should_decryptUsername_when_foundUserWithID() {
+            val oid = UUID.randomUUID();
+
+            val mockedDecryptedUsername = "decryptedUsername";
+            val mockedFoundUser = createUserWithUsername("user1");
+
+            Mockito.when(userRepository.findById(oid)).thenReturn(Optional.of(mockedFoundUser));
+            Mockito.when(encryptionService.decrypt("user1")).thenReturn(mockedDecryptedUsername);
+
+            val result = unitUnderTest.findById(oid);
+
+            Assertions.assertThat(result.get().getUsername()).isEqualTo(mockedDecryptedUsername);
+        }
+
+        @Test
+        void should_returnEmptyOptional_when_foundNoUser() {
+
+            val oid = UUID.randomUUID();
+
+            Mockito.when(userRepository.findById(oid)).thenReturn(Optional.empty());
+
+            Assertions.assertThat(unitUnderTest.findById(oid)).isEmpty();
+        }
+    }
+
+    @Nested
+    class SaveAll {
+
+        @Test
+        void should_callEncryptOnAllUser_when_savingMultipleUsers() {
+            val username1 = "user1";
+            val username2 = "user2";
+            val usersToSave = List.of(createUserWithUsername(username1), createUserWithUsername(username2));
+
+            val mockedEncryptedUsername1 = "encryptedUsername1";
+            val mockedEncryptedUsername2 = "encryptedUsername2";
+
+            Mockito.when(encryptionService.encrypt(username1)).thenReturn(mockedEncryptedUsername1);
+            Mockito.when(encryptionService.encrypt(username2)).thenReturn(mockedEncryptedUsername2);
+            val savedUsernames = new LinkedList<>();
+            Mockito.doAnswer(invocation -> {
+                val users = (List<User>) invocation.getArgument(0, List.class);
+                users.forEach(user -> savedUsernames.add(user.getUsername()));
+                return users;
+            }).when(userRepository).saveAll(usersToSave);
+
+            unitUnderTest.saveAll(usersToSave);
+
+            Assertions.assertThat(savedUsernames).hasSize(2);
+            Assertions.assertThat(savedUsernames).containsExactlyInAnyOrder(mockedEncryptedUsername1, mockedEncryptedUsername2);
+        }
+
+        @Test
+        void should_returnUnEncryptedUsername_when_gettingUsers() {
+            val username1 = "user1";
+            val username2 = "user2";
+            val usersToSave = List.of(createUserWithUsername(username1), createUserWithUsername(username2));
+
+            val mockedEncryptedUsername1 = "encryptedUsername1";
+            val mockedEncryptedUsername2 = "encryptedUsername2";
+
+            Mockito.when(encryptionService.encrypt(username1)).thenReturn(mockedEncryptedUsername1);
+            Mockito.when(encryptionService.encrypt(username2)).thenReturn(mockedEncryptedUsername2);
+            Mockito.when(encryptionService.decrypt(mockedEncryptedUsername1)).thenReturn(username1);
+            Mockito.when(encryptionService.decrypt(mockedEncryptedUsername2)).thenReturn(username2);
+            Mockito.when(userRepository.saveAll(usersToSave)).then(invocationOnMock -> invocationOnMock.getArgument(0, List.class));
+
+            val result = unitUnderTest.saveAll(usersToSave);
+            val usernames = StreamSupport.stream(result.spliterator(), false).map(User::getUsername).toList();
+
+            Assertions.assertThat(usernames).containsExactlyInAnyOrder(username1, username2);
+        }
+    }
+
+    @Nested
+    class Save {
+
+        @Test
+        void should_encryptUsernamen_when_gettingUser() {
+            val username = "username";
+            val userToSave = createUserWithUsername(username);
+
+            val mockedEncryptedUsername1 = "encryptedUsername1";
+            Mockito.when(encryptionService.encrypt(username)).thenReturn(mockedEncryptedUsername1);
+
+            Mockito.when(userRepository.save(userToSave)).then(invocationOnMock -> {
+                val user = invocationOnMock.getArgument(0, User.class);
+                Assertions.assertThat(user.getUsername()).isEqualTo(mockedEncryptedUsername1);
+                return user;
+            });
+
+            unitUnderTest.save(userToSave);
+        }
+
+        @Test
+        void should_returnUncryptedUsername_when_gettingUser() {
+            val username = "username";
+            val userToSave = createUserWithUsername(username);
+
+            val mockedEncryptedUsername1 = "encryptedUsername1";
+            Mockito.when(encryptionService.encrypt(username)).thenReturn(mockedEncryptedUsername1);
+            Mockito.when(encryptionService.decrypt(mockedEncryptedUsername1)).thenReturn(username);
+
+            Mockito.when(userRepository.save(userToSave)).then(invocationOnMock -> invocationOnMock.getArgument(0, User.class));
+
+            val result = unitUnderTest.save(userToSave);
+
+            Assertions.assertThat(result.getUsername()).isEqualTo(username);
+        }
+    }
+
+    @Nested
+    class FindByUsername {
+
+        @Test
+        void should_returnUserWithDecryptedUsername_when_foundUser() {
+            val username = "username";
+
+            val encryptedUsername = "encryptedUsername";
+            val mockedUserFromRepo = createUserWithUsername(encryptedUsername);
+
+            Mockito.when(encryptionService.encrypt(username)).thenReturn(encryptedUsername);
+            Mockito.when(encryptionService.decrypt(encryptedUsername)).thenReturn(username);
+            Mockito.when(userRepository.findByUsername(encryptedUsername)).thenReturn(Optional.of(mockedUserFromRepo));
+
+            val result = unitUnderTest.findByUsername(username);
+
+            Assertions.assertThat(result.get().getUsername()).isEqualTo(username);
+        }
+
+        @Test
+        void should_returnEmptyOptional_when_foundNoUser() {
+            val username = "username";
+
+            val encryptedUsername = "encryptedUsername";
+
+            Mockito.when(encryptionService.encrypt(username)).thenReturn(encryptedUsername);
+
+            Mockito.when(userRepository.findByUsername(encryptedUsername)).thenReturn(Optional.empty());
+
+            val result = unitUnderTest.findByUsername(username);
+
+            Assertions.assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    class Exists {
+
+        @Test
+        void should_searchWithEncryptedUsername_when_searching() {
+            val username = "username";
+
+            val mockedEncryptedUsername = "encryptedUsername";
+            Mockito.when(encryptionService.encrypt(username)).thenReturn(mockedEncryptedUsername);
+
+            unitUnderTest.exists(username);
+
+            Mockito.verify(userRepository).existsByUsername(mockedEncryptedUsername);
+        }
+
+        @Test
+        void should_returnTrue_when_repoExistsReturnTrue() {
+            val username = "username";
+
+            val mockedEncryptedUsername = "encryptedUsername";
+            Mockito.when(encryptionService.encrypt(username)).thenReturn(mockedEncryptedUsername);
+            Mockito.when(userRepository.existsByUsername(mockedEncryptedUsername)).thenReturn(true);
+
+            Assertions.assertThat(unitUnderTest.exists(username)).isTrue();
+        }
+
+        @Test
+        void should_returnFalse_when_repoExistsReturnFalse() {
+            val username = "username";
+
+            val mockedEncryptedUsername = "encryptedUsername";
+            Mockito.when(encryptionService.encrypt(username)).thenReturn(mockedEncryptedUsername);
+            Mockito.when(userRepository.existsByUsername(mockedEncryptedUsername)).thenReturn(false);
+
+            Assertions.assertThat(unitUnderTest.exists(username)).isFalse();
+        }
+    }
+
+    @Nested
+    class IsLocked {
+
+        @Test
+        void should_searchWithEncryptedUsername_when_searching() {
+            val username = "username";
+
+            val mockedEncryptedUsername = "encryptedUsername";
+            Mockito.when(encryptionService.encrypt(username)).thenReturn(mockedEncryptedUsername);
+
+            unitUnderTest.isLocked(username);
+
+            Mockito.verify(userRepository).countUsersLockedByUsername(mockedEncryptedUsername);
+        }
+
+        @Test
+        void should_returnFalse_when_countResultIsZero() {
+            val username = "username";
+
+            val mockedEncryptedUsername = "encryptedUsername";
+            Mockito.when(encryptionService.encrypt(username)).thenReturn(mockedEncryptedUsername);
+            Mockito.when(userRepository.countUsersLockedByUsername(mockedEncryptedUsername)).thenReturn(0L);
+
+            val result = unitUnderTest.isLocked(username);
+
+            Assertions.assertThat(result).isFalse();
+        }
+
+        @Test
+        void should_returnFalse_when_countResultIsOne() {
+            val username = "username";
+
+            val mockedEncryptedUsername = "encryptedUsername";
+            Mockito.when(encryptionService.encrypt(username)).thenReturn(mockedEncryptedUsername);
+            Mockito.when(userRepository.countUsersLockedByUsername(mockedEncryptedUsername)).thenReturn(1L);
+
+            val result = unitUnderTest.isLocked(username);
+
+            Assertions.assertThat(result).isTrue();
+        }
+
+        @Test
+        void should_returnFalse_when_countResultIsAboveOne() {
+            val username = "username";
+
+            val mockedEncryptedUsername = "encryptedUsername";
+            Mockito.when(encryptionService.encrypt(username)).thenReturn(mockedEncryptedUsername);
+            Mockito.when(userRepository.countUsersLockedByUsername(mockedEncryptedUsername)).thenReturn(2L);
+
+            val result = unitUnderTest.isLocked(username);
+
+            Assertions.assertThat(result).isTrue();
+        }
+    }
+
+    @Nested
+    class DeleteUsersByWahltagID {
+
+        @Test
+        void should_callRepositoryWithWahltagID_when_calledWithWahltagID() {
+            val wahltagID = "wahltagID";
+
+            unitUnderTest.deleteUsersByWahltagID(wahltagID);
+
+            Mockito.verify(userRepository).deleteUsersByWahltagID(wahltagID);
+        }
+    }
+
+    private User createUserWithUsername(String username) {
+        val user = new User();
+
+        user.setUsername(username);
+
+        return user;
+    }
+
+}

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplTest.java
@@ -3,7 +3,7 @@ package de.muenchen.oss.wahllokalsystem.authservice.domain;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 
-import de.muenchen.oss.wahllokalsystem.authservice.service.EncryptionService;
+import de.muenchen.oss.wahllokalsystem.authservice.service.CryptoService;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -26,7 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class UserRepositoryImplTest {
 
     @Mock
-    EncryptionService encryptionService;
+    CryptoService cryptoService;
 
     @Mock
     CrudUserRepository userRepository;
@@ -46,9 +46,9 @@ class UserRepositoryImplTest {
             val mockedUsersFromRepo = List.of(createUserWithUsername("user1"), createUserWithUsername("user2"));
 
             Mockito.when(userRepository.findAll()).thenReturn(mockedUsersFromRepo);
-            Mockito.when(encryptionService.encrypt("user1")).thenReturn(mockedEncryptedUsername);
-            Mockito.when(encryptionService.encrypt("user2")).thenReturn(mockedEncryptedUsername);
-            Mockito.when(encryptionService.isEncrypted(any())).thenReturn(false);
+            Mockito.when(cryptoService.encrypt("user1")).thenReturn(mockedEncryptedUsername);
+            Mockito.when(cryptoService.encrypt("user2")).thenReturn(mockedEncryptedUsername);
+            Mockito.when(cryptoService.isEncrypted(any())).thenReturn(false);
 
             unitUnderTest.onInit();
 
@@ -62,7 +62,7 @@ class UserRepositoryImplTest {
             val mockedUsersFromRepo = List.of(createUserWithUsername("user1"), createUserWithUsername("user2"));
 
             Mockito.when(userRepository.findAll()).thenReturn(mockedUsersFromRepo);
-            Mockito.when(encryptionService.isEncrypted(any())).thenReturn(true);
+            Mockito.when(cryptoService.isEncrypted(any())).thenReturn(true);
 
             unitUnderTest.onInit();
 
@@ -79,9 +79,9 @@ class UserRepositoryImplTest {
             val mockedUsersFromRepo = List.of(createUserWithUsername("user1"), createUserWithUsername("user2"));
 
             Mockito.when(userRepository.findAll()).thenReturn(mockedUsersFromRepo);
-            Mockito.when(encryptionService.encrypt("user1")).thenReturn(mockedEncryptedUsername);
-            Mockito.when(encryptionService.encrypt("user2")).thenReturn(mockedEncryptedUsername);
-            Mockito.when(encryptionService.isEncrypted(any())).thenReturn(false);
+            Mockito.when(cryptoService.encrypt("user1")).thenReturn(mockedEncryptedUsername);
+            Mockito.when(cryptoService.encrypt("user2")).thenReturn(mockedEncryptedUsername);
+            Mockito.when(cryptoService.isEncrypted(any())).thenReturn(false);
 
             unitUnderTest.onSchedule();
 
@@ -95,7 +95,7 @@ class UserRepositoryImplTest {
             val mockedUsersFromRepo = List.of(createUserWithUsername("user1"), createUserWithUsername("user2"));
 
             Mockito.when(userRepository.findAll()).thenReturn(mockedUsersFromRepo);
-            Mockito.when(encryptionService.isEncrypted(any())).thenReturn(true);
+            Mockito.when(cryptoService.isEncrypted(any())).thenReturn(true);
 
             unitUnderTest.onSchedule();
 
@@ -114,8 +114,8 @@ class UserRepositoryImplTest {
             val mockedUsersFromRepo = List.of(createUserWithUsername("user1"), createUserWithUsername("user2"));
 
             Mockito.when(userRepository.findByWahltagID(wahltagID)).thenReturn(mockedUsersFromRepo);
-            Mockito.when(encryptionService.decrypt("user1")).thenReturn(decryptedUsername);
-            Mockito.when(encryptionService.decrypt("user2")).thenReturn(decryptedUsername);
+            Mockito.when(cryptoService.decrypt("user1")).thenReturn(decryptedUsername);
+            Mockito.when(cryptoService.decrypt("user2")).thenReturn(decryptedUsername);
 
             val result = unitUnderTest.findByWahltagID(wahltagID);
 
@@ -145,7 +145,7 @@ class UserRepositoryImplTest {
             val mockedFoundUser = createUserWithUsername("user1");
 
             Mockito.when(userRepository.findById(oid)).thenReturn(Optional.of(mockedFoundUser));
-            Mockito.when(encryptionService.decrypt("user1")).thenReturn(mockedDecryptedUsername);
+            Mockito.when(cryptoService.decrypt("user1")).thenReturn(mockedDecryptedUsername);
 
             val result = unitUnderTest.findById(oid);
 
@@ -175,8 +175,8 @@ class UserRepositoryImplTest {
             val mockedEncryptedUsername1 = "encryptedUsername1";
             val mockedEncryptedUsername2 = "encryptedUsername2";
 
-            Mockito.when(encryptionService.encrypt(username1)).thenReturn(mockedEncryptedUsername1);
-            Mockito.when(encryptionService.encrypt(username2)).thenReturn(mockedEncryptedUsername2);
+            Mockito.when(cryptoService.encrypt(username1)).thenReturn(mockedEncryptedUsername1);
+            Mockito.when(cryptoService.encrypt(username2)).thenReturn(mockedEncryptedUsername2);
             val savedUsernames = new LinkedList<>();
             Mockito.doAnswer(invocation -> {
                 val users = (List<User>) invocation.getArgument(0, List.class);
@@ -199,10 +199,10 @@ class UserRepositoryImplTest {
             val mockedEncryptedUsername1 = "encryptedUsername1";
             val mockedEncryptedUsername2 = "encryptedUsername2";
 
-            Mockito.when(encryptionService.encrypt(username1)).thenReturn(mockedEncryptedUsername1);
-            Mockito.when(encryptionService.encrypt(username2)).thenReturn(mockedEncryptedUsername2);
-            Mockito.when(encryptionService.decrypt(mockedEncryptedUsername1)).thenReturn(username1);
-            Mockito.when(encryptionService.decrypt(mockedEncryptedUsername2)).thenReturn(username2);
+            Mockito.when(cryptoService.encrypt(username1)).thenReturn(mockedEncryptedUsername1);
+            Mockito.when(cryptoService.encrypt(username2)).thenReturn(mockedEncryptedUsername2);
+            Mockito.when(cryptoService.decrypt(mockedEncryptedUsername1)).thenReturn(username1);
+            Mockito.when(cryptoService.decrypt(mockedEncryptedUsername2)).thenReturn(username2);
             Mockito.when(userRepository.saveAll(usersToSave)).then(invocationOnMock -> invocationOnMock.getArgument(0, List.class));
 
             val result = unitUnderTest.saveAll(usersToSave);
@@ -221,7 +221,7 @@ class UserRepositoryImplTest {
             val userToSave = createUserWithUsername(username);
 
             val mockedEncryptedUsername1 = "encryptedUsername1";
-            Mockito.when(encryptionService.encrypt(username)).thenReturn(mockedEncryptedUsername1);
+            Mockito.when(cryptoService.encrypt(username)).thenReturn(mockedEncryptedUsername1);
 
             Mockito.when(userRepository.save(userToSave)).then(invocationOnMock -> {
                 val user = invocationOnMock.getArgument(0, User.class);
@@ -238,8 +238,8 @@ class UserRepositoryImplTest {
             val userToSave = createUserWithUsername(username);
 
             val mockedEncryptedUsername1 = "encryptedUsername1";
-            Mockito.when(encryptionService.encrypt(username)).thenReturn(mockedEncryptedUsername1);
-            Mockito.when(encryptionService.decrypt(mockedEncryptedUsername1)).thenReturn(username);
+            Mockito.when(cryptoService.encrypt(username)).thenReturn(mockedEncryptedUsername1);
+            Mockito.when(cryptoService.decrypt(mockedEncryptedUsername1)).thenReturn(username);
 
             Mockito.when(userRepository.save(userToSave)).then(invocationOnMock -> invocationOnMock.getArgument(0, User.class));
 
@@ -259,8 +259,8 @@ class UserRepositoryImplTest {
             val encryptedUsername = "encryptedUsername";
             val mockedUserFromRepo = createUserWithUsername(encryptedUsername);
 
-            Mockito.when(encryptionService.encrypt(username)).thenReturn(encryptedUsername);
-            Mockito.when(encryptionService.decrypt(encryptedUsername)).thenReturn(username);
+            Mockito.when(cryptoService.encrypt(username)).thenReturn(encryptedUsername);
+            Mockito.when(cryptoService.decrypt(encryptedUsername)).thenReturn(username);
             Mockito.when(userRepository.findByUsername(encryptedUsername)).thenReturn(Optional.of(mockedUserFromRepo));
 
             val result = unitUnderTest.findByUsername(username);
@@ -274,7 +274,7 @@ class UserRepositoryImplTest {
 
             val encryptedUsername = "encryptedUsername";
 
-            Mockito.when(encryptionService.encrypt(username)).thenReturn(encryptedUsername);
+            Mockito.when(cryptoService.encrypt(username)).thenReturn(encryptedUsername);
 
             Mockito.when(userRepository.findByUsername(encryptedUsername)).thenReturn(Optional.empty());
 
@@ -292,7 +292,7 @@ class UserRepositoryImplTest {
             val username = "username";
 
             val mockedEncryptedUsername = "encryptedUsername";
-            Mockito.when(encryptionService.encrypt(username)).thenReturn(mockedEncryptedUsername);
+            Mockito.when(cryptoService.encrypt(username)).thenReturn(mockedEncryptedUsername);
 
             unitUnderTest.exists(username);
 
@@ -304,7 +304,7 @@ class UserRepositoryImplTest {
             val username = "username";
 
             val mockedEncryptedUsername = "encryptedUsername";
-            Mockito.when(encryptionService.encrypt(username)).thenReturn(mockedEncryptedUsername);
+            Mockito.when(cryptoService.encrypt(username)).thenReturn(mockedEncryptedUsername);
             Mockito.when(userRepository.existsByUsername(mockedEncryptedUsername)).thenReturn(true);
 
             Assertions.assertThat(unitUnderTest.exists(username)).isTrue();
@@ -315,7 +315,7 @@ class UserRepositoryImplTest {
             val username = "username";
 
             val mockedEncryptedUsername = "encryptedUsername";
-            Mockito.when(encryptionService.encrypt(username)).thenReturn(mockedEncryptedUsername);
+            Mockito.when(cryptoService.encrypt(username)).thenReturn(mockedEncryptedUsername);
             Mockito.when(userRepository.existsByUsername(mockedEncryptedUsername)).thenReturn(false);
 
             Assertions.assertThat(unitUnderTest.exists(username)).isFalse();
@@ -330,7 +330,7 @@ class UserRepositoryImplTest {
             val username = "username";
 
             val mockedEncryptedUsername = "encryptedUsername";
-            Mockito.when(encryptionService.encrypt(username)).thenReturn(mockedEncryptedUsername);
+            Mockito.when(cryptoService.encrypt(username)).thenReturn(mockedEncryptedUsername);
 
             unitUnderTest.isLocked(username);
 
@@ -342,7 +342,7 @@ class UserRepositoryImplTest {
             val username = "username";
 
             val mockedEncryptedUsername = "encryptedUsername";
-            Mockito.when(encryptionService.encrypt(username)).thenReturn(mockedEncryptedUsername);
+            Mockito.when(cryptoService.encrypt(username)).thenReturn(mockedEncryptedUsername);
             Mockito.when(userRepository.countUsersLockedByUsername(mockedEncryptedUsername)).thenReturn(0L);
 
             val result = unitUnderTest.isLocked(username);
@@ -355,7 +355,7 @@ class UserRepositoryImplTest {
             val username = "username";
 
             val mockedEncryptedUsername = "encryptedUsername";
-            Mockito.when(encryptionService.encrypt(username)).thenReturn(mockedEncryptedUsername);
+            Mockito.when(cryptoService.encrypt(username)).thenReturn(mockedEncryptedUsername);
             Mockito.when(userRepository.countUsersLockedByUsername(mockedEncryptedUsername)).thenReturn(1L);
 
             val result = unitUnderTest.isLocked(username);
@@ -368,7 +368,7 @@ class UserRepositoryImplTest {
             val username = "username";
 
             val mockedEncryptedUsername = "encryptedUsername";
-            Mockito.when(encryptionService.encrypt(username)).thenReturn(mockedEncryptedUsername);
+            Mockito.when(cryptoService.encrypt(username)).thenReturn(mockedEncryptedUsername);
             Mockito.when(userRepository.countUsersLockedByUsername(mockedEncryptedUsername)).thenReturn(2L);
 
             val result = unitUnderTest.isLocked(username);

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserServiceTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserServiceTest.java
@@ -1,0 +1,296 @@
+package de.muenchen.oss.wahllokalsystem.authservice.service;
+
+import de.muenchen.oss.wahllokalsystem.authservice.domain.LoginAttempt;
+import de.muenchen.oss.wahllokalsystem.authservice.domain.LoginAttemptRepository;
+import de.muenchen.oss.wahllokalsystem.authservice.domain.User;
+import de.muenchen.oss.wahllokalsystem.authservice.domain.UserRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    LoginAttemptRepository loginAttemptRepository;
+
+    @Mock
+    LoginAttemptModelMapper loginAttemptModelMapper;
+
+    @InjectMocks
+    UserService unitUnderTest;
+
+    @Captor
+    ArgumentCaptor<LoginAttempt> loginAttemptCaptor;
+
+    @Captor
+    ArgumentCaptor<User> userCaptor;
+
+    @Nested
+    class updateFailAttempts {
+
+        @Test
+        void should_throwExceptionWithUsername_when_userWithUsernameDoesNotExist() {
+            val username = "username";
+
+            Mockito.when(userRepository.findByUsername(username)).thenReturn(Optional.empty());
+
+            Assertions.assertThatThrownBy(() -> unitUnderTest.updateFailAttempts(username)).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(username);
+        }
+
+        @Test
+        void should_createNewLoginAttemptInRepo_when_userWithUsernameExistsButHasNoLoginAttempt() {
+            val username = "username";
+
+            val mockedUserFromRepo = new User();
+
+            Mockito.when(userRepository.findByUsername(username)).thenReturn(Optional.of(mockedUserFromRepo));
+            Mockito.when(loginAttemptRepository.findByUsername(username)).thenReturn(Optional.empty());
+
+            unitUnderTest.updateFailAttempts(username);
+
+            Mockito.verify(loginAttemptRepository).save(loginAttemptCaptor.capture());
+
+            val expectedLoginAttempt = new LoginAttempt(username, 1, null);
+            Assertions.assertThat(loginAttemptCaptor.getValue()).isEqualTo(expectedLoginAttempt);
+
+        }
+
+        @Test
+        void should_updateExistingLoginAttemptInRepo_when_userWithUsernameExistsWithLoginAttempt() {
+            val username = "username";
+
+            val mockedUserFromRepo = new User();
+            val mockedLoginAttemptFromRepo = new LoginAttempt(username, 1, null);
+
+            Mockito.when(userRepository.findByUsername(username)).thenReturn(Optional.of(mockedUserFromRepo));
+            Mockito.when(loginAttemptRepository.findByUsername(username)).thenReturn(Optional.of(mockedLoginAttemptFromRepo));
+
+            unitUnderTest.updateFailAttempts(username);
+
+            Mockito.verify(loginAttemptRepository).save(loginAttemptCaptor.capture());
+
+            val expectedLoginAttempt = new LoginAttempt(username, 2, null);
+            Assertions.assertThat(loginAttemptCaptor.getValue()).usingRecursiveComparison().ignoringFields("lastModified").isEqualTo(expectedLoginAttempt);
+            Assertions.assertThat(loginAttemptCaptor.getValue().getLastModified()).isNotNull();
+        }
+
+        @Test
+        void should_updateUserAsLocked_when_existingLoginAttemptsReachesMaxLoginAttempts() {
+            val username = "username";
+            unitUnderTest.setMaxLoginAttempts(3);
+
+            val mockedUserFromRepo = new User();
+            val mockedLoginAttemptFromRepo = new LoginAttempt();
+            mockedLoginAttemptFromRepo.setAttempts(2);
+
+            Mockito.when(userRepository.findByUsername(username)).thenReturn(Optional.of(mockedUserFromRepo));
+            Mockito.when(loginAttemptRepository.findByUsername(username)).thenReturn(Optional.of(mockedLoginAttemptFromRepo));
+
+            unitUnderTest.updateFailAttempts(username);
+
+            Mockito.verify(userRepository).save(userCaptor.capture());
+
+            Assertions.assertThat(userCaptor.getValue().isAccountNonLocked()).isFalse();
+        }
+
+        @Test
+        void should_notUpdateUserAsLocked_when_existingLoginAttemptsNotReachesMaxLoginAttempts() {
+            val username = "username";
+            unitUnderTest.setMaxLoginAttempts(4);
+
+            val mockedUserFromRepo = new User();
+            val mockedLoginAttemptFromRepo = new LoginAttempt();
+            mockedLoginAttemptFromRepo.setAttempts(2);
+
+            Mockito.when(userRepository.findByUsername(username)).thenReturn(Optional.of(mockedUserFromRepo));
+            Mockito.when(loginAttemptRepository.findByUsername(username)).thenReturn(Optional.empty());
+
+            unitUnderTest.updateFailAttempts(username);
+
+            Mockito.verifyNoMoreInteractions(userRepository);
+        }
+
+    }
+
+    @Nested
+    class resetFailAttempts {
+
+        @Test
+        void should_throwExceptionWithUsername_when_userWithUsernameDoesNotExist() {
+            val username = "username";
+
+            Mockito.when(userRepository.findByUsername(username)).thenReturn(Optional.empty());
+
+            Assertions.assertThatThrownBy(() -> unitUnderTest.resetFailAttempts(username)).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(username);
+        }
+
+        @Test
+        void should_updateExistingLoginAttemptInRepo_when_userWithUsernameExistsWithLoginAttempt() {
+            val username = "username";
+
+            val mockedUserFromRepo = createUserWithNonLocked(false);
+            val mockedLoginAttemptFromRepo = new LoginAttempt();
+            mockedLoginAttemptFromRepo.setLastModified(LocalDateTime.now());
+            mockedLoginAttemptFromRepo.setAttempts(10);
+
+            Mockito.when(userRepository.findByUsername(username)).thenReturn(Optional.of(mockedUserFromRepo));
+            Mockito.when(loginAttemptRepository.findByUsername(username)).thenReturn(Optional.of(mockedLoginAttemptFromRepo));
+
+            unitUnderTest.resetFailAttempts(username);
+
+            Mockito.verify(loginAttemptRepository).save(loginAttemptCaptor.capture());
+            Assertions.assertThat(loginAttemptCaptor.getValue().getLastModified()).isNull();
+            Assertions.assertThat(loginAttemptCaptor.getValue().getAttempts()).isEqualTo(0);
+        }
+
+        @Test
+        void should_unlockUser_when_userWithUsernameDoesExist() {
+            val username = "username";
+
+            val mockedUserFromRepo = createUserWithNonLocked(false);
+            val mockedLoginAttemptFromRepo = new LoginAttempt();
+
+            Mockito.when(userRepository.findByUsername(username)).thenReturn(Optional.of(mockedUserFromRepo));
+            Mockito.when(loginAttemptRepository.findByUsername(username)).thenReturn(Optional.of(mockedLoginAttemptFromRepo));
+
+            unitUnderTest.resetFailAttempts(username);
+
+            Mockito.verify(userRepository).save(userCaptor.capture());
+            Assertions.assertThat(userCaptor.getValue().isAccountNonLocked()).isTrue();
+        }
+    }
+
+    @Nested
+    class getUserAttempts {
+
+        @Test
+        void should_returnLoginAttemptModel_when_userAndAttemptExistsForThatUsername() {
+            val username = "username";
+
+            val mockedLoginAttemptFromRepo = new LoginAttempt();
+            val mockedLoginAttemptAsModel = createLoginAttemptModel();
+
+            Mockito.when(userRepository.exists(username)).thenReturn(true);
+            Mockito.when(loginAttemptRepository.findByUsername(username)).thenReturn(Optional.of(mockedLoginAttemptFromRepo));
+            Mockito.when(loginAttemptModelMapper.toModel(mockedLoginAttemptFromRepo)).thenReturn(mockedLoginAttemptAsModel);
+
+            val result = unitUnderTest.getUserAttempts(username);
+
+            Assertions.assertThat(result.get()).isEqualTo(mockedLoginAttemptAsModel);
+        }
+
+        @Test
+        void should_throwExceptionWithUsername_when_userWithThatUsernameDoesNotExist() {
+            val username = "username";
+
+            Mockito.when(userRepository.exists(username)).thenReturn(false);
+
+            Assertions.assertThatThrownBy(() -> unitUnderTest.getUserAttempts(username)).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(username);
+        }
+
+        @Test
+        void should_returnEmptyOptional_when_userUserExistsButHasNoLoginAttempt() {
+            val username = "username";
+
+            Mockito.when(userRepository.exists(username)).thenReturn(true);
+            Mockito.when(loginAttemptRepository.findByUsername(username)).thenReturn(Optional.empty());
+
+            val result = unitUnderTest.getUserAttempts(username);
+
+            Assertions.assertThat(result).isEmpty();
+        }
+
+    }
+
+    @Nested
+    class doesUserExist {
+
+        @Test
+        void should_returnTrue_when_userExists() {
+            val username = "username";
+
+            Mockito.when(userRepository.findByUsername(username)).thenReturn(Optional.of(new User()));
+
+            Assertions.assertThat(unitUnderTest.doesUserExist(username)).isTrue();
+        }
+
+        @Test
+        void should_returnFalse_when_userDoesNotExist() {
+            val username = "username";
+
+            Mockito.when(userRepository.findByUsername(username)).thenReturn(Optional.empty());
+
+            Assertions.assertThat(unitUnderTest.doesUserExist(username)).isFalse();
+        }
+    }
+
+    @Nested
+    class IsLocked {
+
+        @Test
+        void should_returnTrue_when_userNonLockedIsFalse() {
+            val username = "username";
+
+            val mockedRepoUser = createUserWithNonLocked(false);
+            Mockito.when(userRepository.findByUsername(username)).thenReturn(Optional.of(mockedRepoUser));
+
+            val result = unitUnderTest.isLocked(username);
+
+            Assertions.assertThat(result).isTrue();
+        }
+
+        @Test
+        void should_returnFalse_when_userDoesNotExist() {
+            val username = "username";
+
+            Mockito.when(userRepository.findByUsername(username)).thenReturn(Optional.empty());
+
+            val result = unitUnderTest.isLocked(username);
+
+            Assertions.assertThat(result).isFalse();
+        }
+
+        @Test
+        void should_returnFalse_when_userNonLockedIsTrue() {
+            val username = "username";
+
+            val mockedRepoUser = createUserWithNonLocked(true);
+            Mockito.when(userRepository.findByUsername(username)).thenReturn(Optional.of(mockedRepoUser));
+
+            val result = unitUnderTest.isLocked(username);
+
+            Assertions.assertThat(result).isFalse();
+        }
+    }
+
+    private User createUserWithNonLocked(final boolean nonLocked) {
+        val user = new User();
+
+        user.setAccountNonLocked(nonLocked);
+
+        return user;
+    }
+
+    private LoginAttemptModel createLoginAttemptModel() {
+        return new LoginAttemptModel(UUID.randomUUID(), "", 0, LocalDateTime.now());
+    }
+
+}

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserServiceTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserServiceTest.java
@@ -41,7 +41,7 @@ class UserServiceTest {
     ArgumentCaptor<User> userCaptor;
 
     @Nested
-    class updateFailAttempts {
+    class UpdateFailAttempts {
 
         @Test
         void should_throwExceptionWithUsername_when_userWithUsernameDoesNotExist() {
@@ -129,7 +129,7 @@ class UserServiceTest {
     }
 
     @Nested
-    class resetFailAttempts {
+    class ResetFailAttempts {
 
         @Test
         void should_throwExceptionWithUsername_when_userWithUsernameDoesNotExist() {
@@ -178,7 +178,7 @@ class UserServiceTest {
     }
 
     @Nested
-    class getUserAttempts {
+    class GetUserAttempts {
 
         @Test
         void should_returnLoginAttemptModel_when_userAndAttemptExistsForThatUsername() {
@@ -221,7 +221,7 @@ class UserServiceTest {
     }
 
     @Nested
-    class doesUserExist {
+    class DoesUserExist {
 
         @Test
         void should_returnTrue_when_userExists() {


### PR DESCRIPTION
# Beschreibung:

- Übernahme der Datenklassen aus der alten Anwendung
- Folgende Änderungen wurden vollzogen
  - Ergänzung von `@NaturalID` bei Properties die einen fachlichen Schlüssel darstellen
    - username sollte nur einmal existieren und war auch in den alten Flyway-Files als Unique markiert
    - `authority` in `Authority` um Duplikate die zu Verwirrungen führen können zu vermeiden
- der Konfigurationsparameter `serviceauth.crypto.key` wurde bewusst nicht in das Default-Profil gelegt damit er bei einem Nicht-Entwicklungsprofil (`local`) definiert werden muss, da sonst die Anwendung nicht startet
- Der Code aus dem LoginAttempt-Repo-Fragment sind in den UserService gewandet da die Operationen über einen Username liefen.
- Da der Benutzername in der DB-Verschlüsselt wurde, wurde kein Standard Spring-Data Repo für User angeboten. Es wurde ein Interface definiert was durch `UserRepositoryImpl` implementiert wird. In der Datei gibt es ein Interface das von `CrudRepository` erbt. Entsprechend wird durch Spring auch eine Repo-Klasse geniert. Diese ist aber nur innerhalb von `CrudRepository` verfügbar.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [X] Doku aktualisiert
- [X] Swagger-API vollständig - es gibt keinen RestController
- [x] Unit-Tests gepflegt
- [x] Integrationstests gepflegt
- [x] Beispiel-Requests gepflegt - es gibt keinen RestController~~

<!-- Dokumentation -->
### Dokumentation
- [X] Links geprüft - keine Links ergänzt

# Referenzen[^1]:

Verwandt mit Issue #

Closes #174

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
