### PR TITLE
556 Tests-Naming Convention für AdminService

### DIFF
--- a/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/CacheControlConfigurationTest.java
+++ b/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/CacheControlConfigurationTest.java
@@ -41,7 +41,7 @@ class CacheControlConfigurationTest {
 
     @Test
     @Disabled
-    void testForCacheControlHeadersForEntityEndpoint() {
+    void should_returnExpectedHeaderValues_when_givenEndpoint() {
         ResponseEntity<String> response = testRestTemplate.exchange(ENTITY_ENDPOINT_URL, HttpMethod.GET, null, String.class);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertTrue(response.getHeaders().containsKey(HttpHeaders.CACHE_CONTROL));

--- a/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/SecurityConfigurationTest.java
+++ b/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/SecurityConfigurationTest.java
@@ -23,43 +23,43 @@ class SecurityConfigurationTest {
     MockMvc api;
 
     @Test
-    void accessSecuredResourceRootThenUnauthorized() throws Exception {
+    void should_returnStatusUnauthorized_when_accessingSecuredResourceRoot() throws Exception {
         api.perform(get("/"))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
-    void accessSecuredResourceActuatorThenUnauthorized() throws Exception {
+    void should_returnStatusUnauthorized_when_accessingSecuredResourceActuator() throws Exception {
         api.perform(get("/actuator"))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
-    void accessUnsecuredResourceActuatorHealthThenOk() throws Exception {
+    void should_returnStatusOk_when_accessingUnsecuredResourceActuatorHealth() throws Exception {
         api.perform(get("/actuator/health"))
                 .andExpect(status().isOk());
     }
 
     @Test
-    void accessUnsecuredResourceActuatorInfoThenOk() throws Exception {
+    void should_returnStatusOk_when_accessingUnsecuredResourceActuatorInfo() throws Exception {
         api.perform(get("/actuator/info"))
                 .andExpect(status().isOk());
     }
 
     @Test
-    void accessUnsecuredResourceActuatorMetricsThenOk() throws Exception {
+    void should_returnStatusOk_when_accessingUnsecuredResourceActuatorMetrics() throws Exception {
         api.perform(get("/actuator/metrics"))
                 .andExpect(status().isOk());
     }
 
     @Test
-    void accessUnsecuredResourceV3ApiDocsThenOk() throws Exception {
+    void should_returnStatusOk_when_accessingUnsecuredResourceV3ApiDocs() throws Exception {
         api.perform(get("/v3/api-docs"))
                 .andExpect(status().isOk());
     }
 
     @Test
-    void accessUnsecuredResourceSwaggerUiThenOk() throws Exception {
+    void should_returnStatusOk_when_accessingUnsecuredResourceSwaggerUi() throws Exception {
         api.perform(get("/swagger-ui/index.html"))
                 .andExpect(status().isOk());
     }

--- a/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/SwaggerConfigurationTest.java
+++ b/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/SwaggerConfigurationTest.java
@@ -34,7 +34,7 @@ class SwaggerConfigurationTest {
     String version;
 
     @Test
-    void versionIsSetInDoc() throws Exception {
+    void should_returnVersion_when_setInApiDoc() throws Exception {
         val request = MockMvcRequestBuilders.get("/v3/api-docs/public-apis").contentType(MediaType.APPLICATION_JSON);
 
         val response = mockMvc.perform(request).andReturn();

--- a/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/UnicodeConfigurationTest.java
+++ b/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/UnicodeConfigurationTest.java
@@ -53,7 +53,7 @@ class UnicodeConfigurationTest {
 
     @Test
     @Disabled
-    void testForNfcNormalization() {
+    void should_returnComposedString_when_givenDecomposedString() {
         // Persist entity with decomposed string.
         final TheEntityDto theEntityDto = new TheEntityDto();
         theEntityDto.setTextAttribute(TEXT_ATTRIBUTE_DECOMPOSED);

--- a/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/UserInfoAuthoritiesServiceTest.java
+++ b/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/UserInfoAuthoritiesServiceTest.java
@@ -1,6 +1,5 @@
 package de.muenchen.oss.wahllokalsystem.adminservice.configuration;
 
-import de.muenchen.oss.wahllokalsystem.adminservice.configuration.UserInfoAuthoritiesService;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +56,7 @@ class UserInfoAuthoritiesServiceTest {
     class LoadAuthorities {
 
         @Test
-        void buildAuthoritiesFromTemplateResponseWithCollection() {
+        void should_loadAuthoritiesFromTemplate_when_givenAsCollection() {
             val jwtTokenValue = "myTokenValue";
 
             val expectedRequestHeaders = new HttpHeaders();
@@ -87,7 +86,7 @@ class UserInfoAuthoritiesServiceTest {
         }
 
         @Test
-        void buildAuthoritiesFromTemplateResponseWithArray() {
+        void should_loadAuthoritiesFromTemplate_when_givenAsArray() {
             val jwtTokenValue = "myTokenValue";
 
             val expectedRequestHeaders = new HttpHeaders();
@@ -117,7 +116,7 @@ class UserInfoAuthoritiesServiceTest {
         }
 
         @Test
-        void buildAuthoritiesFromTemplateResponseWithUnhandledDataStructure() {
+        void should_returnEmptyList_when_givenAsUnhandledDataStructure() {
             val jwtTokenValue = "myTokenValue";
 
             val expectedRequestHeaders = new HttpHeaders();
@@ -140,7 +139,7 @@ class UserInfoAuthoritiesServiceTest {
         }
 
         @Test
-        void buildAuthoritiesFromTemplateResponseWithoutAuthoritiesClaim() {
+        void should_returnEmptyList_when_noAuthoritiesFound() {
             val jwtTokenValue = "myTokenValue";
 
             val expectedRequestHeaders = new HttpHeaders();
@@ -160,7 +159,7 @@ class UserInfoAuthoritiesServiceTest {
         }
 
         @Test
-        void errorWhileLoadingViaTemplate() {
+        void should_returnEmptyList_when_errorThrownWhileLoadingViaTemplate() {
             val jwtTokenValue = "myTokenValue";
 
             val expectedRequestHeaders = new HttpHeaders();
@@ -177,7 +176,7 @@ class UserInfoAuthoritiesServiceTest {
         }
 
         @Test
-        void loadedAuthoritiesAsPlacedInCache() {
+        void should_loadAuthoritiesFromCache_when_givenValidJwtToken() {
             val jwtSubject = "subject";
             val jwtTokenValue = "myTokenValue";
             val jwtForCachMethodCall = Mockito.mock(Jwt.class);

--- a/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/nfcconverter/NfcConverterTest.java
+++ b/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/nfcconverter/NfcConverterTest.java
@@ -7,7 +7,6 @@ package de.muenchen.oss.wahllokalsystem.adminservice.configuration.nfcconverter;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import de.muenchen.oss.wahllokalsystem.adminservice.configuration.nfcconverter.NfcRequestFilter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletResponse;
@@ -77,7 +76,7 @@ class NfcConverterTest {
     // Test, das Request mit konfigriertem ContentType auf NFC normalisiert wird.
     //
     @Test
-    void testFilterIfContenttypeInWhitelist() throws ServletException, IOException {
+    void should_executeFilter_when_contenttypeInWhitelist() throws ServletException, IOException {
         mockRequest("text/plain");
 
         filter.setContentTypes("text/plain;text/html;application/json");
@@ -106,7 +105,7 @@ class NfcConverterTest {
     // auf NFC normalisiert wird.
     //
     @Test
-    void testSkipFilterIfContenttypeNotInWhitelist() throws ServletException, IOException {
+    void should_skipFilter_when_contenttypeNotInWhitelist() throws ServletException, IOException {
         mockRequest("application/postscript");
 
         filter.setContentTypes("text/plain;text/html");

--- a/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/nfcconverter/NfcHelperTest.java
+++ b/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/nfcconverter/NfcHelperTest.java
@@ -34,7 +34,7 @@ class NfcHelperTest {
     private static final String[] NFC_OUTPUT_EXPECTED = new String[] { FIRST_NFC, SECOND_NFC, THIRD_NFC };
 
     @Test
-    void nfcConverterString() {
+    void should_convertCorrectly_when_givenString() {
         assertEquals(FIRST_NFC, NfcHelper.nfcConverter(FIRST_NFD));
         assertEquals(FIRST_NFC.length(), NfcHelper.nfcConverter(FIRST_NFD).length());
 
@@ -48,7 +48,7 @@ class NfcHelperTest {
     }
 
     @Test
-    void nfcConverterStringBuffer() {
+    void should_convertCorrectly_when_givenStringBuffer() {
         assertEquals(FIRST_NFC, NfcHelper.nfcConverter(new StringBuffer(FIRST_NFD)).toString());
         assertEquals(FIRST_NFC.length(), NfcHelper.nfcConverter(new StringBuffer(FIRST_NFD)).length());
 
@@ -60,13 +60,13 @@ class NfcHelperTest {
     }
 
     @Test
-    void nfcConverterStringArray() {
+    void should_convertCorrectly_when_givenArrayOfStrings() {
         assertArrayEquals(NFC_OUTPUT_EXPECTED, NfcHelper.nfcConverter(NFD_INPUT));
         assertEquals(NFC_OUTPUT_EXPECTED.length, NfcHelper.nfcConverter(NFD_INPUT).length);
     }
 
     @Test
-    void nfcConverterMapOfStrings() {
+    void should_convertCorrectly_when_givenMapOfStrings() {
         final Map<String, String[]> nfdInput = new HashMap<>();
         nfdInput.put(FIRST_NFD, NFD_INPUT);
         nfdInput.put(SECOND_NFD, NFD_INPUT);
@@ -80,7 +80,7 @@ class NfcHelperTest {
     }
 
     @Test
-    void nfcConverterCookie() {
+    void should_convertCorrectly_when_givenCookie() {
         final Cookie nfcCookie = NfcHelper.nfcConverter(createNfdCookie());
 
         assertEquals(NfcConverterTest.TOKEN, nfcCookie.getName());
@@ -90,7 +90,7 @@ class NfcHelperTest {
     }
 
     @Test
-    void nfcConverterCookieWithoutDomain() {
+    void should_convertCorrectly_when_givenCookieWithoutDomain() {
         final Cookie cookieToConvert = createNfdCookie();
         cookieToConvert.setDomain(null);
         final Cookie nfcCookie = NfcHelper.nfcConverter(cookieToConvert);
@@ -102,7 +102,7 @@ class NfcHelperTest {
     }
 
     @Test
-    void nfcConverterCookieArray() {
+    void should_convertCorrectly_when_givenArrayOfCookies() {
         final Cookie[] nfdCookies = Collections.nCopies(3, createNfdCookie()).toArray(new Cookie[3]);
         final Cookie[] nfcCookies = NfcHelper.nfcConverter(nfdCookies);
         Arrays.asList(nfcCookies).forEach(nfcCookie -> {
@@ -114,7 +114,7 @@ class NfcHelperTest {
     }
 
     @Test
-    void nfcConverterCookieArrayNullReturnNull() {
+    void should_returnNull_when_givenEmptyArrayOfCookies() {
         assertNull(NfcHelper.nfcConverter((Cookie[]) null));
     }
 

--- a/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/rest/TheEntityRepositoryTest.java
+++ b/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/rest/TheEntityRepositoryTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import de.muenchen.oss.wahllokalsystem.adminservice.MicroServiceApplication;
 import de.muenchen.oss.wahllokalsystem.adminservice.domain.TheEntity;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -32,24 +33,28 @@ class TheEntityRepositoryTest {
     @Autowired
     private TheEntityRepository repository;
 
-    @Test
-    @Transactional(propagation = Propagation.REQUIRED, noRollbackFor = Exception.class)
-    void testSave() {
+    @Nested
+    class Save {
 
-        // Implement your logic here by replacing and/or extending the code
+        @Test
+        @Transactional(propagation = Propagation.REQUIRED, noRollbackFor = Exception.class)
+        void should_persistEntity_when_entityIsGiven() {
 
-        // initialize
-        TheEntity original = new TheEntity();
-        original.setTextAttribute("test");
+            // Implement your logic here by replacing and/or extending the code
 
-        // persist
-        original = repository.save(original);
+            // initialize
+            TheEntity original = new TheEntity();
+            original.setTextAttribute("test");
 
-        // check
-        TheEntity persisted = repository.findById(original.getId()).orElse(null);
-        assertNotNull(persisted);
-        assertEquals(original, persisted);
+            // persist
+            original = repository.save(original);
 
+            // check
+            TheEntity persisted = repository.findById(original.getId()).orElse(null);
+            assertNotNull(persisted);
+            assertEquals(original, persisted);
+
+        }
     }
 
 }


### PR DESCRIPTION
# Beschreibung:

Tests entsprechend unserer Namingconvetions angepasst

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [X] [Codingconventions](https://it-at-m.github.io/Wahllokalsystem/technik/coding_conventions/) beachtet
- [x] ~~Doku aktualisiert~~ nichts zu zun
- [X] ~~Swagger-API vollständig~~ nichts zu tun
- [x] ~~Unit-Tests gepflegt~~ nichts zu tun
- [X] ~~Integrationstests gepflegt~~ nichts zu tun
- [X] ~~Beispiel-Requests gepflegt~~ nichts zu tun

# Referenzen[^1]:

Closes #556

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced clarity of test method names across multiple test classes, improving readability and understanding of expected outcomes.

- **Refactor**
	- Organized test methods into nested classes for better structure in `TheEntityRepositoryTest`.
  
- **Bug Fixes**
	- No specific bug fixes were mentioned, but improved naming conventions may help prevent misunderstandings in test expectations.

- **Documentation**
	- Improved naming conventions align with behavior-driven development practices, enhancing clarity on test intentions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->