### PR TITLE
574 es werden keine authorities mit dem benutzer mitgeliefert

### DIFF
--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Authority.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Authority.java
@@ -8,15 +8,15 @@ import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import java.util.Set;
 import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.annotations.NaturalId;
 
 @Entity
-@Data
-@EqualsAndHashCode(callSuper = true)
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(onlyExplicitlyIncluded = true)

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/BaseEntity.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/BaseEntity.java
@@ -4,19 +4,22 @@
  */
 package de.muenchen.oss.wahllokalsystem.authservice.domain;
 
+import static java.sql.Types.VARCHAR;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
-import lombok.*;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.JdbcTypeCode;
-
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.UUID;
-
-import static java.sql.Types.VARCHAR;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.val;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.JdbcTypeCode;
 
 @MappedSuperclass
 @NoArgsConstructor

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/BaseEntity.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/BaseEntity.java
@@ -12,7 +12,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import java.io.Serializable;
 import java.util.UUID;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -25,7 +24,6 @@ import org.hibernate.annotations.JdbcTypeCode;
 @Getter
 @Setter
 @ToString
-@EqualsAndHashCode
 public abstract class BaseEntity implements Cloneable, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/BaseEntity.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/BaseEntity.java
@@ -4,20 +4,19 @@
  */
 package de.muenchen.oss.wahllokalsystem.authservice.domain;
 
-import static java.sql.Types.VARCHAR;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
-import java.io.Serializable;
-import java.util.UUID;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.JdbcTypeCode;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.UUID;
+
+import static java.sql.Types.VARCHAR;
 
 @MappedSuperclass
 @NoArgsConstructor
@@ -35,4 +34,17 @@ public abstract class BaseEntity implements Cloneable, Serializable {
     @JdbcTypeCode(VARCHAR)
     private UUID id;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass() || id == null) return false;
+
+        val that = (BaseEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return 42;
+    }
 }

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttempt.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttempt.java
@@ -6,15 +6,15 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.annotations.NaturalId;
 
 @Entity
-@Data
-@EqualsAndHashCode(callSuper = true)
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(onlyExplicitlyIncluded = true)

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Permission.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/Permission.java
@@ -2,14 +2,14 @@ package de.muenchen.oss.wahllokalsystem.authservice.domain;
 
 import jakarta.persistence.Entity;
 import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 @Entity
-@Data
-@EqualsAndHashCode(callSuper = true)
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(onlyExplicitlyIncluded = true)

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/User.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/domain/User.java
@@ -14,16 +14,16 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.util.Set;
 import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import lombok.val;
 
 @Entity
 @Table(name = "Wlsuser") //user as table name is already in use by h2
-@Data
-@EqualsAndHashCode(callSuper = true)
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(onlyExplicitlyIncluded = true)

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/BaseEntityTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/BaseEntityTest.java
@@ -1,0 +1,108 @@
+package de.muenchen.oss.wahllokalsystem.authservice.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+class BaseEntityTest {
+
+    private static final String UUID_STRING_1 = "8b87b673-1eb0-480f-a0e6-622ef860f790";
+    private static final String UUID_STRING_2 = "f804b2b0-d259-4a7d-b246-156ea545dc63";
+
+    @Nested
+    class HashCode {
+
+        @Test
+        void should_haveEqualHashCode_when_objectAreEqual() {
+
+            val baseEntity1 = new BaseEntityWrapper();
+            baseEntity1.setId(UUID.fromString(UUID_STRING_1));
+
+            val baseEntity2 = new BaseEntityWrapper();
+            baseEntity2.setId(UUID.fromString(UUID_STRING_1));
+
+            Assertions.assertThat(baseEntity1.hashCode()).isEqualTo(baseEntity2.hashCode());
+        }
+    }
+
+    @Nested
+    class Equals {
+
+        @Test
+        void should_beEqual_when_idOfObjectAreEqualButOtherPropertiesNot() {
+            val baseEntity1 = new BaseEntityWrapper("textOfEntity1");
+            baseEntity1.setId(UUID.fromString(UUID_STRING_1));
+
+            val baseEntity2 = new BaseEntityWrapper("textOfEntity2");
+            baseEntity2.setId(UUID.fromString(UUID_STRING_1));
+
+            Assertions.assertThat(baseEntity1.equals(baseEntity2)).isTrue();
+        }
+
+        @Test
+        void should_notBeEqual_when_idsAreUnequalAndNotNull() {
+            val baseEntity1 = new BaseEntityWrapper();
+            baseEntity1.setId(UUID.fromString(UUID_STRING_1));
+
+            val baseEntity2 = new BaseEntityWrapper();
+            baseEntity2.setId(UUID.fromString(UUID_STRING_2));
+
+            Assertions.assertThat(baseEntity1.equals(baseEntity2)).isFalse();
+        }
+
+        @Test
+        void should_notBeEqual_when_idsAreNull() {
+            val baseEntity1 = new BaseEntityWrapper();
+            baseEntity1.setId(null);
+
+            val baseEntity2 = new BaseEntityWrapper();
+            baseEntity2.setId(null);
+
+            Assertions.assertThat(baseEntity1.equals(baseEntity2)).isFalse();
+        }
+
+        @Test
+        void should_notBeEqual_when_ownIdIsNullButOtherIsNotNull() {
+            val baseEntity1 = new BaseEntityWrapper();
+            baseEntity1.setId(UUID.fromString(UUID_STRING_1));
+
+            val baseEntity2 = new BaseEntityWrapper();
+            baseEntity2.setId(null);
+
+            Assertions.assertThat(baseEntity1.equals(baseEntity2)).isFalse();
+        }
+
+        @Test
+        void should_notBeEqual_when_ownIdIsNotNullButOtherIsNull() {
+            val baseEntity1 = new BaseEntityWrapper();
+            baseEntity1.setId(null);
+
+            val baseEntity2 = new BaseEntityWrapper();
+            baseEntity2.setId(UUID.fromString(UUID_STRING_2));
+
+            Assertions.assertThat(baseEntity1.equals(baseEntity2)).isFalse();
+        }
+
+        @Test
+        void should_notBeEqual_when_classesAreNotTheSame() {
+            val baseEntity1 = new BaseEntity() {
+            };
+            val baseEntity2 = new BaseEntity() {
+            };
+
+            Assertions.assertThat(baseEntity1.equals(baseEntity2)).isFalse();
+        }
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    class BaseEntityWrapper extends BaseEntity {
+
+        private String textProperty;
+    }
+}

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/BaseEntityTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/BaseEntityTest.java
@@ -34,7 +34,7 @@ class BaseEntityTest {
     class Equals {
 
         @Test
-        void should_beEqual_when_idOfObjectAreEqualButOtherPropertiesNot() {
+        void should_beEqual_when_idsOfObjectsAreEqualButOtherPropertiesNot() {
             val baseEntity1 = new BaseEntityWrapper("textOfEntity1");
             baseEntity1.setId(UUID.fromString(UUID_STRING_1));
 

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttemptRepositoryTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/LoginAttemptRepositoryTest.java
@@ -34,7 +34,7 @@ class LoginAttemptRepositoryTest {
 
             val findByResult = loginAttemptRepository.findByUsername(username);
 
-            Assertions.assertThat(findByResult.get()).isEqualTo(loginAttemptToFind);
+            Assertions.assertThat(findByResult.get()).usingRecursiveComparison().isEqualTo(loginAttemptToFind);
         }
 
         @Test

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/PermissionRepositoryTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/domain/PermissionRepositoryTest.java
@@ -34,7 +34,7 @@ class PermissionRepositoryTest {
 
             val findByResult = permissionRepository.findByPermission(permissionString);
 
-            Assertions.assertThat(findByResult.get()).isEqualTo(permissionToFind);
+            Assertions.assertThat(findByResult.get()).usingRecursiveComparison().isEqualTo(permissionToFind);
         }
 
         @Test

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/rest/UserControllerIntegrationTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/rest/UserControllerIntegrationTest.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.muenchen.oss.wahllokalsystem.authservice.MicroServiceApplication;
 import de.muenchen.oss.wahllokalsystem.authservice.configuration.CacheConfig;
 import de.muenchen.oss.wahllokalsystem.authservice.configuration.Profiles;
+import de.muenchen.oss.wahllokalsystem.authservice.domain.Authority;
+import de.muenchen.oss.wahllokalsystem.authservice.domain.AuthorityRepository;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.LoginAttempt;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.LoginAttemptRepository;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.User;
@@ -16,6 +18,8 @@ import de.muenchen.oss.wahllokalsystem.authservice.service.UserService;
 import de.muenchen.oss.wahllokalsystem.authservice.utils.Authorities;
 import de.muenchen.oss.wahllokalsystem.wls.common.testing.SecurityUtils;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.val;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
@@ -51,6 +55,9 @@ public class UserControllerIntegrationTest {
     LoginAttemptRepository loginAttemptRepository;
 
     @Autowired
+    AuthorityRepository authorityRepository;
+
+    @Autowired
     TransactionTemplate transactionTemplate;
 
     @Autowired
@@ -81,13 +88,20 @@ public class UserControllerIntegrationTest {
         @WithMockUser(username = "Hansi")
         @Test
         void should_returnUserDTO_when_userFound() throws Exception {
-            userRepository.save(new User("Hansi", null, null, true, true, "wahltagID", null, null, null, null, null, null, null));
+            val testauthorityName = "testauthority";
+            transactionTemplate.executeWithoutResult(status -> {
+                val authorityToSave = new Authority(testauthorityName, Collections.emptySet(), Collections.emptySet());
+                val authoritySaved = authorityRepository.save(authorityToSave);
+                val userToSave = new User("Hansi", null, null, true, true, "wahltagID", null, null, null, null, null, new HashSet<>(Set.of(authoritySaved)),
+                        null);
+                userRepository.save(userToSave);
+            });
 
             val request = MockMvcRequestBuilders.get("/user");
 
             val response = api.perform(request).andExpect(status().isOk()).andReturn();
             val responseBody = objectMapper.readValue(response.getResponse().getContentAsString(), UserDTO.class);
-            val expectedResponseBody = new UserDTO("Hansi", null, true, "wahltagID", null, null, null, null, null, Collections.emptySet(), null);
+            val expectedResponseBody = new UserDTO("Hansi", null, true, "wahltagID", null, null, null, null, null, Set.of(testauthorityName), null);
 
             Assertions.assertThat(responseBody).isEqualTo(expectedResponseBody);
         }

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserModelMapperTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserModelMapperTest.java
@@ -31,7 +31,7 @@ class UserModelMapperTest {
 
             val expectedResult = new User(username, "dummy", "dummy@dummy.local", false, true, wahltagID, userInfo.wahltag(), userInfo.wahlbezirkID(),
                     userInfo.wahlbezirknummer(), Wahlbezirksart.UWB, pin, authoritiesToLink, userInfo.wbid_wahlnummer());
-            Assertions.assertThat(result).isEqualTo(expectedResult);
+            Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(expectedResult);
         }
 
         private WahllokalUserInfoModel createWahlbezirksartModelWithAllDataSet(final WahlbezirksartModel wahlbezirkArt) {

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserServiceTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserServiceTest.java
@@ -84,7 +84,7 @@ class UserServiceTest {
             Mockito.verify(loginAttemptRepository).save(loginAttemptCaptor.capture());
 
             val expectedLoginAttempt = new LoginAttempt(username, 1, null);
-            Assertions.assertThat(loginAttemptCaptor.getValue()).isEqualTo(expectedLoginAttempt);
+            Assertions.assertThat(loginAttemptCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedLoginAttempt);
 
         }
 


### PR DESCRIPTION
# Beschreibung:

Die Implementierung von equals und hashCode erfolgte gemäß der Vorschläge zu Implementierungen die man im Netz findet, z.B.: https://thorben-janssen.com/lombok-hibernate-how-to-avoid-common-pitfalls/#dont-use-equalsandhashcode

Entfernung von `@Data` aus den Entitäten da die dabei erzeugte EqualsAndHashcode-Methode in Verbindung mit dem Set zu Problemen führt: Es wurden keine Daten der Relation mitgeliefert.

Um die manuell zu prüfen müssen den Nutzern Authorities zugewiesen werden. Dies ist über folgenden SQL-Statements möglich:

```sql
INSERT INTO Secusers_Secauthorities (user_oid, authority_oid)
VALUES ('68d798ca-ea64-49ce-a433-becd7ebb4c98', '68d798ca-ea64-49ce-a433-becd7ebb4c98');
INSERT INTO Secusers_Secauthorities (user_oid, authority_oid)
VALUES ('68d798ca-ea64-49ce-a433-becd7ebb4c99', '68d798ca-ea64-49ce-a433-becd7ebb4c98');
INSERT INTO Secusers_Secauthorities (user_oid, authority_oid)
VALUES ('68d798ca-ea64-49ce-a433-becd7ebb4c9a', '68d798ca-ea64-49ce-a433-becd7ebb4c98');
```

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] Doku aktualisiert - kein Update erforderlich
- [X] Swagger-API vollständig - keine Änderungen an den Schnittstellen
- [X] Unit-Tests gepflegt - Integrationstest erstellt
- [X] Integrationstests gepflegt
- [X] Beispiel-Requests gepflegt - keine Änderungen an den Schnittstellen oder neue Anfragen zur Nachstellung erforderlich.

# Referenzen[^1]:

Verwandt mit Issue #

Closes #574

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
