### PR TITLE
594 user endpoint liefert die authorities nicht die permissions

### DIFF
--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserModelMapper.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserModelMapper.java
@@ -1,6 +1,7 @@
 package de.muenchen.oss.wahllokalsystem.authservice.service;
 
 import de.muenchen.oss.wahllokalsystem.authservice.domain.Authority;
+import de.muenchen.oss.wahllokalsystem.authservice.domain.Permission;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.User;
 import java.util.Collections;
 import java.util.Optional;
@@ -17,11 +18,15 @@ public interface UserModelMapper {
 
     UserModel toModel(User user);
 
-    default String toModel(Authority authority) {
-        if (authority == null) {
+    default Set<String> permissionsOfAuthoritiesToAuthorities(Set<Authority> authorities) {
+        if (authorities == null) {
             return null;
         }
-        return authority.getAuthority();
+
+        return authorities.stream()
+                .flatMap(authority -> authority.getPermissions().stream())
+                .map(Permission::getPermission)
+                .collect(Collectors.toSet());
     }
 
     @Mapping(target = "id", ignore = true)

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/LdapConfigurationTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/LdapConfigurationTest.java
@@ -5,6 +5,8 @@ import de.muenchen.oss.wahllokalsystem.authservice.MicroServiceApplication;
 import de.muenchen.oss.wahllokalsystem.authservice.TestConstants;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.Authority;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.AuthorityRepository;
+import de.muenchen.oss.wahllokalsystem.authservice.domain.Permission;
+import de.muenchen.oss.wahllokalsystem.authservice.domain.PermissionRepository;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.User;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.UserRepository;
 import de.muenchen.oss.wahllokalsystem.authservice.rest.UserDTO;
@@ -53,6 +55,9 @@ class LdapConfigurationTest {
     AuthorityRepository authorityRepository;
 
     @Autowired
+    PermissionRepository permissionRepository;
+
+    @Autowired
     RegisteredClientRepository registeredClientRepository;
 
     @Autowired
@@ -72,6 +77,7 @@ class LdapConfigurationTest {
     @BeforeEach
     void setup() {
         authorityRepository.deleteAll();
+        permissionRepository.deleteAll();
         userRepository.deleteUsersByWahltagID(WAHLTAG_ID);
     }
 
@@ -133,7 +139,8 @@ class LdapConfigurationTest {
             val username = "user";
 
             transactionTemplate.executeWithoutResult(status -> {
-                val authorityToSave = new Authority("WLS_WAHLVORSTAND", Collections.emptySet(), Collections.emptySet());
+                val savedPermission = permissionRepository.save(new Permission("permission"));
+                val authorityToSave = new Authority("WLS_WAHLVORSTAND", new HashSet<>(Set.of(savedPermission)), Collections.emptySet());
                 val authoritySaved = authorityRepository.save(authorityToSave);
                 val userToSave = new User(username, null, null, true, true, WAHLTAG_ID, null, null, null, null, null, new HashSet<>(Set.of(authoritySaved)),
                         null);
@@ -216,7 +223,7 @@ class LdapConfigurationTest {
             userRequestHeaders.add("Authorization", "Bearer " + token);
             val userRequest = new RequestEntity<>(userRequestHeaders, HttpMethod.GET, URI.create(getHost() + "/user"));
             val userResponse = restTemplate.exchange(userRequest, UserDTO.class);
-            Assertions.assertThat(userResponse.getBody().authorities()).containsExactly("WLS_WAHLVORSTAND");
+            Assertions.assertThat(userResponse.getBody().authorities()).containsExactly("permission");
         }
 
         private String getHost() {

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/rest/UserControllerIntegrationTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/rest/UserControllerIntegrationTest.java
@@ -12,6 +12,8 @@ import de.muenchen.oss.wahllokalsystem.authservice.domain.Authority;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.AuthorityRepository;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.LoginAttempt;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.LoginAttemptRepository;
+import de.muenchen.oss.wahllokalsystem.authservice.domain.Permission;
+import de.muenchen.oss.wahllokalsystem.authservice.domain.PermissionRepository;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.User;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.UserRepository;
 import de.muenchen.oss.wahllokalsystem.authservice.service.UserService;
@@ -58,6 +60,9 @@ public class UserControllerIntegrationTest {
     AuthorityRepository authorityRepository;
 
     @Autowired
+    PermissionRepository permissionRepository;
+
+    @Autowired
     TransactionTemplate transactionTemplate;
 
     @Autowired
@@ -72,6 +77,8 @@ public class UserControllerIntegrationTest {
         transactionTemplate.executeWithoutResult(status -> {
             SecurityUtils.runWith(Authorities.SERVICE_UNLOCK_USER);
             userRepository.deleteUsersByWahltagID("wahltagID");
+            authorityRepository.deleteAll();
+            permissionRepository.deleteAll();
         });
     }
 
@@ -90,7 +97,9 @@ public class UserControllerIntegrationTest {
         void should_returnUserDTO_when_userFound() throws Exception {
             val testauthorityName = "testauthority";
             transactionTemplate.executeWithoutResult(status -> {
-                val authorityToSave = new Authority(testauthorityName, Collections.emptySet(), Collections.emptySet());
+                val permission1Saved = permissionRepository.save(new Permission("permission1"));
+                val permission2Saved = permissionRepository.save(new Permission("permission2"));
+                val authorityToSave = new Authority(testauthorityName, new HashSet<>(Set.of(permission1Saved, permission2Saved)), Collections.emptySet());
                 val authoritySaved = authorityRepository.save(authorityToSave);
                 val userToSave = new User("Hansi", null, null, true, true, "wahltagID", null, null, null, null, null, new HashSet<>(Set.of(authoritySaved)),
                         null);
@@ -101,7 +110,7 @@ public class UserControllerIntegrationTest {
 
             val response = api.perform(request).andExpect(status().isOk()).andReturn();
             val responseBody = objectMapper.readValue(response.getResponse().getContentAsString(), UserDTO.class);
-            val expectedResponseBody = new UserDTO("Hansi", null, true, "wahltagID", null, null, null, null, null, Set.of(testauthorityName), null);
+            val expectedResponseBody = new UserDTO("Hansi", null, true, "wahltagID", null, null, null, null, null, Set.of("permission1", "permission2"), null);
 
             Assertions.assertThat(responseBody).isEqualTo(expectedResponseBody);
         }

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserModelMapperTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserModelMapperTest.java
@@ -27,21 +27,21 @@ class UserModelMapperTest {
         }
 
         @Test
-        void should_returnModel_when_entiyIsGiven() {
+        void should_returnModel_when_entityIsGiven() {
             val authorities = Set.of(
                     new Authority("authority1", Set.of(new Permission("permission11"), new Permission("permission12")), Collections.emptySet()),
                     new Authority("authority2", Set.of(new Permission("permission21"), new Permission("permission22")), Collections.emptySet()));
-            val entiyToMap = new User("username", "password", "email", true, true, "wahltagID", LocalDate.now(), "wahlbezirkID", "wahlbezirkNummer",
+            val entityToMap = new User("username", "password", "email", true, true, "wahltagID", LocalDate.now(), "wahlbezirkID", "wahlbezirkNummer",
                     Wahlbezirksart.BWB, "pin", authorities, "wbdid_wahlnummer");
-            entiyToMap.getAuthorities().forEach(authority -> authority.setUsers(Set.of(entiyToMap)));
+            entityToMap.getAuthorities().forEach(authority -> authority.setUsers(Set.of(entityToMap)));
 
-            val result = unitUnderTest.toModel(entiyToMap);
+            val result = unitUnderTest.toModel(entityToMap);
 
             val expectedAuthorities = Set.of("permission11", "permission12", "permission21", "permission22");
-            val expectedResult = new UserModel(entiyToMap.getUsername(), entiyToMap.getEmail(), entiyToMap.isUserEnabled(), entiyToMap.getWahltagID(),
-                    entiyToMap.getWahltag(),
-                    entiyToMap.getWahlbezirkID(), entiyToMap.getWahlbezirkNummer(), WahlbezirksartModel.BWB, entiyToMap.getPin(), expectedAuthorities,
-                    entiyToMap.getWbid_wahlnummer());
+            val expectedResult = new UserModel(entityToMap.getUsername(), entityToMap.getEmail(), entityToMap.isUserEnabled(), entityToMap.getWahltagID(),
+                    entityToMap.getWahltag(),
+                    entityToMap.getWahlbezirkID(), entityToMap.getWahlbezirkNummer(), WahlbezirksartModel.BWB, entityToMap.getPin(), expectedAuthorities,
+                    entityToMap.getWbid_wahlnummer());
 
             Assertions.assertThat(result).isEqualTo(expectedResult);
         }

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserModelMapperTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserModelMapperTest.java
@@ -1,6 +1,7 @@
 package de.muenchen.oss.wahllokalsystem.authservice.service;
 
 import de.muenchen.oss.wahllokalsystem.authservice.domain.Authority;
+import de.muenchen.oss.wahllokalsystem.authservice.domain.Permission;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.User;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.Wahlbezirksart;
 import java.time.LocalDate;
@@ -16,6 +17,56 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 class UserModelMapperTest {
 
     UserModelMapper unitUnderTest = Mappers.getMapper(UserModelMapper.class);
+
+    @Nested
+    class ToModel {
+
+        @Test
+        void should_returnNull_when_nullIsGiven() {
+            Assertions.assertThat(unitUnderTest.toModel(null)).isNull();
+        }
+
+        @Test
+        void should_returnModel_when_entiyIsGiven() {
+            val authorities = Set.of(
+                    new Authority("authority1", Set.of(new Permission("permission11"), new Permission("permission12")), Collections.emptySet()),
+                    new Authority("authority2", Set.of(new Permission("permission21"), new Permission("permission22")), Collections.emptySet()));
+            val entiyToMap = new User("username", "password", "email", true, true, "wahltagID", LocalDate.now(), "wahlbezirkID", "wahlbezirkNummer",
+                    Wahlbezirksart.BWB, "pin", authorities, "wbdid_wahlnummer");
+            entiyToMap.getAuthorities().forEach(authority -> authority.setUsers(Set.of(entiyToMap)));
+
+            val result = unitUnderTest.toModel(entiyToMap);
+
+            val expectedAuthorities = Set.of("permission11", "permission12", "permission21", "permission22");
+            val expectedResult = new UserModel(entiyToMap.getUsername(), entiyToMap.getEmail(), entiyToMap.isUserEnabled(), entiyToMap.getWahltagID(),
+                    entiyToMap.getWahltag(),
+                    entiyToMap.getWahlbezirkID(), entiyToMap.getWahlbezirkNummer(), WahlbezirksartModel.BWB, entiyToMap.getPin(), expectedAuthorities,
+                    entiyToMap.getWbid_wahlnummer());
+
+            Assertions.assertThat(result).isEqualTo(expectedResult);
+        }
+
+    }
+
+    @Nested
+    class PermissionsOfAuthoritiesToAuthorities {
+
+        @Test
+        void should_returnNull_when_nullIsGiven() {
+            Assertions.assertThat(unitUnderTest.permissionsOfAuthoritiesToAuthorities(null)).isNull();
+        }
+
+        @Test
+        void should_returnSetWithPermissions_when_authoritiesWithPermissionsAreGiven() {
+            val authorities = Set.of(
+                    new Authority("authority1", Set.of(new Permission("permission11"), new Permission("permission12")), Collections.emptySet()),
+                    new Authority("authority2", Set.of(new Permission("permission21"), new Permission("permission22")), Collections.emptySet()));
+
+            val result = unitUnderTest.permissionsOfAuthoritiesToAuthorities(authorities);
+
+            Assertions.assertThat(result).containsExactlyInAnyOrder("permission11", "permission12", "permission21", "permission22");
+        }
+    }
 
     @Nested
     class ToUser {

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserModelMapperTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserModelMapperTest.java
@@ -45,7 +45,6 @@ class UserModelMapperTest {
 
             Assertions.assertThat(result).isEqualTo(expectedResult);
         }
-
     }
 
     @Nested


### PR DESCRIPTION
# Beschreibung:

Es werden die Permissions der User gemappt anstatt der Authorities

## Todo:
- Issues erstellen für Vorschlag in den User das Feld auch in `permissions` zu ändern: #634 

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] Doku aktualisiert - nix zu tun
- [x] Swagger-API vollständig - nix zu tun
- [x] Unit-Tests gepflegt
- [X] Integrationstests gepflegt
- [X] Beispiel-Requests gepflegt - nix zu tun

# Referenzen[^1]:

Verwandt mit Issue #

Closes #594

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
