### PR TITLE
174 - fix: relationship to 'many to many' in doc für AuthService

### DIFF
--- a/docs/src/features/auth-service/index.md
+++ b/docs/src/features/auth-service/index.md
@@ -11,8 +11,8 @@ Der Service hat keine Abhängigkeiten zu anderen Services.
 ```mermaid
 
 erDiagram
-    User 1--0+ Authority : hat
-    Authority 1--0+ Permission : hat
+    User 1+--0+ Authority : hat
+    Authority 1+--0+ Permission : hat
     User 1--|o LoginAttempt : unternahm
     
     User {


### PR DESCRIPTION
# Beschreibung:

Die Grafik spiegelt nicht die many-to-many Beziehung wieder:
- User <-> Authority
- Authority <-> Permission

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->

<!-- Dokumentation -->
### Dokumentation
- [X] Links geprüft - keine Links oder Seiten verändert

# Referenzen[^1]:

Verwandt mit Issue #174

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
