### PR TITLE
fix image filepath

### DIFF
--- a/docs/src/features/index.md
+++ b/docs/src/features/index.md
@@ -9,7 +9,7 @@ Für jeden Service gibt es eine separate Beschreibung zu dessen Aufgaben und Fun
 Das folgende Datenmodell wurde mit Betrachtung der gesetzlichen Grundlage verschiedener Wahlen, sowie des örtlichen 
 Kommunal- und/oder Landes- Wahlrechts erstellt.
 
-![Datenmodell:](../public/fachlichesDatenmodell/vermutetesFachlichesDatenmodell_20241008.png)
+![Datenmodell:](/fachlichesDatenmodell/vermutetesFachlichesDatenmodell_20241008.png)
 
 `Wahltermin` - ein Datum an dem eine Wahl oder auch mehrere Wahlen oder Abstimmungen im
 gleichen Wahllokal starten. Diese enden in der Regel auch am gleichen Tag, es gibt aber auch
@@ -49,7 +49,7 @@ Der Inhalt eines Stimmzettels bestimmt sich aus der Zugehörigkeit zum Wahlkreis
 
 ##### Beispiel Bundestagswahl
 
-![Wahlkreise in der Landeshauptstadt München](../public/fachlichesDatenmodell/Wahlkreiskarte_BTW2025.png)
+![Wahlkreise in der Landeshauptstadt München](/fachlichesDatenmodell/Wahlkreiskarte_BTW2025.png)
 
 [Mehr Informationen zur Bundestagswahl](https://stadt.muenchen.de/infos/bundestagswahlen.html)
 
@@ -62,7 +62,7 @@ Der Inhalt eines Stimmzettels bestimmt aber seine Zugehörigkeit zum Stimmkreis 
 
 ##### Beispiel Landtagswahl
 
-![Stimmkreiskarte in der Landeshauptstadt München](../public/fachlichesDatenmodell/Stimmkreiskarte_LTW_V1.jpg)
+![Stimmkreiskarte in der Landeshauptstadt München](/fachlichesDatenmodell/Stimmkreiskarte_LTW_V1.jpg)
 
 [Mehr Informationen zur Landtagswahl.](https://stadt.muenchen.de/infos/landtagswahlen-und-bezirkswahlen-teil-ii.html)
 


### PR DESCRIPTION
# Beschreibung:

Soll folgendes beheben wenn man die Doku lokal anzeigt:

```
Files in the public directory are served at the root path.
Instead of /public/fachlichesDatenmodell/vermutetesFachlichesDatenmodell_20241008.png, use /fachlichesDatenmodell/vermutetesFachlichesDatenmodell_20241008.png.
Files in the public directory are served at the root path.
Instead of /public/fachlichesDatenmodell/Wahlkreiskarte_BTW2025.png, use /fachlichesDatenmodell/Wahlkreiskarte_BTW2025.png.
Files in the public directory are served at the root path.
Instead of /public/fachlichesDatenmodell/Stimmkreiskarte_LTW_V1.jpg, use /fachlichesDatenmodell/Stimmkreiskarte_LTW_V1.jpg.
```

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

# Referenzen[^1]:

Verwandt mit Issue #

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
