### PR TITLE
#646 :coffin: remove patch config

### DIFF
--- a/wls-gui-wahllokalsystem/src/api/fetch-utils.ts
+++ b/wls-gui-wahllokalsystem/src/api/fetch-utils.ts
@@ -54,27 +54,6 @@ export function putConfig(body: any): RequestInit {
 }
 
 /**
- * Returns a default PATCH-Config for fetch
- * If available, the version of the entity to be updated is included in this as an "If-Match" header.
- * @param body Optional body to be transferred
- */
-// eslint-disable-next-line
-export function patchConfig(body: any): RequestInit {
-  const headers = getHeaders();
-  if (body.version !== undefined) {
-    headers.append("If-Match", body.version);
-  }
-  return {
-    method: "PATCH",
-    body: body ? JSON.stringify(body) : undefined,
-    headers,
-    mode: "cors",
-    credentials: "same-origin",
-    redirect: "manual",
-  };
-}
-
-/**
  * Covers the default handling of a response. This includes:
  *
  * - Error with missing authorizations --> HTTP 403


### PR DESCRIPTION
# Beschreibung:

PatchConfig aus fetch-utils entfernt, da nicht benötigt. Die PutConfig ist aktuall unused, wird aber später für die Wahltermindaten und den Wahlvorstand notwendig sein und bleibt daher erhalten.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Codingconventions](https://it-at-m.github.io/Wahllokalsystem/technik/coding_conventions/) beachtet
- [x] ~Doku aktualisiert~ nichts zutun
- [x] ~Unit-Tests gepflegt~ nichts zutun
- [x] ~Komponententests gepflegt~ nichts zutun

# Referenzen[^1]:

Closes #646 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the `patchConfig` function, streamlining the request configuration process.
- **Chores**
	- Maintained existing configurations for GET, POST, and PUT requests without changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->