### PR TITLE
Port in env für http test files 8206

### DIFF
--- a/wls-monitoring-service/src/test/resources/http.request/http-client.env.json
+++ b/wls-monitoring-service/src/test/resources/http.request/http-client.env.json
@@ -2,7 +2,7 @@
   "docker": {
     "token_type": "",
     "auth_token": "",
-    "WLS_MONITORING_SERVICE_URL": "http://localhost:8201",
+    "WLS_MONITORING_SERVICE_URL": "http://localhost:8206",
     "SSO_URL": "http://kubernetes.docker.internal:8100"
   },
   "nonDocker": {


### PR DESCRIPTION
# Beschreibung:

Die Portnummer für Profil "docker" im http-client.env ist richtig 8206, war falsch 8201.

Closes #524 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
