### PR TITLE
#435 :white_check_mark: rename tests

### DIFF
--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/SecurityConfigurationTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/SecurityConfigurationTest.java
@@ -76,7 +76,7 @@ class SecurityConfigurationTest {
     }
 
     @Test
-    void should_returnStatusOk_when_accessingUnsecuredResourceV3ApiDocs () throws Exception {
+    void should_returnStatusOk_when_accessingUnsecuredResourceV3ApiDocs() throws Exception {
         api.perform(get("/v3/api-docs"))
                 .andExpect(status().isOk());
     }

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/SecurityConfigurationTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/SecurityConfigurationTest.java
@@ -46,43 +46,43 @@ class SecurityConfigurationTest {
     ObjectMapper objectMapper;
 
     @Test
-    void accessSecuredResourceRootThenUnauthorized() throws Exception {
+    void should_returnStatusUnauthorized_when_accessingSecuredResourceRoot() throws Exception {
         api.perform(get("/"))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
-    void accessSecuredResourceActuatorThenUnauthorized() throws Exception {
+    void should_returnStatusUnauthorized_when_accessingSecuredResourceActuator() throws Exception {
         api.perform(get("/actuator"))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
-    void accessUnsecuredResourceActuatorHealthThenOk() throws Exception {
+    void should_returnStatusOk_when_accessingUnsecuredResourceActuatorHealth() throws Exception {
         api.perform(get("/actuator/health"))
                 .andExpect(status().isOk());
     }
 
     @Test
-    void accessUnsecuredResourceActuatorInfoThenOk() throws Exception {
+    void should_returnStatusOk_when_accessingUnsecuredResourceActuatorInfo() throws Exception {
         api.perform(get("/actuator/info"))
                 .andExpect(status().isOk());
     }
 
     @Test
-    void accessUnsecuredResourceActuatorMetricsThenOk() throws Exception {
+    void should_returnStatusOk_when_accessingUnsecuredResourceActuatorMetrics() throws Exception {
         api.perform(get("/actuator/metrics"))
                 .andExpect(status().isOk());
     }
 
     @Test
-    void accessUnsecuredResourceV3ApiDocsThenOk() throws Exception {
+    void should_returnStatusOk_when_accessingUnsecuredResourceV3ApiDocs () throws Exception {
         api.perform(get("/v3/api-docs"))
                 .andExpect(status().isOk());
     }
 
     @Test
-    void accessUnsecuredResourceSwaggerUiThenOk() throws Exception {
+    void should_returnStatusOk_when_accessingUnsecuredResourceSwaggerUi() throws Exception {
         api.perform(get("/swagger-ui/index.html"))
                 .andExpect(status().isOk());
     }

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/SwaggerConfigurationTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/SwaggerConfigurationTest.java
@@ -34,7 +34,7 @@ class SwaggerConfigurationTest {
     String version;
 
     @Test
-    void versionIsSetInDoc() throws Exception {
+    void should_returnVersion_when_setInApiDoc() throws Exception {
         val request = MockMvcRequestBuilders.get("/v3/api-docs/public-apis").contentType(MediaType.APPLICATION_JSON);
 
         val response = mockMvc.perform(request).andReturn();

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/UserInfoAuthoritiesServiceTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/UserInfoAuthoritiesServiceTest.java
@@ -56,7 +56,7 @@ class UserInfoAuthoritiesServiceTest {
     class LoadAuthorities {
 
         @Test
-        void buildAuthoritiesFromTemplateResponseWithCollection() {
+        void should_returnVersion_when_setInApiDoc() {
             val jwtTokenValue = "myTokenValue";
 
             val expectedRequestHeaders = new HttpHeaders();
@@ -86,7 +86,7 @@ class UserInfoAuthoritiesServiceTest {
         }
 
         @Test
-        void buildAuthoritiesFromTemplateResponseWithArray() {
+        void should_loadAuthoritiesFromTemplate_when_givenAsArray() {
             val jwtTokenValue = "myTokenValue";
 
             val expectedRequestHeaders = new HttpHeaders();
@@ -116,7 +116,7 @@ class UserInfoAuthoritiesServiceTest {
         }
 
         @Test
-        void buildAuthoritiesFromTemplateResponseWithUnhandledDataStructure() {
+        void should_returnEmptyList_when_givenAsUnhandledDataStructure() {
             val jwtTokenValue = "myTokenValue";
 
             val expectedRequestHeaders = new HttpHeaders();
@@ -139,7 +139,7 @@ class UserInfoAuthoritiesServiceTest {
         }
 
         @Test
-        void buildAuthoritiesFromTemplateResponseWithoutAuthoritiesClaim() {
+        void should_returnEmptyList_when_noAuthoritiesFound() {
             val jwtTokenValue = "myTokenValue";
 
             val expectedRequestHeaders = new HttpHeaders();
@@ -159,7 +159,7 @@ class UserInfoAuthoritiesServiceTest {
         }
 
         @Test
-        void errorWhileLoadingViaTemplate() {
+        void should_returnEmptyList_when_errorThrownWhileLoadingViaTemplate() {
             val jwtTokenValue = "myTokenValue";
 
             val expectedRequestHeaders = new HttpHeaders();
@@ -176,7 +176,7 @@ class UserInfoAuthoritiesServiceTest {
         }
 
         @Test
-        void loadedAuthoritiesAsPlacedInCache() {
+        void should_loadAuthoritiesFromCache_when_givenValidJwtToken() {
             val jwtSubject = "subject";
             val jwtTokenValue = "myTokenValue";
             val jwtForCachMethodCall = Mockito.mock(Jwt.class);

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/UserInfoAuthoritiesServiceTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/UserInfoAuthoritiesServiceTest.java
@@ -56,7 +56,7 @@ class UserInfoAuthoritiesServiceTest {
     class LoadAuthorities {
 
         @Test
-        void should_returnVersion_when_setInApiDoc() {
+        void should_loadAuthoritiesFromTemplate_when_givenAsCollection() {
             val jwtTokenValue = "myTokenValue";
 
             val expectedRequestHeaders = new HttpHeaders();
@@ -81,8 +81,9 @@ class UserInfoAuthoritiesServiceTest {
 
             val authorities = unitUnderTest.loadAuthorities(jwt);
 
-            Assertions.assertThat(authorities).hasSize(claimAuthorityValues.size());
-            Assertions.assertThat(authorities).containsAll(expectedAuthorities);
+            Assertions.assertThat(authorities)
+                    .hasSize(claimAuthorityValues.size())
+                    .containsAll(expectedAuthorities);
         }
 
         @Test
@@ -111,8 +112,9 @@ class UserInfoAuthoritiesServiceTest {
 
             val authorities = unitUnderTest.loadAuthorities(jwt);
 
-            Assertions.assertThat(authorities).hasSize(claimAuthorityValues.length);
-            Assertions.assertThat(authorities).containsAll(expctedAuthorities);
+            Assertions.assertThat(authorities)
+                    .hasSize(claimAuthorityValues.length)
+                    .containsAll(expctedAuthorities);
         }
 
         @Test
@@ -206,8 +208,9 @@ class UserInfoAuthoritiesServiceTest {
 
             val authoritiesThatShouldComeFromCache = unitUnderTest.loadAuthorities(jwtForCachMethodCall);
 
-            Assertions.assertThat(authorities).hasSize(claimAuthorityValues.size());
-            Assertions.assertThat(authorities).containsAll(expectedAuthorities);
+            Assertions.assertThat(authorities)
+                    .hasSize(claimAuthorityValues.size())
+                    .containsAll(expectedAuthorities);
             Assertions.assertThat(authoritiesThatShouldComeFromCache).isSameAs(authorities);
 
             Mockito.verify(restTemplate, Mockito.times(1)).exchange(userInfoUri, HttpMethod.GET, expectedRequestEntity, Map.class);

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/nfcconverter/NfcConverterTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/nfcconverter/NfcConverterTest.java
@@ -76,7 +76,7 @@ class NfcConverterTest {
     // Test, das Request mit konfigriertem ContentType auf NFC normalisiert wird.
     //
     @Test
-    void testFilterIfContenttypeInWhitelist() throws ServletException, IOException {
+    void should_executeFilter_when_contenttypeInWhitelist() throws ServletException, IOException {
         mockRequest("text/plain");
 
         filter.setContentTypes("text/plain;text/html;application/json");
@@ -105,7 +105,7 @@ class NfcConverterTest {
     // auf NFC normalisiert wird.
     //
     @Test
-    void testSkipFilterIfContenttypeNotInWhitelist() throws ServletException, IOException {
+    void should_skipFilter_when_contenttypeNotInWhitelist() throws ServletException, IOException {
         mockRequest("application/postscript");
 
         filter.setContentTypes("text/plain;text/html");

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/nfcconverter/NfcHelperTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/nfcconverter/NfcHelperTest.java
@@ -34,7 +34,7 @@ class NfcHelperTest {
     private static final String[] NFC_OUTPUT_EXPECTED = new String[] { FIRST_NFC, SECOND_NFC, THIRD_NFC };
 
     @Test
-    void nfcConverterString() {
+    void should_convertCorrectly_when_givenString() {
         assertEquals(FIRST_NFC, NfcHelper.nfcConverter(FIRST_NFD));
         assertEquals(FIRST_NFC.length(), NfcHelper.nfcConverter(FIRST_NFD).length());
 
@@ -48,7 +48,7 @@ class NfcHelperTest {
     }
 
     @Test
-    void nfcConverterStringBuffer() {
+    void should_convertCorrectly_when_givenStringBuffer() {
         assertEquals(FIRST_NFC, NfcHelper.nfcConverter(new StringBuffer(FIRST_NFD)).toString());
         assertEquals(FIRST_NFC.length(), NfcHelper.nfcConverter(new StringBuffer(FIRST_NFD)).length());
 
@@ -60,13 +60,13 @@ class NfcHelperTest {
     }
 
     @Test
-    void nfcConverterStringArray() {
+    void should_convertCorrectly_when_givenArrayOfStrings() {
         assertArrayEquals(NFC_OUTPUT_EXPECTED, NfcHelper.nfcConverter(NFD_INPUT));
         assertEquals(NFC_OUTPUT_EXPECTED.length, NfcHelper.nfcConverter(NFD_INPUT).length);
     }
 
     @Test
-    void nfcConverterMapOfStrings() {
+    void should_convertCorrectly_when_givenMapOfStrings() {
         final Map<String, String[]> nfdInput = new HashMap<>();
         nfdInput.put(FIRST_NFD, NFD_INPUT);
         nfdInput.put(SECOND_NFD, NFD_INPUT);
@@ -80,7 +80,7 @@ class NfcHelperTest {
     }
 
     @Test
-    void nfcConverterCookie() {
+    void should_convertCorrectly_when_givenCookie() {
         final Cookie nfcCookie = NfcHelper.nfcConverter(createNfdCookie());
 
         assertEquals(NfcConverterTest.TOKEN, nfcCookie.getName());
@@ -90,7 +90,7 @@ class NfcHelperTest {
     }
 
     @Test
-    void nfcConverterCookieWithoutDomain() {
+    void should_convertCorrectly_when_givenCookieWithoutDomain() {
         final Cookie cookieToConvert = createNfdCookie();
         cookieToConvert.setDomain(null);
         final Cookie nfcCookie = NfcHelper.nfcConverter(cookieToConvert);
@@ -102,7 +102,7 @@ class NfcHelperTest {
     }
 
     @Test
-    void nfcConverterCookieArray() {
+    void should_convertCorrectly_when_givenArrayOfCookies() {
         final Cookie[] nfdCookies = Collections.nCopies(3, createNfdCookie()).toArray(new Cookie[3]);
         final Cookie[] nfcCookies = NfcHelper.nfcConverter(nfdCookies);
         Arrays.asList(nfcCookies).forEach(nfcCookie -> {
@@ -114,7 +114,7 @@ class NfcHelperTest {
     }
 
     @Test
-    void nfcConverterCookieArrayNullReturnNull() {
+    void should_returnNull_when_givenEmptyArrayOfCookies() {
         assertNull(NfcHelper.nfcConverter((Cookie[]) null));
     }
 

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/service/waehleranzahl/WaehleranzahlModelMapperTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/service/waehleranzahl/WaehleranzahlModelMapperTest.java
@@ -5,6 +5,7 @@ import de.muenchen.oss.wahllokalsystem.wls.common.security.domain.BezirkUndWahlI
 import java.time.LocalDateTime;
 import lombok.val;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 
@@ -12,35 +13,43 @@ class WaehleranzahlModelMapperTest {
 
     private final WaehleranzahlModelMapper unitUnderTest = Mappers.getMapper(WaehleranzahlModelMapper.class);
 
-    @Test
-    void should_returnEqualWaehleranzahlModel_when_waehleranzahlIsMapped() {
-        val wahlID = "wahlID01";
-        val wahlbezirkID = "wahlbezirkID01";
-        BezirkUndWahlID bezirkUndWahlID = new BezirkUndWahlID(wahlID, wahlbezirkID);
-        val anzahlWaehler = 99;
-        LocalDateTime uhrzeit = LocalDateTime.now();
-        val waehleranzahlEntity = new Waehleranzahl(bezirkUndWahlID, anzahlWaehler, uhrzeit);
+    @Nested
+    class ToModel {
 
-        val waehleranzahlModel = unitUnderTest.toModel(waehleranzahlEntity);
+        @Test
+        void should_returnEqualWaehleranzahlModel_when_waehleranzahlIsMapped() {
+            val wahlID = "wahlID01";
+            val wahlbezirkID = "wahlbezirkID01";
+            BezirkUndWahlID bezirkUndWahlID = new BezirkUndWahlID(wahlID, wahlbezirkID);
+            val anzahlWaehler = 99;
+            LocalDateTime uhrzeit = LocalDateTime.now();
+            val waehleranzahlEntity = new Waehleranzahl(bezirkUndWahlID, anzahlWaehler, uhrzeit);
 
-        val expectedResult = new WaehleranzahlModel(bezirkUndWahlID, anzahlWaehler, uhrzeit);
+            val waehleranzahlModel = unitUnderTest.toModel(waehleranzahlEntity);
 
-        Assertions.assertThat(waehleranzahlModel).isEqualTo(expectedResult);
+            val expectedResult = new WaehleranzahlModel(bezirkUndWahlID, anzahlWaehler, uhrzeit);
+
+            Assertions.assertThat(waehleranzahlModel).isEqualTo(expectedResult);
+        }
     }
 
-    @Test
-    void should_returnEqualWaehleranzahl_when_waehleranzahlModelIsMapped() {
-        val wahlID = "wahlID01";
-        val wahlbezirkID = "wahlbezirkID01";
-        BezirkUndWahlID bezirkUndWahlID = new BezirkUndWahlID(wahlID, wahlbezirkID);
-        val anzahlWaehler = 99;
-        LocalDateTime uhrzeit = LocalDateTime.now();
-        val waehleranzahlModel = new WaehleranzahlModel(bezirkUndWahlID, anzahlWaehler, uhrzeit);
+    @Nested
+    class ToEntity {
 
-        val waehleranzahlEntity = unitUnderTest.toEntity(waehleranzahlModel);
+        @Test
+        void should_returnEqualWaehleranzahl_when_waehleranzahlModelIsMapped() {
+            val wahlID = "wahlID01";
+            val wahlbezirkID = "wahlbezirkID01";
+            BezirkUndWahlID bezirkUndWahlID = new BezirkUndWahlID(wahlID, wahlbezirkID);
+            val anzahlWaehler = 99;
+            LocalDateTime uhrzeit = LocalDateTime.now();
+            val waehleranzahlModel = new WaehleranzahlModel(bezirkUndWahlID, anzahlWaehler, uhrzeit);
 
-        val expectedResult = new Waehleranzahl(bezirkUndWahlID, anzahlWaehler, uhrzeit);
+            val waehleranzahlEntity = unitUnderTest.toEntity(waehleranzahlModel);
 
-        Assertions.assertThat(waehleranzahlEntity).isEqualTo(expectedResult);
+            val expectedResult = new Waehleranzahl(bezirkUndWahlID, anzahlWaehler, uhrzeit);
+
+            Assertions.assertThat(waehleranzahlEntity).isEqualTo(expectedResult);
+        }
     }
 }

--- a/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/configuration/UserInfoAuthoritiesServiceTest.java
+++ b/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/configuration/UserInfoAuthoritiesServiceTest.java
@@ -81,8 +81,9 @@ class UserInfoAuthoritiesServiceTest {
 
             val authorities = unitUnderTest.loadAuthorities(jwt);
 
-            Assertions.assertThat(authorities).hasSize(claimAuthorityValues.size());
-            Assertions.assertThat(authorities).containsAll(expectedAuthorities);
+            Assertions.assertThat(authorities)
+                    .hasSize(claimAuthorityValues.size())
+                    .containsAll(expectedAuthorities);
         }
 
         @Test
@@ -111,8 +112,9 @@ class UserInfoAuthoritiesServiceTest {
 
             val authorities = unitUnderTest.loadAuthorities(jwt);
 
-            Assertions.assertThat(authorities).hasSize(claimAuthorityValues.length);
-            Assertions.assertThat(authorities).containsAll(expctedAuthorities);
+            Assertions.assertThat(authorities)
+                    .hasSize(claimAuthorityValues.length)
+                    .containsAll(expctedAuthorities);
         }
 
         @Test
@@ -206,8 +208,9 @@ class UserInfoAuthoritiesServiceTest {
 
             val authoritiesThatShouldComeFromCache = unitUnderTest.loadAuthorities(jwtForCachMethodCall);
 
-            Assertions.assertThat(authorities).hasSize(claimAuthorityValues.size());
-            Assertions.assertThat(authorities).containsAll(expectedAuthorities);
+            Assertions.assertThat(authorities)
+                    .hasSize(claimAuthorityValues.size())
+                    .containsAll(expectedAuthorities);
             Assertions.assertThat(authoritiesThatShouldComeFromCache).isSameAs(authorities);
 
             Mockito.verify(restTemplate, Mockito.times(1)).exchange(userInfoUri, HttpMethod.GET, expectedRequestEntity, Map.class);


### PR DESCRIPTION
# Beschreibung:

Umbenennung aller Tests im monitoring-service, entsprechend der Naming Convention

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] alle Testnamen entsprechen der Convention

# Referenzen[^1]:

Closes #435 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
