### PR TITLE
547 fehler wegen immutable username bei klasse user - fix mit remove von naturalID

### DIFF
--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/User.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/User.java
@@ -19,7 +19,6 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.val;
-import org.hibernate.annotations.NaturalId;
 
 @Entity
 @Table(name = "Wlsuser") //user as table name is already in use by h2
@@ -39,7 +38,6 @@ public class User extends BaseEntity {
         return copy;
     }
 
-    @NaturalId
     @NotNull
     @Size(min = 1)
     @ToString.Include

--- a/wls-auth-service/src/main/resources/application-test.yml
+++ b/wls-auth-service/src/main/resources/application-test.yml
@@ -1,15 +1,13 @@
 spring:
 
+  flyway:
+    enabled: true
   # Spring JPA
   h2.console.enabled: true
   jpa:
     database: H2
     hibernate:
-      # always drop and create the db should be the best
-      # configuration for local (development) mode. this
-      # is also the default, that spring offers by convention.
-      # but here explicite:
-      ddl-auto: create-drop
+      ddl-auto: validate
       naming.physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     # Logging for database operation
     show-sql: true

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplIntegrationTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplIntegrationTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -129,6 +130,19 @@ class UserRepositoryImplIntegrationTest {
 
             Assertions.assertThat(savedUser.getUsername()).isEqualTo(USERNAME_UNENCRYPTED);
         }
+
+        @Test
+        void should_throwException_whenUserWithUsernameAlreadyExists() {
+            val userToSave = new User();
+            userToSave.setUsername(USERNAME_UNENCRYPTED);
+
+            transactionTemplate.execute(status -> userRepository.save(userToSave));
+
+            val userToSaveWithSameUsername = new User();
+            userToSaveWithSameUsername.setUsername(USERNAME_UNENCRYPTED);
+            Assertions.assertThatException().isThrownBy(() -> transactionTemplate.execute(status -> userRepository.save(userToSaveWithSameUsername)))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
     }
 
     @Nested
@@ -216,6 +230,42 @@ class UserRepositoryImplIntegrationTest {
             Assertions.assertThat(savedUsers).allSatisfy(user -> Assertions.assertThat(crudUserRepository.existsById(user.getId())).isFalse());
             Assertions.assertThat(authorityRepository.count()).isEqualTo(1);
             Assertions.assertThat(permissionRepository.count()).isEqualTo(3);
+        }
+    }
+
+    @Nested
+    class OnSchedule {
+
+        @Test
+        void should_encryptExistingUsers_when_usersExists() {
+            val wahltagID = "wahltagID";
+            val userToEncrypt = createUser(USERNAME_UNENCRYPTED, wahltagID);
+
+            val savedSavedUnencryptedUser = transactionTemplate.execute(status -> crudUserRepository.save(userToEncrypt));
+
+            transactionTemplate.executeWithoutResult(status -> userRepository.onSchedule());
+
+            val userAfterEncryption = crudUserRepository.findById(savedSavedUnencryptedUser.getId()).get();
+
+            Assertions.assertThat(userAfterEncryption.getUsername()).isEqualTo(USERNAME_ENCRYPTED);
+        }
+    }
+
+    @Nested
+    class OnInit {
+
+        @Test
+        void should_encryptExistingUsers_when_usersExists() {
+            val wahltagID = "wahltagID";
+            val userToEncrypt = createUser(USERNAME_UNENCRYPTED, wahltagID);
+
+            val savedSavedUnencryptedUser = transactionTemplate.execute(status -> crudUserRepository.save(userToEncrypt));
+
+            transactionTemplate.executeWithoutResult(status -> userRepository.onSchedule());
+
+            val userAfterEncryption = crudUserRepository.findById(savedSavedUnencryptedUser.getId()).get();
+
+            Assertions.assertThat(userAfterEncryption.getUsername()).isEqualTo(USERNAME_ENCRYPTED);
         }
     }
 

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplIntegrationTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplIntegrationTest.java
@@ -171,6 +171,19 @@ class UserRepositoryImplIntegrationTest {
 
             Assertions.assertThat(savedUser).allSatisfy(user -> Assertions.assertThat(user.getUsername()).isEqualTo(USERNAME_UNENCRYPTED));
         }
+
+        @Test
+        void should_throwException_whenMultipleUsersHaveSameName() {
+            val user1 = new User();
+            user1.setUsername(USERNAME_UNENCRYPTED);
+            val user2 = new User();
+            user2.setUsername(USERNAME_UNENCRYPTED);
+
+            val userToSaveWithSameUsername = new User();
+            userToSaveWithSameUsername.setUsername(USERNAME_UNENCRYPTED);
+            Assertions.assertThatException().isThrownBy(() -> transactionTemplate.execute(status -> userRepository.saveAll(List.of(user1, user2))))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
     }
 
     @Nested

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplIntegrationTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplIntegrationTest.java
@@ -274,7 +274,7 @@ class UserRepositoryImplIntegrationTest {
 
             val savedSavedUnencryptedUser = transactionTemplate.execute(status -> crudUserRepository.save(userToEncrypt));
 
-            transactionTemplate.executeWithoutResult(status -> userRepository.onSchedule());
+            transactionTemplate.executeWithoutResult(status -> userRepository.onInit());
 
             val userAfterEncryption = crudUserRepository.findById(savedSavedUnencryptedUser.getId()).get();
 

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplIntegrationTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/UserRepositoryImplIntegrationTest.java
@@ -132,7 +132,7 @@ class UserRepositoryImplIntegrationTest {
         }
 
         @Test
-        void should_throwException_whenUserWithUsernameAlreadyExists() {
+        void should_throwException_when_userWithUsernameAlreadyExists() {
             val userToSave = new User();
             userToSave.setUsername(USERNAME_UNENCRYPTED);
 
@@ -173,7 +173,7 @@ class UserRepositoryImplIntegrationTest {
         }
 
         @Test
-        void should_throwException_whenMultipleUsersHaveSameName() {
+        void should_throwException_when_multipleUsersHaveSameName() {
             val user1 = new User();
             user1.setUsername(USERNAME_UNENCRYPTED);
             val user2 = new User();


### PR DESCRIPTION
# Beschreibung:

- Fehlende Tests ergänzt
- NaturalID entfernt aber Prüfung auf unique ergänzt (als Test) da der Username weiterhin Unique sein muss

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [X] Doku aktualisiert - nix zu tun
- [X] Swagger-API vollständig - nix zu tun
- [X] Unit-Tests gepflegt - nur Integrationstests
- [X] Integrationstests gepflegt
- [X] Beispiel-Requests gepflegt - nix zu tun

# Referenzen[^1]:

Verwandt mit Issue #

Closes #547

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
