### PR TITLE
Keine Asynchrone Verarbeitung in ControllerIntegrationTest

### DIFF
--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/awerte/AWerteControllerIntegrationTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/awerte/AWerteControllerIntegrationTest.java
@@ -25,6 +25,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -34,6 +39,15 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @AutoConfigureMockMvc
 @ActiveProfiles(profiles = { SPRING_TEST_PROFILE, SPRING_NO_SECURITY_PROFILE, Profiles.DUMMY_CLIENTS })
 public class AWerteControllerIntegrationTest {
+
+    @Configuration
+    static class TestConfiguration {
+        @Primary
+        @Bean
+        public TaskExecutor syncTaskExecutor() {
+            return new SyncTaskExecutor();
+        }
+    }
 
     @Autowired
     ObjectMapper objectMapper;


### PR DESCRIPTION
# Beschreibung:

Auf Grund von Fehlern während der Tests wurde der TaskExecutor für Tests durch einen SynchroneExcetuor ersetzt. Mockito konnte keinen Methodenaufruf feststellen weshalb der Test auf failed ging.

Erst bei dem 4. Versuch war der durchlauf erfolgreich. D.h. wir haben instabile Tests.

Auszug aus dem Log mit Failed:

```log
[INFO] Results:
[INFO] 
Error:  Failures: 
Error:    AWerteControllerIntegrationTest$InitialiseAWerte.should_callAsynchronousMethodInitialiseAWerteAndReturnWithOK_when_wahlbezirkIDsAreGiven:112 
Wanted but not invoked:
asyncAWerteService.initialiseAWerte(
    [wahlbezirkID1, wahlbezirkID2, wahlbezirkID3]
);
-> at de.muenchen.oss.wahllokalsystem.ergebnismeldungservice.service.awerte.AsyncAWerteService.initialiseAWerte(AsyncAWerteService.java:32)
Actually, there were zero interactions with this mock.

[INFO] 
Error:  Tests run: 206, Failures: 1, Errors: 0, Skipped: 1
```



## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] [Codingconventions](https://it-at-m.github.io/Wahllokalsystem/technik/coding_conventions/) beachtet - nix zu tun
- [X] Doku aktualisiert - nix zu tun
- [X] Swagger-API vollständig - nix zu tun
- [X] Unit-Tests gepflegt - nix zu tun
- [X] Integrationstests gepflegt - nix zu tun
- [X] Beispiel-Requests gepflegt - nix zu tun

# Referenzen[^1]:

Verwandt mit Issue #

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
