### PR TITLE
Authservice - Configure max-http-request-header-size: 32KB

### DIFF
--- a/wls-auth-service/src/main/resources/application.yml
+++ b/wls-auth-service/src/main/resources/application.yml
@@ -37,6 +37,7 @@ server:
     include-stacktrace: never
     whitelabel:
       enabled: false
+  max-http-request-header-size: 32KB
 
 # Config for spring actuator endpoints
 management:


### PR DESCRIPTION
# Beschreibung:

Größere RequestHeader erlauben, analog zu #318

## Definition of Done (DoD):

# Referenzen[^1]:

Verwandt mit Issue #318

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
