### PR TITLE
exception konstante im encryptionbuilder umbenannt

### DIFF
--- a/wls-common/security/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/security/EncryptionBuilder.java
+++ b/wls-common/security/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/security/EncryptionBuilder.java
@@ -26,8 +26,8 @@ public class EncryptionBuilder {
     private final Cipher decryptionCipher;
 
     public EncryptionBuilder(ServiceIDFormatter formatter,
-            @Qualifier("encryptionCipher") Cipher encryptionCipher,
-            @Qualifier("decryptionCipher") Cipher decryptionCipher) {
+                             @Qualifier("encryptionCipher") Cipher encryptionCipher,
+                             @Qualifier("decryptionCipher") Cipher decryptionCipher) {
         this.formatter = formatter;
         this.encryptionCipher = encryptionCipher;
         this.decryptionCipher = decryptionCipher;
@@ -42,7 +42,7 @@ public class EncryptionBuilder {
             } catch (IllegalBlockSizeException | BadPaddingException e) {
                 log.error("Unable to decrypt the given value <" + value + "> as of an " + e.getClass().getSimpleName() + ". Using direct object reference!", e);
                 throw TechnischeWlsException.withCode(technischeExceptionKonstante).inService(formatter.getId())
-                        .buildWithMessage("Problem bei Referenzierung/Dereferenzierung von Objekt-Referenzen");
+                        .buildWithMessage("Exception" + " " + technischeExceptionKonstante + ":Problem bei Referenzierung/Dereferenzierung von Objekt-Referenzen");
             }
         }
         return value;
@@ -56,7 +56,7 @@ public class EncryptionBuilder {
             } catch (IllegalBlockSizeException | BadPaddingException e) {
                 log.error("Unable to encrypt the given value <" + value + "> as of an " + e.getClass().getSimpleName() + ". Using direct object reference!", e);
                 throw TechnischeWlsException.withCode(technischeExceptionKonstante).inService(formatter.getId())
-                        .buildWithMessage("Problem bei Referenzierung/Dereferenzierung von Objekt-Referenzen");
+                        .buildWithMessage("Exception" + " " + technischeExceptionKonstante + ":Problem bei Referenzierung/Dereferenzierung von Objekt-Referenzen");
             }
         }
         return value;

--- a/wls-common/security/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/security/EncryptionBuilder.java
+++ b/wls-common/security/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/security/EncryptionBuilder.java
@@ -26,8 +26,8 @@ public class EncryptionBuilder {
     private final Cipher decryptionCipher;
 
     public EncryptionBuilder(ServiceIDFormatter formatter,
-                             @Qualifier("encryptionCipher") Cipher encryptionCipher,
-                             @Qualifier("decryptionCipher") Cipher decryptionCipher) {
+            @Qualifier("encryptionCipher") Cipher encryptionCipher,
+            @Qualifier("decryptionCipher") Cipher decryptionCipher) {
         this.formatter = formatter;
         this.encryptionCipher = encryptionCipher;
         this.decryptionCipher = decryptionCipher;
@@ -42,7 +42,8 @@ public class EncryptionBuilder {
             } catch (IllegalBlockSizeException | BadPaddingException e) {
                 log.error("Unable to decrypt the given value <" + value + "> as of an " + e.getClass().getSimpleName() + ". Using direct object reference!", e);
                 throw TechnischeWlsException.withCode(technischeExceptionKonstante).inService(formatter.getId())
-                        .buildWithMessage("Exception" + " " + technischeExceptionKonstante + ":Problem bei Referenzierung/Dereferenzierung von Objekt-Referenzen");
+                        .buildWithMessage(
+                                "Exception" + " " + technischeExceptionKonstante + ":Problem bei Referenzierung/Dereferenzierung von Objekt-Referenzen");
             }
         }
         return value;
@@ -56,7 +57,8 @@ public class EncryptionBuilder {
             } catch (IllegalBlockSizeException | BadPaddingException e) {
                 log.error("Unable to encrypt the given value <" + value + "> as of an " + e.getClass().getSimpleName() + ". Using direct object reference!", e);
                 throw TechnischeWlsException.withCode(technischeExceptionKonstante).inService(formatter.getId())
-                        .buildWithMessage("Exception" + " " + technischeExceptionKonstante + ":Problem bei Referenzierung/Dereferenzierung von Objekt-Referenzen");
+                        .buildWithMessage(
+                                "Exception" + " " + technischeExceptionKonstante + ":Problem bei Referenzierung/Dereferenzierung von Objekt-Referenzen");
             }
         }
         return value;

--- a/wls-common/security/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/security/EncryptionBuilder.java
+++ b/wls-common/security/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/security/EncryptionBuilder.java
@@ -26,8 +26,8 @@ public class EncryptionBuilder {
     private final Cipher decryptionCipher;
 
     public EncryptionBuilder(ServiceIDFormatter formatter,
-            @Qualifier("encryptionCipher") Cipher encryptionCipher,
-            @Qualifier("decryptionCipher") Cipher decryptionCipher) {
+                             @Qualifier("encryptionCipher") Cipher encryptionCipher,
+                             @Qualifier("decryptionCipher") Cipher decryptionCipher) {
         this.formatter = formatter;
         this.encryptionCipher = encryptionCipher;
         this.decryptionCipher = decryptionCipher;
@@ -42,8 +42,7 @@ public class EncryptionBuilder {
             } catch (IllegalBlockSizeException | BadPaddingException e) {
                 log.error("Unable to decrypt the given value <" + value + "> as of an " + e.getClass().getSimpleName() + ". Using direct object reference!", e);
                 throw TechnischeWlsException.withCode(technischeExceptionKonstante).inService(formatter.getId())
-                        .buildWithMessage(
-                                "Exception" + " " + technischeExceptionKonstante + ":Problem bei Referenzierung/Dereferenzierung von Objekt-Referenzen");
+                        .buildWithMessage("Problem bei Referenzierung/Dereferenzierung von Objekt-Referenzen");
             }
         }
         return value;
@@ -57,8 +56,7 @@ public class EncryptionBuilder {
             } catch (IllegalBlockSizeException | BadPaddingException e) {
                 log.error("Unable to encrypt the given value <" + value + "> as of an " + e.getClass().getSimpleName() + ". Using direct object reference!", e);
                 throw TechnischeWlsException.withCode(technischeExceptionKonstante).inService(formatter.getId())
-                        .buildWithMessage(
-                                "Exception" + " " + technischeExceptionKonstante + ":Problem bei Referenzierung/Dereferenzierung von Objekt-Referenzen");
+                        .buildWithMessage("Problem bei Referenzierung/Dereferenzierung von Objekt-Referenzen");
             }
         }
         return value;

--- a/wls-common/security/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/security/EncryptionBuilder.java
+++ b/wls-common/security/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/security/EncryptionBuilder.java
@@ -26,8 +26,8 @@ public class EncryptionBuilder {
     private final Cipher decryptionCipher;
 
     public EncryptionBuilder(ServiceIDFormatter formatter,
-                             @Qualifier("encryptionCipher") Cipher encryptionCipher,
-                             @Qualifier("decryptionCipher") Cipher decryptionCipher) {
+            @Qualifier("encryptionCipher") Cipher encryptionCipher,
+            @Qualifier("decryptionCipher") Cipher decryptionCipher) {
         this.formatter = formatter;
         this.encryptionCipher = encryptionCipher;
         this.decryptionCipher = decryptionCipher;

--- a/wls-common/security/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/security/EncryptionBuilder.java
+++ b/wls-common/security/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/security/EncryptionBuilder.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
 public class EncryptionBuilder {
 
     private static final Logger log = LoggerFactory.getLogger(EncryptionBuilder.class);
-    private static final String technischeExceptionKonstante = "S";
+    private static final String technischeExceptionKonstante = "399";
 
     private final ServiceIDFormatter formatter;
     private final Cipher encryptionCipher;

--- a/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/EncryptionBuilderTest.java
+++ b/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/EncryptionBuilderTest.java
@@ -70,6 +70,16 @@ class EncryptionBuilderTest {
             Assertions.assertThatThrownBy(() -> unitUnderTest.decryptValue("Mzc2NTI2NzIzQUZEQUIzRA=="))
                     .isInstanceOf(TechnischeWlsException.class);
         }
+
+        @Test
+        void correctExceptionCodeIsThrown() throws IllegalBlockSizeException, BadPaddingException {
+            val mockedIllegalBlockSizeException = new IllegalBlockSizeException("MockedIllegalBlockSize");
+            Mockito.when(formatter.getId()).thenReturn("1");
+            Mockito.when(cipher.doFinal("376526723AFDAB3D".getBytes())).thenThrow(mockedIllegalBlockSizeException);
+
+            Assertions.assertThatThrownBy(() -> unitUnderTest.decryptValue("Mzc2NTI2NzIzQUZEQUIzRA=="))
+                    .hasMessageContaining("399");
+        }
     }
 
     @Nested
@@ -109,6 +119,16 @@ class EncryptionBuilderTest {
 
             Assertions.assertThatThrownBy(() -> unitUnderTest.encryptValue("Mzc2NTI2NzIzQUZEQUIzRA=="))
                     .isInstanceOf(TechnischeWlsException.class);
+        }
+
+        @Test
+        void correctExceptionCodeIsThrown() throws IllegalBlockSizeException, BadPaddingException {
+            val mockedIllegalBlockSizeException = new IllegalBlockSizeException("MockedIllegalBlockSize");
+            Mockito.when(formatter.getId()).thenReturn("1");
+            Mockito.when(cipher.doFinal("Mzc2NTI2NzIzQUZEQUIzRA==".getBytes())).thenThrow(mockedIllegalBlockSizeException);
+
+            Assertions.assertThatThrownBy(() -> unitUnderTest.encryptValue("Mzc2NTI2NzIzQUZEQUIzRA=="))
+                    .hasMessageContaining("399");
         }
     }
 }

--- a/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/EncryptionBuilderTest.java
+++ b/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/EncryptionBuilderTest.java
@@ -78,7 +78,7 @@ class EncryptionBuilderTest {
             Mockito.when(cipher.doFinal("376526723AFDAB3D".getBytes())).thenThrow(mockedIllegalBlockSizeException);
 
             Assertions.assertThatThrownBy(() -> unitUnderTest.decryptValue("Mzc2NTI2NzIzQUZEQUIzRA=="))
-                    .hasMessageContaining("399");
+                    .hasFieldOrPropertyWithValue("code", "399");
         }
     }
 
@@ -124,11 +124,12 @@ class EncryptionBuilderTest {
         @Test
         void correctExceptionCodeIsThrown() throws IllegalBlockSizeException, BadPaddingException {
             val mockedIllegalBlockSizeException = new IllegalBlockSizeException("MockedIllegalBlockSize");
+
             Mockito.when(formatter.getId()).thenReturn("1");
             Mockito.when(cipher.doFinal("Mzc2NTI2NzIzQUZEQUIzRA==".getBytes())).thenThrow(mockedIllegalBlockSizeException);
 
             Assertions.assertThatThrownBy(() -> unitUnderTest.encryptValue("Mzc2NTI2NzIzQUZEQUIzRA=="))
-                    .hasMessageContaining("399");
+                    .hasFieldOrPropertyWithValue("code", "399");
         }
     }
 }


### PR DESCRIPTION
# Beschreibung:

Die Exception-Konstante zur technischen WLS-Exception im Encryption-Builder wurde zu 399 umbenannt. Gründe für die Wahl dieses Codes: In den Exception-Konstanten des Basisdatenservices sind 300 bis ca. 350 vergeben. Würde man die Konstante vom EncryptionBuilder dort miteinbauen, müsste man die dependencies für den Basisdatenservice ergänzen, wo wir hier die Abhängigkeit nicht wollen.
Durchaus evtl. Punkt zur Diskussion.


Closes #171

