### PR TITLE
kopfdaten saveAll Rechte angepasst

### DIFF
--- a/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/domain/kopfdaten/KopfdatenRepository.java
+++ b/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/domain/kopfdaten/KopfdatenRepository.java
@@ -29,6 +29,10 @@ public interface KopfdatenRepository extends CrudRepository<Kopfdaten, BezirkUnd
     <S extends Kopfdaten> S save(S kopfdaten);
 
     @Override
+    @PreAuthorize("hasAuthority('Basisdaten_WRITE_Kopfdaten')")
+    <S extends Kopfdaten> Iterable<S> saveAll(Iterable<S> iterable);
+
+    @Override
     @CacheEvict(value = CACHE, key = "#p0")
     @PreAuthorize("hasAuthority('Basisdaten_DELETE_Kopfdaten')")
     void deleteById(BezirkUndWahlID bezirkUndWahlID);

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/utils/Authorities.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/utils/Authorities.java
@@ -80,7 +80,7 @@ public class Authorities {
     public static final String S2S_INFOMANAGEMENT_REPOSITORY_WRITE_KONFIGURIERTERWAHLTAG = "Infomanagement_WRITE_KonfigurierterWahltag";
     public static final String S2S_INFOMANAGEMENT_REPOSITORY_DELETE_KONFIGURIERTERWAHLTAG = "Infomanagement_DELETE_KonfigurierterWahltag";
 
-    public static final String[] ALL_AUTHORITIES_GET_WAHLVORSCHLAEGE = new String[]{
+    public static final String[] ALL_AUTHORITIES_GET_WAHLVORSCHLAEGE = new String[] {
             SERVICE_GET_WAHLVORSCHLAEGE,
             REPOSITORY_READ_WAHLVORSCHLAEGE,
             REPOSITORY_WRITE_WAHLVORSCHLAEGE,

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/utils/Authorities.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/utils/Authorities.java
@@ -80,7 +80,7 @@ public class Authorities {
     public static final String S2S_INFOMANAGEMENT_REPOSITORY_WRITE_KONFIGURIERTERWAHLTAG = "Infomanagement_WRITE_KonfigurierterWahltag";
     public static final String S2S_INFOMANAGEMENT_REPOSITORY_DELETE_KONFIGURIERTERWAHLTAG = "Infomanagement_DELETE_KonfigurierterWahltag";
 
-    public static final String[] ALL_AUTHORITIES_GET_WAHLVORSCHLAEGE = new String[] {
+    public static final String[] ALL_AUTHORITIES_GET_WAHLVORSCHLAEGE = new String[]{
             SERVICE_GET_WAHLVORSCHLAEGE,
             REPOSITORY_READ_WAHLVORSCHLAEGE,
             REPOSITORY_WRITE_WAHLVORSCHLAEGE,
@@ -208,7 +208,7 @@ public class Authorities {
 
             REPOSITORY_WRITE_WAHL,
             REPOSITORY_WRITE_WAHLBEZIRK,
-            REPOSITORY_READ_KOPFDATEN
+            REPOSITORY_WRITE_KOPFDATEN
     };
 
     public static final String[] ALL_AUTHORITIES_PUT_WAHLTERMINDATEN_THAT_GOT_CATCHED_ON_MISSING = {


### PR DESCRIPTION
# Beschreibung:

Das kopfdatenRepo überschreibt jetzt saveAll und erfordert damit statt read-Rechte die write-Rechte, wie es sein sollte.

## Definition of Done (DoD):

### Backend ###
- [x] Unit-Tests gepflegt
- [x] Integrationstests gepflegt

Closes #466
