### PR TITLE
174 bereitstellung datenstrukturen - Fix en/de-Crypting von Username; saveByWahltagID

### DIFF
--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/User.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/User.java
@@ -4,7 +4,6 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
@@ -19,6 +18,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import lombok.val;
 import org.hibernate.annotations.NaturalId;
 
 @Entity
@@ -29,6 +29,15 @@ import org.hibernate.annotations.NaturalId;
 @AllArgsConstructor
 @ToString(onlyExplicitlyIncluded = true)
 public class User extends BaseEntity {
+
+    public static User flatCopyOf(final User user) {
+        val copy = new User(user.getUsername(), user.getPassword(), user.getEmail(), user.isUserEnabled(), user.isAccountNonLocked(), user.getWahltagID(),
+                user.getWahltag(), user.getWahlbezirkID(), user.getWahlbezirkNummer(), user.getWahlbezirksArt(), user.getPin(), user.getAuthorities(),
+                user.getWbid_wahlnummer());
+        copy.setId(user.getId());
+
+        return copy;
+    }
 
     @NaturalId
     @NotNull
@@ -68,7 +77,7 @@ public class User extends BaseEntity {
     @ToString.Include
     private String pin;
 
-    @ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.PERSIST)
+    @ManyToMany(cascade = CascadeType.PERSIST)
     @JoinTable(name = "Secusers_Secauthorities", joinColumns = { @JoinColumn(name = "user_oid") }, inverseJoinColumns = { @JoinColumn(name = "authority_oid") })
     private Set<Authority> authorities;
 

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImpl.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImpl.java
@@ -10,9 +10,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.StreamSupport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -58,8 +60,7 @@ public class UserRepositoryImpl implements UserRepository {
 
         val savedUsers = userRepository.saveAll(users);
 
-        savedUsers.forEach(this::decrypt);
-        return savedUsers;
+        return StreamSupport.stream(savedUsers.spliterator(), false).map(this::decrypt).toList();
     }
 
     public User save(final User user) {
@@ -110,12 +111,14 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     private User decrypt(User user) {
-        val username = user.getUsername();
+        val decryptedUser = User.flatCopyOf(user);
+
+        val username = decryptedUser.getUsername();
         log.debug("decrypting user <{}>...", username);
         if (username != null) {
-            user.setUsername(cryptoService.decrypt(username));
+            decryptedUser.setUsername(cryptoService.decrypt(username));
         }
-        return user;
+        return decryptedUser;
     }
 
     private List<User> decrypt(final Collection<User> users) {
@@ -135,6 +138,7 @@ interface CrudUserRepository extends CrudRepository<User, UUID> {
     @Query("select count(u) from User u where u.username = :username and u.accountNonLocked = false")
     long countUsersLockedByUsername(String username);
 
+    @Modifying
     void deleteUsersByWahltagID(String wahltagID);
 
     Collection<User> findByWahltagID(String wahltagID);

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImpl.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImpl.java
@@ -14,7 +14,6 @@ import java.util.stream.StreamSupport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -138,7 +137,6 @@ interface CrudUserRepository extends CrudRepository<User, UUID> {
     @Query("select count(u) from User u where u.username = :username and u.accountNonLocked = false")
     long countUsersLockedByUsername(String username);
 
-    @Modifying
     void deleteUsersByWahltagID(String wahltagID);
 
     Collection<User> findByWahltagID(String wahltagID);

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplIntegrationTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplIntegrationTest.java
@@ -1,0 +1,144 @@
+package de.muenchen.oss.wahllokalsystem.authservice.domain;
+
+import de.muenchen.oss.wahllokalsystem.authservice.MicroServiceApplication;
+import de.muenchen.oss.wahllokalsystem.authservice.TestConstants;
+import jakarta.persistence.EntityManager;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(classes = MicroServiceApplication.class, properties = { "serviceauth.crypto.key=secret" })
+@ActiveProfiles(TestConstants.SPRING_TEST_PROFILE)
+class UserRepositoryImplIntegrationTest {
+
+    private static final String USERNAME_UNENCRYPTED = "username";
+    private static final String USERNAME_ENCRYPTED = "ENCRYPTED:AcZZ7iVGyYoE-DTb9rNwgQ==";
+
+    @Autowired
+    UserRepositoryImpl userRepository;
+
+    @Autowired
+    CrudUserRepository crudUserRepository;
+
+    @Autowired
+    AuthorityRepository authorityRepository;
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Autowired
+    TransactionTemplate transactionTemplate;
+    @Autowired
+    private PermissionRepository permissionRepository;
+
+    @AfterEach
+    void tearDown() {
+        crudUserRepository.deleteAll();
+        authorityRepository.deleteAll();
+    }
+
+    @Nested
+    class Save {
+
+        @Test
+        void should_encryptUsername_when_savingUser() {
+            val userToSave = new User();
+            userToSave.setUsername(USERNAME_UNENCRYPTED);
+
+            val savedUser = transactionTemplate.execute(status -> userRepository.save(userToSave));
+
+            val result = (User) entityManager.createQuery("SELECT u FROM User u WHERE u.id = :id").setParameter("id", savedUser.getId()).getSingleResult();
+
+            Assertions.assertThat(result.getUsername()).isEqualTo(USERNAME_ENCRYPTED);
+        }
+
+        @Test
+        void should_returnUnencryptedUsername_when_savingUser() {
+            val userToSave = new User();
+            userToSave.setUsername("username");
+
+            val savedUser = transactionTemplate.execute(status -> userRepository.save(userToSave));
+
+            Assertions.assertThat(savedUser.getUsername()).isEqualTo(USERNAME_UNENCRYPTED);
+        }
+    }
+
+    @Nested
+    class FindByUsername {
+
+        @Test
+        void should_returnUser_when_searchingWithUnencryptedUsername() {
+            val userToSave = new User();
+            userToSave.setUsername(USERNAME_UNENCRYPTED);
+
+            val savedUser = transactionTemplate.execute(status -> userRepository.save(userToSave));
+
+            val result = userRepository.findByUsername(USERNAME_UNENCRYPTED);
+
+            Assertions.assertThat(result.get().getId()).isEqualTo(savedUser.getId());
+        }
+    }
+
+    @Nested
+    class Exists {
+
+        @Test
+        void should_returnTrue_when_searchingWithUnencryptedUsernameForExistingUser() {
+            val userToSave = new User();
+            userToSave.setUsername(USERNAME_UNENCRYPTED);
+
+            transactionTemplate.execute(status -> userRepository.save(userToSave));
+
+            val result = userRepository.exists(USERNAME_UNENCRYPTED);
+            Assertions.assertThat(result).isTrue();
+        }
+    }
+
+    @Nested
+    class DeleteUsersByWahltagID {
+
+        @Test
+        void should_do_sth() {
+            val wahltagID = "wahltagID";
+
+            val savedUsers = transactionTemplate.execute(status -> {
+                val permission1 = permissionRepository.save(new Permission("permission1"));
+                val permission2 = permissionRepository.save(new Permission("permission2"));
+                val permission3 = permissionRepository.save(new Permission("permission3"));
+
+                val authority = authorityRepository.save(new Authority("authority1", Set.of(permission1, permission2, permission3), Collections.emptySet()));
+
+                val user1 = userRepository.save(createUser("user1", wahltagID, authority));
+                val user2 = userRepository.save(createUser("user2", wahltagID, authority));
+                val user3 = userRepository.save(createUser("user3", wahltagID, authority));
+
+                return List.of(user1, user2, user3);
+            });
+
+            transactionTemplate.executeWithoutResult(status -> userRepository.deleteUsersByWahltagID(wahltagID));
+
+            Assertions.assertThat(savedUsers).allSatisfy(user -> Assertions.assertThat(crudUserRepository.existsById(user.getId())).isFalse());
+            Assertions.assertThat(authorityRepository.count()).isEqualTo(1);
+            Assertions.assertThat(permissionRepository.count()).isEqualTo(3);
+        }
+
+        private User createUser(final String username, final String wahltagID, final Authority authority) {
+            val user = new User();
+
+            user.setUsername(username);
+            user.setWahltagID(wahltagID);
+            user.setAuthorities(Set.of(authority));
+
+            return user;
+        }
+    }
+}

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplIntegrationTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplIntegrationTest.java
@@ -217,16 +217,6 @@ class UserRepositoryImplIntegrationTest {
             Assertions.assertThat(authorityRepository.count()).isEqualTo(1);
             Assertions.assertThat(permissionRepository.count()).isEqualTo(3);
         }
-
-        private User createUser(final String username, final String wahltagID, final Authority authority) {
-            val user = new User();
-
-            user.setUsername(username);
-            user.setWahltagID(wahltagID);
-            user.setAuthorities(Set.of(authority));
-
-            return user;
-        }
     }
 
     private User createUser(final String encryptedUsername) {
@@ -237,6 +227,16 @@ class UserRepositoryImplIntegrationTest {
         val user = new User();
         user.setUsername(encryptedUsername);
         user.setWahltagID(wahltagID);
+
+        return user;
+    }
+
+    private User createUser(final String username, final String wahltagID, final Authority authority) {
+        val user = new User();
+
+        user.setUsername(username);
+        user.setWahltagID(wahltagID);
+        user.setAuthorities(Set.of(authority));
 
         return user;
     }

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplIntegrationTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplIntegrationTest.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import lombok.val;
+import org.apache.commons.collections4.IterableUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
@@ -47,6 +48,64 @@ class UserRepositoryImplIntegrationTest {
     }
 
     @Nested
+    class FindByWahltagID {
+
+        @Test
+        void should_returnDecryptedUsername_when_gettingUserFromRepo() {
+            val wahltagID = "wahltagID";
+            val userToFind = createUser(USERNAME_ENCRYPTED, wahltagID);
+
+            transactionTemplate.execute(status -> crudUserRepository.save(userToFind));
+
+            val result = userRepository.findByWahltagID(wahltagID);
+
+            Assertions.assertThat(result).hasSize(1);
+            Assertions.assertThat(result).allSatisfy(user -> Assertions.assertThat(user.getUsername()).isEqualTo(USERNAME_UNENCRYPTED));
+        }
+
+        @Test
+        void should_keepTheUsernameEncrypted_when_gettingUserFromRepo() {
+            val wahltagID = "wahltagID";
+            val userToFind = createUser(USERNAME_ENCRYPTED, wahltagID);
+
+            val savedUser = transactionTemplate.execute(status -> crudUserRepository.save(userToFind));
+
+            userRepository.findByWahltagID(wahltagID);
+
+            val userInRepoAfterFindBy = crudUserRepository.findById(savedUser.getId());
+            Assertions.assertThat(userInRepoAfterFindBy.get().getUsername()).isEqualTo(USERNAME_ENCRYPTED);
+        }
+    }
+
+    @Nested
+    class FindById {
+
+        @Test
+        void should_returnDecryptedUsername_when_gettingUserFromRepo() {
+            val userToFind = createUser(USERNAME_ENCRYPTED);
+
+            val savedUser = transactionTemplate.execute(status -> crudUserRepository.save(userToFind));
+
+            val result = userRepository.findById(savedUser.getId());
+
+            Assertions.assertThat(result.get().getUsername()).isEqualTo(USERNAME_UNENCRYPTED);
+        }
+
+        @Test
+        void should_keepTheUsernameEncrypted_when_gettingUserFromRepo() {
+            val userToFind = createUser(USERNAME_ENCRYPTED);
+
+            val savedUser = transactionTemplate.execute(status -> crudUserRepository.save(userToFind));
+
+            userRepository.findById(savedUser.getId());
+
+            val userInRepoAfterFindBy = crudUserRepository.findById(savedUser.getId());
+            Assertions.assertThat(userInRepoAfterFindBy.get().getUsername()).isEqualTo(USERNAME_ENCRYPTED);
+        }
+
+    }
+
+    @Nested
     class Save {
 
         @Test
@@ -69,6 +128,34 @@ class UserRepositoryImplIntegrationTest {
             val savedUser = transactionTemplate.execute(status -> userRepository.save(userToSave));
 
             Assertions.assertThat(savedUser.getUsername()).isEqualTo(USERNAME_UNENCRYPTED);
+        }
+    }
+
+    @Nested
+    class SaveAll {
+
+        @Test
+        void should_encryptUsername_when_savingUser() {
+            val userToSave = new User();
+            userToSave.setUsername(USERNAME_UNENCRYPTED);
+
+            val savedUser = transactionTemplate.execute(status -> userRepository.saveAll(List.of(userToSave)));
+
+            val result = (User) entityManager.createQuery("SELECT u FROM User u WHERE u.id = :id")
+                    .setParameter("id", IterableUtils.toList(savedUser).get(0).getId())
+                    .getSingleResult();
+
+            Assertions.assertThat(result.getUsername()).isEqualTo(USERNAME_ENCRYPTED);
+        }
+
+        @Test
+        void should_returnUnencryptedUsername_when_savingUser() {
+            val userToSave = new User();
+            userToSave.setUsername("username");
+
+            val savedUser = transactionTemplate.execute(status -> userRepository.saveAll(List.of(userToSave)));
+
+            Assertions.assertThat(savedUser).allSatisfy(user -> Assertions.assertThat(user.getUsername()).isEqualTo(USERNAME_UNENCRYPTED));
         }
     }
 
@@ -140,5 +227,17 @@ class UserRepositoryImplIntegrationTest {
 
             return user;
         }
+    }
+
+    private User createUser(final String encryptedUsername) {
+        return createUser(encryptedUsername, null);
+    }
+
+    private User createUser(final String encryptedUsername, final String wahltagID) {
+        val user = new User();
+        user.setUsername(encryptedUsername);
+        user.setWahltagID(wahltagID);
+
+        return user;
     }
 }

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserTest.java
@@ -1,0 +1,42 @@
+package de.muenchen.oss.wahllokalsystem.authservice.domain;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.UUID;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class UserTest {
+
+    @Nested
+    class FlatCopyOf {
+
+        @Test
+        void should_createUserWithNonNUllProperties_when_usingUserWithAllPropertiesSet() {
+            val sourceUser = createUserWithAllPropertiesSet();
+
+            val result = User.flatCopyOf(sourceUser);
+
+            Assertions.assertThat(result).hasNoNullFieldsOrProperties();
+        }
+
+        @Test
+        void should_createUserWithAllPropertiesEqual_when_usingUserWithAllPropertiesSet() {
+            val sourceUser = createUserWithAllPropertiesSet();
+
+            val result = User.flatCopyOf(sourceUser);
+
+            Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(sourceUser);
+        }
+
+        private User createUserWithAllPropertiesSet() {
+            val user = new User("username", "password", "email", true, true, "wahltagID", LocalDate.now(), "wahlbezirkID", "wahlbezirkNummer",
+                    Wahlbezirksart.UWB, "PIN", Collections.emptySet(), "wbid_wahlnummer");
+            user.setId(UUID.randomUUID());
+            return user;
+        }
+    }
+
+}


### PR DESCRIPTION
# Beschreibung:
- im Rahmen von #175 wurde festgestellt dass nach dem Speichern der Username wieder entschlüsselt wurde
  - Grund dafür ist eine managed Entity verändert wurde
- Ein Löschen von Benutzern eines Wahltages war nicht möglich
  - Ursache dafür war das `fetch = EAGER`

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [X] Doku aktualisiert - nichts zu tun
- [X] Swagger-API vollständig - keine Änderungen an der API
- [x] Unit-Tests gepflegt
- [X] Integrationstests gepflegt
- [X] Beispiel-Requests gepflegt - keine Änderungen an der API

# Referenzen[^1]:

Verwandt mit Issue #174

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
