### PR TITLE
Database Tables Names and Properties as in Naming-Convention

### DIFF
--- a/wls-basisdaten-service/src/main/resources/db/migrations/h2/V0_1__createTableTheEntity.sql
+++ b/wls-basisdaten-service/src/main/resources/db/migrations/h2/V0_1__createTableTheEntity.sql
@@ -1,5 +1,5 @@
-CREATE TABLE theEntity
+CREATE TABLE TheEntity
 (
-    id            varchar2(36) NOT NULL primary key,
-    textAttribute varchar2(8)  NOT NULL
+    id            VARCHAR2(36) NOT NULL PRIMARY KEY,
+    textAttribute VARCHAR2(8)  NOT NULL
 )

--- a/wls-basisdaten-service/src/main/resources/db/migrations/h2/V1_0__createWahlvorschlaegeTable.sql
+++ b/wls-basisdaten-service/src/main/resources/db/migrations/h2/V1_0__createWahlvorschlaegeTable.sql
@@ -1,11 +1,11 @@
-CREATE TABLE wahlvorschlaege
+CREATE TABLE Wahlvorschlaege
 (
     id                  VARCHAR(255) NOT NULL,
-    stimmzettelgebietid VARCHAR(255) NOT NULL,
+    stimmzettelgebietID VARCHAR(255) NOT NULL,
     wahlID              VARCHAR(255) NOT NULL,
     wahlbezirkID        VARCHAR(255) NOT NULL,
 
-    unique (wahlID, wahlbezirkID),
+    UNIQUE (wahlID, wahlbezirkID),
 
     PRIMARY KEY (id)
 );
@@ -19,11 +19,11 @@ CREATE TABLE Wahlvorschlag
     erhaeltStimmen    BOOLEAN      NOT NULL,
     wahlvorschlaegeID VARCHAR(255) NOT NULL,
 
-    unique (identifikator),
+    UNIQUE (identifikator),
 
-    foreign key (wahlvorschlaegeID) REFERENCES wahlvorschlaege (id),
+    FOREIGN KEY (wahlvorschlaegeID) REFERENCES Wahlvorschlaege(id),
 
-    primary key (id)
+    PRIMARY KEY (id)
 );
 
 CREATE TABLE Kandidat
@@ -37,9 +37,9 @@ CREATE TABLE Kandidat
     einzelbewerber                BOOLEAN      NOT NULL,
     wahlvorschlagID               VARCHAR(255) NOT NULL,
 
-    unique (identifikator),
+    UNIQUE (identifikator),
 
-    foreign key (wahlvorschlagID) REFERENCES Wahlvorschlag (id),
+    FOREIGN KEY (wahlvorschlagID) REFERENCES Wahlvorschlag(id),
 
-    primary key (id)
+    PRIMARY KEY (id)
 )

--- a/wls-basisdaten-service/src/main/resources/db/migrations/h2/V2_0__createHandbuchTable.sql
+++ b/wls-basisdaten-service/src/main/resources/db/migrations/h2/V2_0__createHandbuchTable.sql
@@ -1,8 +1,8 @@
 CREATE TABLE Handbuch
 (
-    wahltagID      varchar(1024) not null,
-    wahlbezirksart varchar(255)  not null,
-    handbuch       blob          not null,
+    wahltagID      VARCHAR(1024) NOT NULL,
+    wahlbezirksart VARCHAR(255)  NOT NULL,
+    handbuch       BLOB          NOT NULL,
 
-    primary key (wahltagID, wahlbezirksart)
+    PRIMARY KEY (wahltagID, wahlbezirksart)
 );

--- a/wls-basisdaten-service/src/main/resources/db/migrations/h2/V3_0__createWahltagTable.sql
+++ b/wls-basisdaten-service/src/main/resources/db/migrations/h2/V3_0__createWahltagTable.sql
@@ -1,4 +1,4 @@
-CREATE TABLE wahltag
+CREATE TABLE Wahltag
 (
     wahltagID           VARCHAR(1024) NOT NULL,
     wahltag             TIMESTAMP NOT NULL,

--- a/wls-basisdaten-service/src/main/resources/db/migrations/h2/V5_0__createTablesReferendumvorlage.sql
+++ b/wls-basisdaten-service/src/main/resources/db/migrations/h2/V5_0__createTablesReferendumvorlage.sql
@@ -1,4 +1,4 @@
-CREATE TABLE referendumvorlagen
+CREATE TABLE Referendumvorlagen
 (
     id                  VARCHAR2(36)   NOT NULL,
     wahlID              VARCHAR2(1000) NOT NULL,
@@ -11,7 +11,7 @@ CREATE TABLE referendumvorlagen
 
 );
 
-CREATE TABLE referendumvorlage
+CREATE TABLE Referendumvorlage
 (
     id                   VARCHAR2(36)   NOT NULL,
     wahlvorschlagID      VARCHAR2(1000) NOT NULL,
@@ -22,12 +22,12 @@ CREATE TABLE referendumvorlage
     referendumvorlagenID VARCHAR2(36)   NOT NULL,
 
 
-    FOREIGN KEY (referendumvorlagenID) REFERENCES referendumvorlagen (id),
+    FOREIGN KEY (referendumvorlagenID) REFERENCES Referendumvorlagen(id),
 
     PRIMARY KEY (id)
 );
 
-CREATE TABLE referendumoption
+CREATE TABLE Referendumoption
 (
     id                  VARCHAR2(1000) NOT NULL,
     name                VARCHAR2(1000) NOT NULL,
@@ -35,5 +35,5 @@ CREATE TABLE referendumoption
     referendumvorlageID VARCHAR2(36)   NOT NULL,
 
     UNIQUE (id),
-    FOREIGN KEY (referendumvorlageID) REFERENCES referendumvorlage (id)
+    FOREIGN KEY (referendumvorlageID) REFERENCES Referendumvorlage(id)
 );

--- a/wls-basisdaten-service/src/main/resources/db/migrations/h2/V6_0__createWahlTable.sql
+++ b/wls-basisdaten-service/src/main/resources/db/migrations/h2/V6_0__createWahlTable.sql
@@ -1,15 +1,15 @@
-create table Wahl
+CREATE TABLE Wahl
 (
-    wahlid                      varchar(1024) not null,
-    name                        varchar(255) not null,
-    reihenfolge                 bigint not null,
-    waehlerverzeichnisnummer    bigint not null,
-    wahltag                     datetime not null,
-    wahlart                     varchar(255) not null,
-    r                           bigint,
-    g                           bigint,
-    b                           bigint,
-    nummer                      varchar(255) not null,
+    wahlID                      VARCHAR(1024) NOT NULL,
+    name                        VARCHAR(255) NOT NULL,
+    reihenfolge                 BIGINT NOT NULL,
+    waehlerverzeichnisnummer    BIGINT NOT NULL,
+    wahltag                     DATETIME NOT NULL,
+    wahlart                     VARCHAR(255) NOT NULL,
+    r                           BIGINT,
+    g                           BIGINT,
+    b                           BIGINT,
+    nummer                      VARCHAR(255) NOT NULL,
 
-    primary key (wahlid)
+    PRIMARY KEY (wahlID)
 );

--- a/wls-basisdaten-service/src/main/resources/db/migrations/h2/V8_0__createWahlbezirk.sql
+++ b/wls-basisdaten-service/src/main/resources/db/migrations/h2/V8_0__createWahlbezirk.sql
@@ -5,7 +5,7 @@ CREATE TABLE Wahlbezirk
     nummer          VARCHAR(255) NOT NULL,
     wahlbezirkart   VARCHAR(255) NOT NULL,
     wahlnummer      VARCHAR(255),
-    wahlid          VARCHAR(255),
+    wahlID          VARCHAR(255),
 
     PRIMARY KEY (wahlbezirkID)
 );

--- a/wls-basisdaten-service/src/main/resources/db/migrations/h2/V9_0__dropTableTheEntity.sql
+++ b/wls-basisdaten-service/src/main/resources/db/migrations/h2/V9_0__dropTableTheEntity.sql
@@ -1,1 +1,1 @@
-DROP TABLE theEntity
+DROP TABLE TheEntity

--- a/wls-basisdaten-service/src/main/resources/db/migrations/oracle/V0_1__createTableTheEntity.sql
+++ b/wls-basisdaten-service/src/main/resources/db/migrations/oracle/V0_1__createTableTheEntity.sql
@@ -1,5 +1,5 @@
-CREATE TABLE theEntity
+CREATE TABLE TheEntity
 (
-    id            varchar2(36) NOT NULL primary key,
-    textAttribute varchar2(8)  NOT NULL
+    id            VARCHAR2(36) NOT NULL PRIMARY KEY,
+    textAttribute VARCHAR2(8)  NOT NULL
 )

--- a/wls-basisdaten-service/src/main/resources/db/migrations/oracle/V1_0__createWahlvorschlaegeTable.sql
+++ b/wls-basisdaten-service/src/main/resources/db/migrations/oracle/V1_0__createWahlvorschlaegeTable.sql
@@ -1,11 +1,11 @@
-CREATE TABLE wahlvorschlaege
+CREATE TABLE Wahlvorschlaege
 (
     id                  VARCHAR(255) NOT NULL,
-    stimmzettelgebietid VARCHAR(255) NOT NULL,
+    stimmzettelgebietID VARCHAR(255) NOT NULL,
     wahlID              VARCHAR(255) NOT NULL,
     wahlbezirkID        VARCHAR(255) NOT NULL,
 
-    unique (wahlID, wahlbezirkID),
+    UNIQUE (wahlID, wahlbezirkID),
 
     PRIMARY KEY (id)
 );
@@ -19,11 +19,11 @@ CREATE TABLE Wahlvorschlag
     erhaeltStimmen    NUMBER       NOT NULL,
     wahlvorschlaegeID VARCHAR(255) NOT NULL,
 
-    unique (identifikator),
+    UNIQUE (identifikator),
 
-    foreign key (wahlvorschlaegeID) REFERENCES wahlvorschlaege (id),
+    FOREIGN KEY (wahlvorschlaegeID) REFERENCES Wahlvorschlaege(id),
 
-    primary key (id)
+    PRIMARY KEY (id)
 );
 
 CREATE TABLE Kandidat
@@ -37,9 +37,9 @@ CREATE TABLE Kandidat
     einzelbewerber                NUMBER       NOT NULL,
     wahlvorschlagID               VARCHAR(255) NOT NULL,
 
-    unique (identifikator),
+    UNIQUE (identifikator),
 
-    foreign key (wahlvorschlagID) REFERENCES Wahlvorschlag (id),
+    FOREIGN KEY (wahlvorschlagID) REFERENCES Wahlvorschlag(id),
 
-    primary key (id)
+    PRIMARY KEY (id)
 )

--- a/wls-basisdaten-service/src/main/resources/db/migrations/oracle/V2_0__createHandbuchTable.sql
+++ b/wls-basisdaten-service/src/main/resources/db/migrations/oracle/V2_0__createHandbuchTable.sql
@@ -1,8 +1,8 @@
 CREATE TABLE Handbuch
 (
-    wahltagID      VARCHAR(1024) not null,
-    wahlbezirksart VARCHAR(255)  not null,
-    handbuch       blob          not null,
+    wahltagID      VARCHAR(1024) NOT NULL,
+    wahlbezirksart VARCHAR(255)  NOT NULL,
+    handbuch       BLOB          NOT NULL,
 
-    primary key (wahltagID, wahlbezirksart)
+    PRIMARY KEY (wahltagID, wahlbezirksart)
 );

--- a/wls-basisdaten-service/src/main/resources/db/migrations/oracle/V3_0__createWahltagTable.sql
+++ b/wls-basisdaten-service/src/main/resources/db/migrations/oracle/V3_0__createWahltagTable.sql
@@ -1,4 +1,4 @@
-CREATE TABLE wahltag
+CREATE TABLE Wahltag
 (
     wahltagID           VARCHAR(1024) NOT NULL,
     wahltag             TIMESTAMP NOT NULL,

--- a/wls-basisdaten-service/src/main/resources/db/migrations/oracle/V5_0__createTablesReferendumvorlage.sql
+++ b/wls-basisdaten-service/src/main/resources/db/migrations/oracle/V5_0__createTablesReferendumvorlage.sql
@@ -1,4 +1,4 @@
-CREATE TABLE referendumvorlagen
+CREATE TABLE Referendumvorlagen
 (
     id                  VARCHAR2(36)   NOT NULL,
     wahlID              VARCHAR2(1000) NOT NULL,
@@ -8,10 +8,9 @@ CREATE TABLE referendumvorlagen
     UNIQUE (wahlID, wahlbezirkID),
 
     PRIMARY KEY (id)
-
 );
 
-CREATE TABLE referendumvorlage
+CREATE TABLE Referendumvorlage
 (
     id                   VARCHAR2(36)   NOT NULL,
     wahlvorschlagID      VARCHAR2(1000) NOT NULL,
@@ -22,12 +21,12 @@ CREATE TABLE referendumvorlage
     referendumvorlagenID VARCHAR2(36)   NOT NULL,
 
 
-    FOREIGN KEY (referendumvorlagenID) REFERENCES referendumvorlagen (id),
+    FOREIGN KEY (referendumvorlagenID) REFERENCES Referendumvorlagen(id),
 
     PRIMARY KEY (id)
 );
 
-CREATE TABLE referendumoption
+CREATE TABLE Referendumoption
 (
     id                  VARCHAR2(1000) NOT NULL,
     name                VARCHAR2(1000) NOT NULL,
@@ -35,5 +34,5 @@ CREATE TABLE referendumoption
     referendumvorlageID VARCHAR2(36)   NOT NULL,
 
     UNIQUE (id),
-    FOREIGN KEY (referendumvorlageID) REFERENCES referendumvorlage (id)
+    FOREIGN KEY (referendumvorlageID) REFERENCES Referendumvorlage(id)
 );

--- a/wls-basisdaten-service/src/main/resources/db/migrations/oracle/V6_0__createWahlTable.sql
+++ b/wls-basisdaten-service/src/main/resources/db/migrations/oracle/V6_0__createWahlTable.sql
@@ -1,15 +1,15 @@
 create table Wahl
 (
-    wahlid                      varchar(1024) not null,
-    name                        varchar(255) not null,
-    reihenfolge                 NUMBER(19, 0) not null,
-    waehlerverzeichnisnummer    NUMBER(19, 0) not null,
-    wahltag                     TIMESTAMP  not null,
-    wahlart                     varchar(255) not null,
+    wahlID                      VARCHAR(1024) NOT NULL,
+    name                        VARCHAR(255) NOT NULL,
+    reihenfolge                 NUMBER(19, 0) NOT NULL,
+    waehlerverzeichnisnummer    NUMBER(19, 0) NOT NULL,
+    wahltag                     TIMESTAMP  NOT NULL,
+    wahlart                     VARCHAR(255) NOT NULL,
     r                           NUMBER(19, 0),
     g                           NUMBER(19, 0),
     b                           NUMBER(19, 0),
-    nummer                      varchar(255) not null,
+    nummer                      VARCHAR(255) NOT NULL,
 
-    PRIMARY KEY (wahlid)
+    PRIMARY KEY (wahlID)
 );

--- a/wls-basisdaten-service/src/main/resources/db/migrations/oracle/V8_0__createWahlbezirk.sql
+++ b/wls-basisdaten-service/src/main/resources/db/migrations/oracle/V8_0__createWahlbezirk.sql
@@ -5,7 +5,7 @@ CREATE TABLE Wahlbezirk
     nummer          VARCHAR(255) NOT NULL,
     wahlbezirkart   VARCHAR(255) NOT NULL,
     wahlnummer      VARCHAR(255),
-    wahlid          VARCHAR(255),
+    wahlID          VARCHAR(255),
 
     PRIMARY KEY (wahlbezirkID)
 );

--- a/wls-basisdaten-service/src/main/resources/db/migrations/oracle/V9_0__dropTableTheEntity.sql
+++ b/wls-basisdaten-service/src/main/resources/db/migrations/oracle/V9_0__dropTableTheEntity.sql
@@ -1,1 +1,1 @@
-DROP TABLE theEntity
+DROP TABLE TheEntity


### PR DESCRIPTION
# Beschreibung:

Database Tables Names and Properties as in [Naming-Convention](https://it-at-m.github.io/Wahllokalsystem/technik/coding_conventions/db_naming.html)

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->
- [x] - DB Namen und Properties Convention-Konform;
- [x] - MicroserviceApp startet, mit db-h2 und db-oracle;
- [x] - alle Unit-Tests bestanden.

Closes #471 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
