### PR TITLE
:recycle: rename authorities + combine security tests

### DIFF
--- a/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/integration/BroadcastIntegrationTest.java
+++ b/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/integration/BroadcastIntegrationTest.java
@@ -2,9 +2,10 @@ package de.muenchen.oss.wahllokalsystem.broadcastservice.integration;
 
 import static de.muenchen.oss.wahllokalsystem.broadcastservice.TestConstants.SPRING_NO_SECURITY_PROFILE;
 import static de.muenchen.oss.wahllokalsystem.broadcastservice.TestConstants.SPRING_TEST_PROFILE;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.muenchen.oss.wahllokalsystem.broadcastservice.MicroServiceApplication;
 import de.muenchen.oss.wahllokalsystem.broadcastservice.domain.Message;
@@ -13,9 +14,9 @@ import de.muenchen.oss.wahllokalsystem.broadcastservice.rest.BroadcastMessageDTO
 import de.muenchen.oss.wahllokalsystem.broadcastservice.service.BroadcastMapper;
 import de.muenchen.oss.wahllokalsystem.broadcastservice.util.BroadcastExceptionKonstanten;
 import de.muenchen.oss.wahllokalsystem.broadcastservice.utils.Authorities;
-import de.muenchen.oss.wahllokalsystem.wls.common.testing.SecurityUtils;
 import de.muenchen.oss.wahllokalsystem.broadcastservice.utils.Testdaten;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.FachlicheWlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.testing.SecurityUtils;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -87,7 +88,7 @@ public class BroadcastIntegrationTest {
                 .apply(SecurityMockMvcConfigurers.springSecurity())
                 .build();
 
-        SecurityUtils.runWith(Authorities.getAllAuthorities());
+        SecurityUtils.runWith(Authorities.ALL_BROADCAST_AUTHORITIES);
         messageRepository.deleteAll();
     }
 

--- a/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/security/BroadcastSecurityTest.java
+++ b/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/security/BroadcastSecurityTest.java
@@ -9,11 +9,16 @@ import de.muenchen.oss.wahllokalsystem.broadcastservice.utils.Authorities;
 import de.muenchen.oss.wahllokalsystem.wls.common.testing.SecurityUtils;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.access.AccessDeniedException;
@@ -47,33 +52,21 @@ public class BroadcastSecurityTest {
                     .isThrownBy(() -> broadcastService.broadcast(null)).withMessageStartingWith("Access Denied");
         }
 
-        @Test
-        void accessDenied_missingOneAuthority_BROADCAST_WRITE_MESSAGE() {
-            SecurityUtils.runWith(Authorities.BROADCAST_BUSINESSACTION_BROADCAST);
+        @ParameterizedTest(name = "{index} - {1} missing")
+        @MethodSource("getMissingAuthoritiesVariations")
+        void should_throwAccessDeniedException_when_anyAuthorityMissing(final ArgumentsAccessor argumentsAccessor) {
+            SecurityUtils.runWith(argumentsAccessor.get(0, String[].class));
 
             List<String> wahlbezirke = Arrays.asList("1", "2", "3", "4");
             BroadcastMessageDTO m1 = new BroadcastMessageDTO(wahlbezirke, "I should fail");
             Assertions.assertThatExceptionOfType(AccessDeniedException.class)
                     .isThrownBy(() -> broadcastService.broadcast(m1))
                     .withMessageStartingWith("Access Denied");
-
-        }
-
-        @Test
-        void accessDenied_missingOneAuthority_BROADCAST_BUSINESSACTION_BROADCAST() {
-            List<String> wahlbezirke = Arrays.asList("1", "2", "3", "4");
-            BroadcastMessageDTO m1 = new BroadcastMessageDTO(wahlbezirke, "I should fail");
-            SecurityUtils.runWith(Authorities.BROADCAST_WRITE_MESSAGE);
-
-            Assertions.assertThatExceptionOfType(AccessDeniedException.class)
-                    .isThrownBy(() -> broadcastService.broadcast(m1))
-                    .withMessageStartingWith("Access Denied");
-
         }
 
         @Test
         void accessPositive() {
-            SecurityUtils.runWith(Authorities.BROADCAST_BUSINESSACTION_BROADCAST, Authorities.BROADCAST_WRITE_MESSAGE);
+            SecurityUtils.runWith(Authorities.ALL_AUTHORITIES_POST_BROADCAST);
             List<String> wahlbezirke = Arrays.asList("1", "2", "3", "4");
             BroadcastMessageDTO m1 = new BroadcastMessageDTO(wahlbezirke, "I should have access");
 
@@ -81,6 +74,9 @@ public class BroadcastSecurityTest {
                     .doesNotThrowAnyException();
         }
 
+        private static Stream<Arguments> getMissingAuthoritiesVariations() {
+            return SecurityUtils.buildArgumentsForMissingAuthoritiesVariations(Authorities.ALL_AUTHORITIES_POST_BROADCAST);
+        }
     }
 
     @Nested
@@ -94,18 +90,23 @@ public class BroadcastSecurityTest {
                     .withMessageStartingWith("Access Denied");
         }
 
-        @Test
-        void accessDenied_missing_Role_BROADCAST_BUSINESSACTION_NACHRICHTABRUFEN() {
-            SecurityUtils.runWith(Authorities.BROADCAST_BUSINESSACTION_BROADCAST);
+        @ParameterizedTest(name = "{index} - {1} missing")
+        @MethodSource("getMissingAuthoritiesVariations")
+        void should_throwAccessDeniedException_when_anyAuthorityMissing(final ArgumentsAccessor argumentsAccessor) {
+            SecurityUtils.runWith(argumentsAccessor.get(0, String[].class));
 
             Assertions.assertThatExceptionOfType(AccessDeniedException.class)
                     .isThrownBy(() -> broadcastService.getOldestMessage("wahlbezirkId"))
                     .withMessageStartingWith("Access Denied");
         }
 
+        private static Stream<Arguments> getMissingAuthoritiesVariations() {
+            return SecurityUtils.buildArgumentsForMissingAuthoritiesVariations(Authorities.ALL_AUTHORITIES_GET_BROADCAST);
+        }
+
         @Test
         void accessPositiveTest_Role_BROADCAST_BUSINESSACTION_NACHRICHTABRUFEN() {
-            SecurityUtils.runWith(Authorities.BROADCAST_BUSINESSACTION_NACHRICHTABRUFEN, Authorities.BROADCAST_READ_MESSAGE);
+            SecurityUtils.runWith(Authorities.ALL_AUTHORITIES_GET_BROADCAST);
             Assertions.assertThatThrownBy(() -> broadcastService.getOldestMessage("wahlbezirkId")).isNotInstanceOf(AccessDeniedException.class);
         }
     }
@@ -121,31 +122,25 @@ public class BroadcastSecurityTest {
                     .withMessageStartingWith("Access Denied");
         }
 
-        @Test
-        void accessDenied_missing_Role_BROADCAST_DELETE_MESSAGE() {
-            SecurityUtils.runWith(Authorities.BROADCAST_BUSINESSACTION_NACHRICHTGELESEN);
+        @ParameterizedTest(name = "{index} - {1} missing")
+        @MethodSource("getMissingAuthoritiesVariations")
+        void should_throwAccessDeniedException_when_anyAuthorityMissing(final ArgumentsAccessor argumentsAccessor) {
+            SecurityUtils.runWith(argumentsAccessor.get(0, String[].class));
             Assertions.assertThatExceptionOfType(AccessDeniedException.class)
                     .isThrownBy(() -> broadcastService.deleteMessage("1-2-3-4-5"))
                     .withMessageStartingWith("Access Denied");
-
-        }
-
-        @Test
-        void accessDenied_missing_Role_BROADCAST_BUSINESSACTION_NACHRICHTGELESEN() {
-            SecurityUtils.runWith(Authorities.BROADCAST_DELETE_MESSAGE);
-            Assertions.assertThatExceptionOfType(AccessDeniedException.class)
-                    .isThrownBy(() -> broadcastService.deleteMessage("1-2-3-4-5"))
-                    .withMessageStartingWith("Access Denied");
-
         }
 
         @Test
         void accessPositive() {
-            SecurityUtils.runWith(Authorities.BROADCAST_BUSINESSACTION_NACHRICHTGELESEN, Authorities.BROADCAST_DELETE_MESSAGE);
+            SecurityUtils.runWith(Authorities.ALL_AUTHORITIES_DELETE_BROADCAST);
             Assertions.assertThatCode(() -> broadcastService.deleteMessage("1-2-3-4-5"))
                     .doesNotThrowAnyException();
         }
 
+        private static Stream<Arguments> getMissingAuthoritiesVariations() {
+            return SecurityUtils.buildArgumentsForMissingAuthoritiesVariations(Authorities.ALL_AUTHORITIES_DELETE_BROADCAST);
+        }
     }
 
 }

--- a/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/utils/Authorities.java
+++ b/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/utils/Authorities.java
@@ -6,23 +6,35 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Authorities {
 
-    public static String BROADCAST_BUSINESSACTION_BROADCAST = "Broadcast_BUSINESSACTION_Broadcast";
-    public static String BROADCAST_BUSINESSACTION_NACHRICHTABRUFEN = "Broadcast_BUSINESSACTION_GetMessage";
-    public static String BROADCAST_BUSINESSACTION_NACHRICHTGELESEN = "Broadcast_BUSINESSACTION_MessageRead";
+    public static String SERVICE_POST_MESSAGE = "Broadcast_BUSINESSACTION_Broadcast";
+    public static String SERVICE_GET_MESSAGE = "Broadcast_BUSINESSACTION_GetMessage";
+    public static String SERVICE_READ_MESSAGE = "Broadcast_BUSINESSACTION_MessageRead";
 
-    public static String BROADCAST_READ_MESSAGE = "Broadcast_READ_Message";
-    public static String BROADCAST_WRITE_MESSAGE = "Broadcast_WRITE_Message";
-    public static String BROADCAST_DELETE_MESSAGE = "Broadcast_DELETE_Message";
+    public static String REPOSITORY_READ_MESSAGE = "Broadcast_READ_Message";
+    public static String REPOSITORY_WRITE_MESSAGE = "Broadcast_WRITE_Message";
+    public static String REPOSITORY_DELETE_MESSAGE = "Broadcast_DELETE_Message";
 
-    public static String[] getAllAuthorities() {
-        return new String[] {
-                BROADCAST_BUSINESSACTION_BROADCAST,
-                BROADCAST_BUSINESSACTION_NACHRICHTABRUFEN,
-                BROADCAST_BUSINESSACTION_NACHRICHTGELESEN,
+    public static final String[] ALL_BROADCAST_AUTHORITIES = {
+            SERVICE_POST_MESSAGE,
+            SERVICE_GET_MESSAGE,
+            SERVICE_READ_MESSAGE,
+            REPOSITORY_READ_MESSAGE,
+            REPOSITORY_WRITE_MESSAGE,
+            REPOSITORY_DELETE_MESSAGE
+    };
 
-                BROADCAST_READ_MESSAGE,
-                BROADCAST_WRITE_MESSAGE,
-                BROADCAST_DELETE_MESSAGE
-        };
-    }
+    public static final String[] ALL_AUTHORITIES_POST_BROADCAST = {
+            SERVICE_POST_MESSAGE,
+            REPOSITORY_WRITE_MESSAGE
+    };
+
+    public static final String[] ALL_AUTHORITIES_GET_BROADCAST = {
+            SERVICE_GET_MESSAGE,
+            REPOSITORY_READ_MESSAGE
+    };
+
+    public static final String[] ALL_AUTHORITIES_DELETE_BROADCAST = {
+            SERVICE_READ_MESSAGE,
+            REPOSITORY_DELETE_MESSAGE
+    };
 }


### PR DESCRIPTION
# Beschreibung:

Analog zu anderen Services wurden die Authorities für die Tests umbenannt in `SERVICE_{METHOD}_MESSAGE` und `REPOSITORY_{METHOD}_MESSAGE`. 
Die Methode `getMissingAuthoritiesVariations()` wurde für die ServiceSecurityTests eingeführt, um die Anzahl der Tests zu verringern und einheitlich zu den anderen Services zu sein.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [ ] ~Doku aktualisiert~ - nichts zutun
- [ ] ~Swagger-API vollständig~ - nichts zutun
- [x] Unit-Tests gepflegt
- [x] Integrationstests gepflegt
- [ ] ~Beispiel-Requests gepflegt~ - nichts zutun
