### PR TITLE
557 Tests-Naming Convention für wls-common

### DIFF
--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/FachlicheWlsExceptionTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/FachlicheWlsExceptionTest.java
@@ -3,22 +3,27 @@ package de.muenchen.oss.wahllokalsystem.wls.common.exception;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory;
 import lombok.val;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class FachlicheWlsExceptionTest {
 
-    @Test
-    void verifyDataIsSetCorrect() {
-        val code = "089";
-        val message = "very useful message";
-        val serviceName = "testService";
-        val causingException = new NullPointerException("something was null");
-        val fachlicheWlsException = FachlicheWlsException.withCode(code).inService(serviceName).withCause(causingException).buildWithMessage(message);
+    @Nested
+    class BuilderPattern {
 
-        Assertions.assertThat(fachlicheWlsException.getCategory()).isSameAs(WlsExceptionCategory.FACHLICH);
-        Assertions.assertThat(fachlicheWlsException.getCode()).isSameAs(code);
-        Assertions.assertThat(fachlicheWlsException.getMessage()).isSameAs(message);
-        Assertions.assertThat(fachlicheWlsException.getServiceName()).isSameAs(serviceName);
-        Assertions.assertThat(fachlicheWlsException.getCause()).isSameAs(causingException);
+        @Test
+        void should_returnFachlicheWlsExceptionWithAllPropertiesSet_when_buildWithAllStepsOfBuilder() {
+            val code = "089";
+            val message = "very useful message";
+            val serviceName = "testService";
+            val causingException = new NullPointerException("something was null");
+            val fachlicheWlsException = FachlicheWlsException.withCode(code).inService(serviceName).withCause(causingException).buildWithMessage(message);
+
+            Assertions.assertThat(fachlicheWlsException.getCategory()).isSameAs(WlsExceptionCategory.FACHLICH);
+            Assertions.assertThat(fachlicheWlsException.getCode()).isSameAs(code);
+            Assertions.assertThat(fachlicheWlsException.getMessage()).isSameAs(message);
+            Assertions.assertThat(fachlicheWlsException.getServiceName()).isSameAs(serviceName);
+            Assertions.assertThat(fachlicheWlsException.getCause()).isSameAs(causingException);
+        }
     }
 }

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/InfrastrukturelleWlsExceptionTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/InfrastrukturelleWlsExceptionTest.java
@@ -3,25 +3,30 @@ package de.muenchen.oss.wahllokalsystem.wls.common.exception;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory;
 import lombok.val;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class InfrastrukturelleWlsExceptionTest {
 
-    @Test
-    void verifyDataIsSetCorrect() {
-        val code = "089";
-        val message = "very useful message";
-        val serviceName = "testService";
-        val causingException = new NullPointerException("something was null");
+    @Nested
+    class BuilderPattern {
 
-        val infrastrukturelleWlsException = InfrastrukturelleWlsException.withCode(code).inService(serviceName).withCause(causingException)
-                .buildWithMessage(message);
+        @Test
+        void should_returnInfrastrukturelleWlsExceptionWithAllPropertiesSet_when_buildWithAllStepsOfBuilder() {
+            val code = "089";
+            val message = "very useful message";
+            val serviceName = "testService";
+            val causingException = new NullPointerException("something was null");
 
-        Assertions.assertThat(infrastrukturelleWlsException.getCategory()).isSameAs(WlsExceptionCategory.INFRASTRUKTUR);
-        Assertions.assertThat(infrastrukturelleWlsException.getCode()).isSameAs(code);
-        Assertions.assertThat(infrastrukturelleWlsException.getMessage()).isSameAs(message);
-        Assertions.assertThat(infrastrukturelleWlsException.getServiceName()).isSameAs(serviceName);
-        Assertions.assertThat(infrastrukturelleWlsException.getCause()).isSameAs(causingException);
+            val infrastrukturelleWlsException = InfrastrukturelleWlsException.withCode(code).inService(serviceName).withCause(causingException)
+                    .buildWithMessage(message);
+
+            Assertions.assertThat(infrastrukturelleWlsException.getCategory()).isSameAs(WlsExceptionCategory.INFRASTRUKTUR);
+            Assertions.assertThat(infrastrukturelleWlsException.getCode()).isSameAs(code);
+            Assertions.assertThat(infrastrukturelleWlsException.getMessage()).isSameAs(message);
+            Assertions.assertThat(infrastrukturelleWlsException.getServiceName()).isSameAs(serviceName);
+            Assertions.assertThat(infrastrukturelleWlsException.getCause()).isSameAs(causingException);
+        }
     }
 
 }

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/SicherheitsWlsExceptionTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/SicherheitsWlsExceptionTest.java
@@ -3,23 +3,28 @@ package de.muenchen.oss.wahllokalsystem.wls.common.exception;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory;
 import lombok.val;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class SicherheitsWlsExceptionTest {
 
-    @Test
-    void verifyDataIsSetCorrect() {
-        val code = "089";
-        val message = "very useful message";
-        val serviceName = "testService";
-        val causingException = new NullPointerException("something was null");
+    @Nested
+    class BuilderPattern {
 
-        val sicherheitsWlsException = SicherheitsWlsException.withCode(code).inService(serviceName).withCause(causingException).buildWithMessage(message);
+        @Test
+        void should_returnSicherheitsWlsExceptionWithAllPropertiesSet_when_buildWithAllStepsOfBuilder() {
+            val code = "089";
+            val message = "very useful message";
+            val serviceName = "testService";
+            val causingException = new NullPointerException("something was null");
 
-        Assertions.assertThat(sicherheitsWlsException.getCategory()).isSameAs(WlsExceptionCategory.SECURITY);
-        Assertions.assertThat(sicherheitsWlsException.getCode()).isSameAs(code);
-        Assertions.assertThat(sicherheitsWlsException.getMessage()).isSameAs(message);
-        Assertions.assertThat(sicherheitsWlsException.getServiceName()).isSameAs(serviceName);
-        Assertions.assertThat(sicherheitsWlsException.getCause()).isSameAs(causingException);
+            val sicherheitsWlsException = SicherheitsWlsException.withCode(code).inService(serviceName).withCause(causingException).buildWithMessage(message);
+
+            Assertions.assertThat(sicherheitsWlsException.getCategory()).isSameAs(WlsExceptionCategory.SECURITY);
+            Assertions.assertThat(sicherheitsWlsException.getCode()).isSameAs(code);
+            Assertions.assertThat(sicherheitsWlsException.getMessage()).isSameAs(message);
+            Assertions.assertThat(sicherheitsWlsException.getServiceName()).isSameAs(serviceName);
+            Assertions.assertThat(sicherheitsWlsException.getCause()).isSameAs(causingException);
+        }
     }
 }

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/TechnischeWlsExceptionTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/TechnischeWlsExceptionTest.java
@@ -3,25 +3,30 @@ package de.muenchen.oss.wahllokalsystem.wls.common.exception;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory;
 import lombok.val;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class TechnischeWlsExceptionTest {
 
-    @Test
-    void verifyDataIsSetCorrect() {
-        val code = "089";
-        val message = "very useful message";
-        val serviceName = "testService";
-        val causingException = new NullPointerException("something was null");
+    @Nested
+    class BuilderPattern {
 
-        val technischeWlsException = TechnischeWlsException.withCode(code).inService(serviceName).withCause(causingException)
-                .buildWithMessage(message);
+        @Test
+        void should_returnTechnischeWlsExceptionWithAllPropertiesSet_when_buildWithAllStepsOfBuilder() {
+            val code = "089";
+            val message = "very useful message";
+            val serviceName = "testService";
+            val causingException = new NullPointerException("something was null");
 
-        Assertions.assertThat(technischeWlsException.getCategory()).isSameAs(WlsExceptionCategory.TECHNISCH);
-        Assertions.assertThat(technischeWlsException.getCode()).isSameAs(code);
-        Assertions.assertThat(technischeWlsException.getMessage()).isSameAs(message);
-        Assertions.assertThat(technischeWlsException.getServiceName()).isSameAs(serviceName);
-        Assertions.assertThat(technischeWlsException.getCause()).isSameAs(causingException);
+            val technischeWlsException = TechnischeWlsException.withCode(code).inService(serviceName).withCause(causingException)
+                    .buildWithMessage(message);
+
+            Assertions.assertThat(technischeWlsException.getCategory()).isSameAs(WlsExceptionCategory.TECHNISCH);
+            Assertions.assertThat(technischeWlsException.getCode()).isSameAs(code);
+            Assertions.assertThat(technischeWlsException.getMessage()).isSameAs(message);
+            Assertions.assertThat(technischeWlsException.getServiceName()).isSameAs(serviceName);
+            Assertions.assertThat(technischeWlsException.getCause()).isSameAs(causingException);
+        }
     }
 
 }

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/builder/WlsExceptionFactoryTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/builder/WlsExceptionFactoryTest.java
@@ -5,6 +5,7 @@ import de.muenchen.oss.wahllokalsystem.wls.common.exception.WlsException;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionData;
 import lombok.val;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -17,41 +18,57 @@ class WlsExceptionFactoryTest {
     @Mock
     private WlsExceptionCreator<WlsException> mockedCreator;
 
-    @Test
-    void exceptionDataIsCollectedAndSendToCreator() {
-        val unitUnderTest = new WlsExceptionFactory<>(mockedCreator);
+    @Nested
+    class BuildWithMessage {
 
-        val dataForBuild = new WlsExceptionData("message", "serviceName", "code", new NullPointerException("npe"));
-        val mockedWlsException = FachlicheWlsException.withCode(dataForBuild.getCode()).buildWithMessage(dataForBuild.getMessage());
-        Mockito.when(mockedCreator.createWlsException(dataForBuild)).thenReturn(mockedWlsException);
+        @Test
+        void should_returnWlsExceptionWithException_when_buildWithMessageIsCalled() {
+            val unitUnderTest = new WlsExceptionFactory<>(mockedCreator);
 
-        unitUnderTest.withCode(dataForBuild.getCode());
-        unitUnderTest.inService(dataForBuild.getServiceName());
-        unitUnderTest.withCause(dataForBuild.getCause());
-        val createdWlsException = unitUnderTest.buildWithMessage(dataForBuild.getMessage());
+            val dataForBuild = new WlsExceptionData("message", "serviceName", "code", new NullPointerException("npe"));
+            val mockedWlsException = FachlicheWlsException.withCode(dataForBuild.getCode()).buildWithMessage(dataForBuild.getMessage());
+            Mockito.when(mockedCreator.createWlsException(dataForBuild)).thenReturn(mockedWlsException);
 
-        Assertions.assertThat(createdWlsException).isSameAs(mockedWlsException);
+            unitUnderTest.withCode(dataForBuild.getCode());
+            unitUnderTest.inService(dataForBuild.getServiceName());
+            unitUnderTest.withCause(dataForBuild.getCause());
+            val createdWlsException = unitUnderTest.buildWithMessage(dataForBuild.getMessage());
+
+            Assertions.assertThat(createdWlsException).isSameAs(mockedWlsException);
+        }
     }
 
-    @Test
-    void withCodeReturnsFactoryItself() {
-        val unitUnderTest = new WlsExceptionFactory<>(mockedCreator);
+    @Nested
+    class WithCode {
 
-        Assertions.assertThat(unitUnderTest.withCode("code")).isSameAs(unitUnderTest);
+        @Test
+        void should_returnFactoryItself_when_called() {
+            val unitUnderTest = new WlsExceptionFactory<>(mockedCreator);
+
+            Assertions.assertThat(unitUnderTest.withCode("code")).isSameAs(unitUnderTest);
+        }
     }
 
-    @Test
-    void inServiceReturnsFactoryItself() {
-        val unitUnderTest = new WlsExceptionFactory<>(mockedCreator);
+    @Nested
+    class InService {
 
-        Assertions.assertThat(unitUnderTest.inService("service")).isSameAs(unitUnderTest);
+        @Test
+        void should_returnFactoryItself_when_called() {
+            val unitUnderTest = new WlsExceptionFactory<>(mockedCreator);
+
+            Assertions.assertThat(unitUnderTest.inService("service")).isSameAs(unitUnderTest);
+        }
     }
 
-    @Test
-    void withCauseReturnsFactoryItself() {
-        val unitUnderTest = new WlsExceptionFactory<>(mockedCreator);
+    @Nested
+    class WithCause {
 
-        Assertions.assertThat(unitUnderTest.withCause(new NullPointerException("npe"))).isSameAs(unitUnderTest);
+        @Test
+        void should_returnFactoryItself_when_called() {
+            val unitUnderTest = new WlsExceptionFactory<>(mockedCreator);
+
+            Assertions.assertThat(unitUnderTest.withCause(new NullPointerException("npe"))).isSameAs(unitUnderTest);
+        }
     }
 
 }

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/AbstractExceptionHandlerTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/AbstractExceptionHandlerTest.java
@@ -37,7 +37,7 @@ class AbstractExceptionHandlerTest {
     class GetWahlExceptionDTO {
 
         @Test
-        void handleWlsException() {
+        void should_returnWlsExceptionDTOWithExceptionData_when_parameterIsWlsException() {
             val code = "089";
             val serviceName = "service name";
             val cause = new NullPointerException("sth null");
@@ -53,7 +53,7 @@ class AbstractExceptionHandlerTest {
         }
 
         @Test
-        void handleAccessDeniedException() {
+        void should_returnWlsExceptionDTOWithSecurityData_when_parameterIsAccessDeniedException() {
             val causingException = new NullPointerException("some was null");
             val accessDeniedException = new AccessDeniedException("you shall not pass", causingException);
 
@@ -67,7 +67,7 @@ class AbstractExceptionHandlerTest {
         }
 
         @Test
-        void handleHttpMessageNotReadableException() {
+        void should_returnWlsExceptionDTOWithFachlicheData_when_parameterIsHttpMessageNotReadableException() {
             val cause = new IllegalArgumentException("text is not a fax");
             final HttpInputMessage inputMessage = (null);
             val messageNotReadableException = new HttpMessageNotReadableException("wrong type of message", cause, inputMessage);
@@ -81,7 +81,7 @@ class AbstractExceptionHandlerTest {
         }
 
         @Test
-        void handleTransientDataAccessException() {
+        void should_returnWlsExceptionDTOWithTechnischeData_when_parameterIsTransientDataAccessException() {
             val causingException = new NullPointerException("some was null");
             val transientException = new TransientDataAccessException("my TransientDataAccessException message", causingException) {
 
@@ -96,7 +96,7 @@ class AbstractExceptionHandlerTest {
         }
 
         @Test
-        void handleAnythingElse() {
+        void should_returnWlsExceptionDTOWithDataForUnknownException_when_parameterDoesNotHaveExplicitHandling() {
             val nullPointerException = new NullPointerException("object was null");
 
             val result = unitUnderTest.getWahlExceptionDTO(nullPointerException);
@@ -108,39 +108,47 @@ class AbstractExceptionHandlerTest {
         }
     }
 
-    @Test
-    void createForTransientException() {
-        val causingException = new NullPointerException("some was null");
-        val transientException = new TransientDataAccessException("my TransientDataAccessException message", causingException) {
+    @Nested
+    class CreateForTransientException {
 
-        };
+        @Test
+        void should_returnWlsExceptionDTOMessageFromThrowable_when_throwableIsGiven() {
+            val causingException = new NullPointerException("some was null");
+            val transientException = new TransientDataAccessException("my TransientDataAccessException message", causingException) {
 
-        val result = unitUnderTest.createForTransientException(transientException);
+            };
 
-        val expectedResult = new WlsExceptionDTO(WlsExceptionCategory.T, ExceptionKonstanten.CODE_TRANSIENT, GET_SERVICE_RESULT,
-                "Temporäres Problem, Ursache: " + transientException.getClass() + ", Nachricht: " + transientException.getMessage());
+            val result = unitUnderTest.createForTransientException(transientException);
 
-        Assertions.assertThat(result).isEqualTo(expectedResult);
+            val expectedResult = new WlsExceptionDTO(WlsExceptionCategory.T, ExceptionKonstanten.CODE_TRANSIENT, GET_SERVICE_RESULT,
+                    "Temporäres Problem, Ursache: " + transientException.getClass() + ", Nachricht: " + transientException.getMessage());
+
+            Assertions.assertThat(result).isEqualTo(expectedResult);
+        }
     }
 
-    @Test
-    void createForAccessDeniedException() {
-        val causingException = new NullPointerException("some was null");
-        val accessDeniedException = new AccessDeniedException("you shall not pass", causingException);
+    @Nested
+    class CreateForAccessDeniedException {
 
-        val result = unitUnderTest.createForAccessDeniedException(accessDeniedException);
+        @Test
+        void should_returnWlsExceptionForAccessDenied_when_throwableIsGiven() {
+            val causingException = new NullPointerException("some was null");
+            val accessDeniedException = new AccessDeniedException("you shall not pass", causingException);
 
-        val expectedResult = new WlsExceptionDTO(WlsExceptionCategory.S, ExceptionKonstanten.CODE_SECURITY_ACCESS_DENIED, GET_SERVICE_RESULT,
-                accessDeniedException.getMessage());
+            val result = unitUnderTest.createForAccessDeniedException(accessDeniedException);
 
-        Assertions.assertThat(result).isEqualTo(expectedResult);
+            val expectedResult = new WlsExceptionDTO(WlsExceptionCategory.S, ExceptionKonstanten.CODE_SECURITY_ACCESS_DENIED, GET_SERVICE_RESULT,
+                    accessDeniedException.getMessage());
+
+            Assertions.assertThat(result).isEqualTo(expectedResult);
+        }
     }
 
     @Nested
     class CreateResponse {
 
         @Test
-        void categoryIsNull() {
+        void should_createInternalServerError_when_exceptionDTOCategoryIsNull() {
             val wlsExceptionDTO = createWlsExceptionDTOWithCategory(null);
 
             val result = unitUnderTest.createResponse(wlsExceptionDTO);
@@ -151,7 +159,7 @@ class AbstractExceptionHandlerTest {
         }
 
         @Test
-        void categoryIsFachlichNotFound() {
+        void should_returnNotFound_when_exceptionIsCategoryIsFachlichAndCodeEntityNotFound() {
             val wlsExceptionDTO = createWlsExceptionDTOWithCategoryAndCode(WlsExceptionCategory.F, ExceptionKonstanten.CODE_ENTITY_NOT_FOUND);
 
             val result = unitUnderTest.createResponse(wlsExceptionDTO);
@@ -162,7 +170,7 @@ class AbstractExceptionHandlerTest {
         }
 
         @Test
-        void categoryIsFachlichNotNotFound() {
+        void should_returnBadRequest_when_exceptionIsCategoryIsFachlichAndButCodeIsNotEntityNotFound() {
             val wlsExceptionDTO = createWlsExceptionDTOWithCategoryAndCode(WlsExceptionCategory.F, ExceptionKonstanten.CODE_ENTITY_NOT_FOUND + "ABC");
 
             val result = unitUnderTest.createResponse(wlsExceptionDTO);
@@ -173,7 +181,7 @@ class AbstractExceptionHandlerTest {
         }
 
         @Test
-        void categoryIsTechnischNotTransient() {
+        void should_returnInternalServerError_when_categoryIsTechnischAndCodeIsNotTransient() {
             val wlsExceptionDTO = createWlsExceptionDTOWithCategoryAndCode(WlsExceptionCategory.T, ExceptionKonstanten.CODE_TRANSIENT + "ABC");
 
             val result = unitUnderTest.createResponse(wlsExceptionDTO);
@@ -184,7 +192,7 @@ class AbstractExceptionHandlerTest {
         }
 
         @Test
-        void categoryIsTechnischTransient() {
+        void should_returnConflict_when_categoryIsTechnischAndCodeIsTransient() {
             val wlsExceptionDTO = createWlsExceptionDTOWithCategoryAndCode(WlsExceptionCategory.T, ExceptionKonstanten.CODE_TRANSIENT);
 
             val result = unitUnderTest.createResponse(wlsExceptionDTO);
@@ -195,7 +203,7 @@ class AbstractExceptionHandlerTest {
         }
 
         @Test
-        void categoryIsSicherheit() {
+        void should_returnForbidden_when_categoryIsSicherheit() {
             val wlsExceptionDTO = createWlsExceptionDTOWithCategory(WlsExceptionCategory.S);
 
             val result = unitUnderTest.createResponse(wlsExceptionDTO);
@@ -206,7 +214,7 @@ class AbstractExceptionHandlerTest {
         }
 
         @Test
-        void categoryIsInfrastruktur() {
+        void should_returnInternalServerError_when_categoryIsInfrastruktur() {
             val wlsExceptionDTO = createWlsExceptionDTOWithCategory(WlsExceptionCategory.I);
 
             val result = unitUnderTest.createResponse(wlsExceptionDTO);

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/WlsResponseErrorHandlerTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/WlsResponseErrorHandlerTest.java
@@ -38,7 +38,7 @@ class WlsResponseErrorHandlerTest {
     class HandleError {
 
         @Test
-        void fachlicheExceptionCreatedFromResponse() throws Exception {
+        void should_createFachlicheWlsException_when_responseWlsExceptionDTOWithCategoryFachlich() throws Exception {
             val mockedResponseBody = new ByteArrayInputStream("mocked response body as stream".getBytes());
             Mockito.when(response.getBody()).thenReturn(mockedResponseBody);
 
@@ -51,7 +51,7 @@ class WlsResponseErrorHandlerTest {
         }
 
         @Test
-        void technischeExceptionCreatedFromResponse() throws Exception {
+        void should_createFachlicheWlsException_when_responseWlsExceptionDTOWithCategoryTechnisch() throws Exception {
             val mockedResponseBody = new ByteArrayInputStream("mocked response body as stream".getBytes());
             Mockito.when(response.getBody()).thenReturn(mockedResponseBody);
 
@@ -64,7 +64,7 @@ class WlsResponseErrorHandlerTest {
         }
 
         @Test
-        void securityExceptionCreatedFromResponse() throws Exception {
+        void should_createFachlicheWlsException_when_responseWlsExceptionDTOWithCategorySecurity() throws Exception {
             val mockedResponseBody = new ByteArrayInputStream("mocked response body as stream".getBytes());
             Mockito.when(response.getBody()).thenReturn(mockedResponseBody);
 
@@ -77,7 +77,7 @@ class WlsResponseErrorHandlerTest {
         }
 
         @Test
-        void infrastrukturExceptionCreatedFromResponse() throws Exception {
+        void should_createFachlicheWlsException_when_responseWlsExceptionDTOWithCategoryInfrastructure() throws Exception {
             val mockedResponseBody = new ByteArrayInputStream("mocked response body as stream".getBytes());
             Mockito.when(response.getBody()).thenReturn(mockedResponseBody);
 
@@ -90,7 +90,7 @@ class WlsResponseErrorHandlerTest {
         }
 
         @Test
-        void exceptionDuringCreationOfExceptionFromResponse() throws Exception {
+        void should_unknownTechnischeWlsException_when_exceptionDuringCreationOfExceptionFromResponseOccurred() throws Exception {
             val exceptionThrownByMappingResponse = new IOException("something strange happened");
             Mockito.when(response.getBody()).thenThrow(exceptionThrownByMappingResponse);
 

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/WlsResponseErrorHandlerTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/WlsResponseErrorHandlerTest.java
@@ -51,7 +51,7 @@ class WlsResponseErrorHandlerTest {
         }
 
         @Test
-        void should_createFachlicheWlsException_when_responseWlsExceptionDTOWithCategoryTechnisch() throws Exception {
+        void should_createTechnischeWlsException_when_responseWlsExceptionDTOWithCategoryTechnisch() throws Exception {
             val mockedResponseBody = new ByteArrayInputStream("mocked response body as stream".getBytes());
             Mockito.when(response.getBody()).thenReturn(mockedResponseBody);
 
@@ -64,7 +64,7 @@ class WlsResponseErrorHandlerTest {
         }
 
         @Test
-        void should_createFachlicheWlsException_when_responseWlsExceptionDTOWithCategorySecurity() throws Exception {
+        void should_createSicherheitsWlsException_when_responseWlsExceptionDTOWithCategorySecurity() throws Exception {
             val mockedResponseBody = new ByteArrayInputStream("mocked response body as stream".getBytes());
             Mockito.when(response.getBody()).thenReturn(mockedResponseBody);
 
@@ -77,7 +77,7 @@ class WlsResponseErrorHandlerTest {
         }
 
         @Test
-        void should_createFachlicheWlsException_when_responseWlsExceptionDTOWithCategoryInfrastructure() throws Exception {
+        void should_createInfrastrukturelleWlsException_when_responseWlsExceptionDTOWithCategoryInfrastructure() throws Exception {
             val mockedResponseBody = new ByteArrayInputStream("mocked response body as stream".getBytes());
             Mockito.when(response.getBody()).thenReturn(mockedResponseBody);
 

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/WlsResponseErrorHandlerTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/errorhandler/WlsResponseErrorHandlerTest.java
@@ -38,7 +38,7 @@ class WlsResponseErrorHandlerTest {
     class HandleError {
 
         @Test
-        void should_createFachlicheWlsException_when_responseWlsExceptionDTOWithCategoryFachlich() throws Exception {
+        void should_createFachlicheWlsException_when_responseWlsExceptionDTOWithCategoryFachlichIsGiven() throws Exception {
             val mockedResponseBody = new ByteArrayInputStream("mocked response body as stream".getBytes());
             Mockito.when(response.getBody()).thenReturn(mockedResponseBody);
 
@@ -51,7 +51,7 @@ class WlsResponseErrorHandlerTest {
         }
 
         @Test
-        void should_createTechnischeWlsException_when_responseWlsExceptionDTOWithCategoryTechnisch() throws Exception {
+        void should_createTechnischeWlsException_when_responseWlsExceptionDTOWithCategoryTechnischIsGiven() throws Exception {
             val mockedResponseBody = new ByteArrayInputStream("mocked response body as stream".getBytes());
             Mockito.when(response.getBody()).thenReturn(mockedResponseBody);
 
@@ -64,7 +64,7 @@ class WlsResponseErrorHandlerTest {
         }
 
         @Test
-        void should_createSicherheitsWlsException_when_responseWlsExceptionDTOWithCategorySecurity() throws Exception {
+        void should_createSicherheitsWlsException_when_responseWlsExceptionDTOWithCategorySecurityIsGiven() throws Exception {
             val mockedResponseBody = new ByteArrayInputStream("mocked response body as stream".getBytes());
             Mockito.when(response.getBody()).thenReturn(mockedResponseBody);
 
@@ -77,7 +77,7 @@ class WlsResponseErrorHandlerTest {
         }
 
         @Test
-        void should_createInfrastrukturelleWlsException_when_responseWlsExceptionDTOWithCategoryInfrastructure() throws Exception {
+        void should_createInfrastrukturelleWlsException_when_responseWlsExceptionDTOWithCategoryInfrastructureIsGiven() throws Exception {
             val mockedResponseBody = new ByteArrayInputStream("mocked response body as stream".getBytes());
             Mockito.when(response.getBody()).thenReturn(mockedResponseBody);
 

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/DTOMapperTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/DTOMapperTest.java
@@ -19,12 +19,12 @@ class DTOMapperTest {
     class ToDTO {
 
         @Test
-        void nullInNullOut() {
+        void should_returnNull_when_nullIsGiven() {
             Assertions.assertThat(unitUnderTest.toDTO(null)).isNull();
         }
 
         @Test
-        void toDTO() {
+        void should_returnDTO_whenExceptionIsGiven() {
             val code = "089";
             val serviceName = "dto mapper test";
             val message = "lets check the mapping";
@@ -40,12 +40,12 @@ class DTOMapperTest {
 
     @ParameterizedTest(name = "expected: {0} input: {1}")
     @MethodSource
-    void toDTOCategory(final WlsExceptionCategory expectedResult,
+    void should_returnWlsExceptionCategory_when_restDTOCategoryIsGiven(final WlsExceptionCategory expectedResult,
             final de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory categoryToMap) {
         Assertions.assertThat(unitUnderTest.toDTOCategory(categoryToMap)).isEqualTo(expectedResult);
     }
 
-    private static Stream<Arguments> toDTOCategory() {
+    private static Stream<Arguments> should_returnWlsExceptionCategory_when_restDTOCategoryIsGiven() {
         return Stream.of(
                 Arguments.of(WlsExceptionCategory.F, de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory.FACHLICH),
                 Arguments.of(WlsExceptionCategory.I, de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory.INFRASTRUKTUR),

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/WlsExceptionDTOTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/WlsExceptionDTOTest.java
@@ -10,75 +10,81 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 class WlsExceptionDTOTest {
 
-    @Test
-    void onlyHasOneConstructor() {
-        Assertions.assertThat(WlsExceptionDTO.class.getConstructors().length).withFailMessage("es sollte nur den überschrieben Konstruktur geben").isEqualTo(1);
-    }
-
-    @Test
-    void isNullSafe() {
-        val result = new WlsExceptionDTO(null, null, null, null);
-
-        val expectedResult = new WlsExceptionDTO(WlsExceptionCategory.T, ExceptionKonstanten.CODE_ALLGEMEIN_UNBEKANNT, ExceptionKonstanten.SERVICE_UNBEKANNT,
-                ExceptionKonstanten.MESSAGE_UNBEKANNTER_FEHLER);
-
-        Assertions.assertThat(result).isEqualTo(expectedResult);
-    }
-
-    @Test
-    void parametersAreSetToCorrectProperty() {
-        val category = WlsExceptionCategory.I;
-        val code = "089233";
-        val service = "WLS3.0 TestService";
-        val message = "Lorem ipsum";
-
-        val result = new WlsExceptionDTO(category, code, service, message);
-
-        Assertions.assertThat(result.category()).isEqualTo(category);
-        Assertions.assertThat(result.code()).isEqualTo(code);
-        Assertions.assertThat(result.message()).isEqualTo(message);
-        Assertions.assertThat(result.service()).isEqualTo(service);
-    }
-
     @Nested
-    class TestLoggingEvents {
-
-        @RegisterExtension
-        public LoggerExtension loggerExtension = new LoggerExtension();
+    class Constructor {
 
         @Test
-        void noLoggEventsOnCorrectUsedConstructor() {
-            new WlsExceptionDTO(WlsExceptionCategory.T, "code", "service", "message");
-
-            Assertions.assertThat(loggerExtension.getFormattedMessages().isEmpty()).isTrue();
+        void should_onlyHaveDefinedConstructorWithNullHandling_when_checkingAvailableConstructors() {
+            Assertions.assertThat(WlsExceptionDTO.class.getConstructors().length).withFailMessage("es sollte nur den überschrieben Konstruktur geben")
+                    .isEqualTo(1);
         }
 
         @Test
-        void warnOnCategoryIsNull() {
-            new WlsExceptionDTO(null, "code", "service", "message");
+        void should_useDefaultValues_when_isCalledWithNullArguments() {
+            val result = new WlsExceptionDTO(null, null, null, null);
 
-            Assertions.assertThat(loggerExtension.getFormattedMessages().size()).isEqualTo(1);
+            val expectedResult = new WlsExceptionDTO(WlsExceptionCategory.T, ExceptionKonstanten.CODE_ALLGEMEIN_UNBEKANNT,
+                    ExceptionKonstanten.SERVICE_UNBEKANNT,
+                    ExceptionKonstanten.MESSAGE_UNBEKANNTER_FEHLER);
+
+            Assertions.assertThat(result).isEqualTo(expectedResult);
         }
 
         @Test
-        void warnOnCodeIsNull() {
-            new WlsExceptionDTO(WlsExceptionCategory.T, null, "service", "message");
+        void should_assignParametersCorrectly_when_calledWithParameters() {
+            val category = WlsExceptionCategory.I;
+            val code = "089233";
+            val service = "WLS3.0 TestService";
+            val message = "Lorem ipsum";
 
-            Assertions.assertThat(loggerExtension.getFormattedMessages().size()).isEqualTo(1);
+            val result = new WlsExceptionDTO(category, code, service, message);
+
+            Assertions.assertThat(result.category()).isEqualTo(category);
+            Assertions.assertThat(result.code()).isEqualTo(code);
+            Assertions.assertThat(result.message()).isEqualTo(message);
+            Assertions.assertThat(result.service()).isEqualTo(service);
         }
 
-        @Test
-        void warnOnServiceIsNull() {
-            new WlsExceptionDTO(WlsExceptionCategory.T, "code", null, "message");
+        @Nested
+        class TestLoggingEvents {
 
-            Assertions.assertThat(loggerExtension.getFormattedMessages().size()).isEqualTo(1);
-        }
+            @RegisterExtension
+            public LoggerExtension loggerExtension = new LoggerExtension();
 
-        @Test
-        void warnOnMessageIsNull() {
-            new WlsExceptionDTO(WlsExceptionCategory.T, "code", "service", null);
+            @Test
+            void should_creteNoLoggEvents_when_allParametersArNonNull() {
+                new WlsExceptionDTO(WlsExceptionCategory.T, "code", "service", "message");
 
-            Assertions.assertThat(loggerExtension.getFormattedMessages().size()).isEqualTo(1);
+                Assertions.assertThat(loggerExtension.getFormattedMessages().isEmpty()).isTrue();
+            }
+
+            @Test
+            void should_createWarn_when_categoryIsNull() {
+                new WlsExceptionDTO(null, "code", "service", "message");
+
+                Assertions.assertThat(loggerExtension.getFormattedMessages().size()).isEqualTo(1);
+            }
+
+            @Test
+            void should_createWarn_when_codeIsNull() {
+                new WlsExceptionDTO(WlsExceptionCategory.T, null, "service", "message");
+
+                Assertions.assertThat(loggerExtension.getFormattedMessages().size()).isEqualTo(1);
+            }
+
+            @Test
+            void should_createWarn_when_serviceIsNull() {
+                new WlsExceptionDTO(WlsExceptionCategory.T, "code", null, "message");
+
+                Assertions.assertThat(loggerExtension.getFormattedMessages().size()).isEqualTo(1);
+            }
+
+            @Test
+            void should_createWarn_when_messageIsNull() {
+                new WlsExceptionDTO(WlsExceptionCategory.T, "code", "service", null);
+
+                Assertions.assertThat(loggerExtension.getFormattedMessages().size()).isEqualTo(1);
+            }
         }
     }
 

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/util/ExceptionFactoryTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/util/ExceptionFactoryTest.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 import lombok.val;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -26,72 +27,88 @@ class ExceptionFactoryTest {
     @InjectMocks
     ExceptionFactory unitUnderTest;
 
-    @Test
-    void createFachlicheWlsException() {
-        val code = "0815";
-        val message = "Everything Everywhere All at Once";
-        val wrappedData = new ExceptionDataWrapper(code, message);
+    @Nested
+    class CreateFachlicheWlsException {
 
-        val serviceID = "serviceID";
-        Mockito.when(serviceIDFormatter.getId()).thenReturn(serviceID);
+        @Test
+        void should_createFachlicheWlsExceptionWithCodeAndMessage_when_parameterIsNotNull() {
+            val code = "0815";
+            val message = "Everything Everywhere All at Once";
+            val wrappedData = new ExceptionDataWrapper(code, message);
 
-        val result = unitUnderTest.createFachlicheWlsException(wrappedData);
+            val serviceID = "serviceID";
+            Mockito.when(serviceIDFormatter.getId()).thenReturn(serviceID);
 
-        val expectedResult = FachlicheWlsException.withCode(code).inService(serviceID).buildWithMessage(message);
+            val result = unitUnderTest.createFachlicheWlsException(wrappedData);
 
-        Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(expectedResult);
+            val expectedResult = FachlicheWlsException.withCode(code).inService(serviceID).buildWithMessage(message);
+
+            Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(expectedResult);
+        }
+    }
+
+    @Nested
+    class CreateTechnischeWlsException {
+
+        @Test
+        void should_createTechnischeWlsExceptionWithCodeAndMessage_when_parameterIsNotNull() {
+            val code = "0815";
+            val message = "Everything Everywhere All at Once";
+            val wrappedData = new ExceptionDataWrapper(code, message);
+
+            val serviceID = "serviceID";
+            Mockito.when(serviceIDFormatter.getId()).thenReturn(serviceID);
+
+            val result = unitUnderTest.createTechnischeWlsException(wrappedData);
+
+            val expectedResult = TechnischeWlsException.withCode(code).inService(serviceID).buildWithMessage(message);
+
+            Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(expectedResult);
+        }
+    }
+
+    @Nested
+    class CreateInfrastrukturelleWlsException {
+
+        @Test
+        void should_createInfrastrukturelleWlsExceptionWithCodeAndMessage_when_parameterIsNotNull() {
+            val code = "0815";
+            val message = "Everything Everywhere All at Once";
+            val wrappedData = new ExceptionDataWrapper(code, message);
+
+            val serviceID = "serviceID";
+            Mockito.when(serviceIDFormatter.getId()).thenReturn(serviceID);
+
+            val result = unitUnderTest.createInfrastrukturelleWlsException(wrappedData);
+
+            val expectedResult = InfrastrukturelleWlsException.withCode(code).inService(serviceID).buildWithMessage(message);
+
+            Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(expectedResult);
+        }
+    }
+
+    @Nested
+    class CreateSicherheitsWlsException {
+
+        @Test
+        void should_createSicherheitsWlsExceptionWithCodeAndMessage_when_parameterIsNotNull() {
+            val code = "0815";
+            val message = "Everything Everywhere All at Once";
+            val wrappedData = new ExceptionDataWrapper(code, message);
+
+            val serviceID = "serviceID";
+            Mockito.when(serviceIDFormatter.getId()).thenReturn(serviceID);
+
+            val result = unitUnderTest.createSicherheitsWlsException(wrappedData);
+
+            val expectedResult = SicherheitsWlsException.withCode(code).inService(serviceID).buildWithMessage(message);
+
+            Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(expectedResult);
+        }
     }
 
     @Test
-    void createTechnischeWlsException() {
-        val code = "0815";
-        val message = "Everything Everywhere All at Once";
-        val wrappedData = new ExceptionDataWrapper(code, message);
-
-        val serviceID = "serviceID";
-        Mockito.when(serviceIDFormatter.getId()).thenReturn(serviceID);
-
-        val result = unitUnderTest.createTechnischeWlsException(wrappedData);
-
-        val expectedResult = TechnischeWlsException.withCode(code).inService(serviceID).buildWithMessage(message);
-
-        Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(expectedResult);
-    }
-
-    @Test
-    void createInfrastrukturelleWlsException() {
-        val code = "0815";
-        val message = "Everything Everywhere All at Once";
-        val wrappedData = new ExceptionDataWrapper(code, message);
-
-        val serviceID = "serviceID";
-        Mockito.when(serviceIDFormatter.getId()).thenReturn(serviceID);
-
-        val result = unitUnderTest.createInfrastrukturelleWlsException(wrappedData);
-
-        val expectedResult = InfrastrukturelleWlsException.withCode(code).inService(serviceID).buildWithMessage(message);
-
-        Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(expectedResult);
-    }
-
-    @Test
-    void createSicherheitsWlsException() {
-        val code = "0815";
-        val message = "Everything Everywhere All at Once";
-        val wrappedData = new ExceptionDataWrapper(code, message);
-
-        val serviceID = "serviceID";
-        Mockito.when(serviceIDFormatter.getId()).thenReturn(serviceID);
-
-        val result = unitUnderTest.createSicherheitsWlsException(wrappedData);
-
-        val expectedResult = SicherheitsWlsException.withCode(code).inService(serviceID).buildWithMessage(message);
-
-        Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(expectedResult);
-    }
-
-    @Test
-    void verifyAllWlsExceptionsAreSupportedAndMethodSignaturesFollowsCommonDesign() {
+    void should_matchDesignForMethodSignaturesForAllWlsExceptions_when_developed() {
         val createMethodNamePrefix = "create";
         val permittedSubclassed = WlsException.class.getPermittedSubclasses();
         val createMethods = Arrays.stream(unitUnderTest.getClass().getMethods())

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/util/ServiceIDFormatterSpringContextTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/util/ServiceIDFormatterSpringContextTest.java
@@ -1,6 +1,7 @@
 package de.muenchen.oss.wahllokalsystem.wls.common.exception.util;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -11,8 +12,12 @@ class ServiceIDFormatterSpringContextTest {
     @Autowired
     ServiceIDFormatter serviceIDFormatter;
 
-    @Test
-    void checkPropertyForServiceNameIsUsed() {
-        Assertions.assertThat(serviceIDFormatter.getId()).contains("My app name");
+    @Nested
+    class GetId {
+
+        @Test
+        void should_returnServiceId_when_propertyIsDefinedInSpringContext() {
+            Assertions.assertThat(serviceIDFormatter.getId()).contains("My app name");
+        }
     }
 }

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/util/ServiceIDFormatterTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/util/ServiceIDFormatterTest.java
@@ -2,15 +2,20 @@ package de.muenchen.oss.wahllokalsystem.wls.common.exception.util;
 
 import lombok.val;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class ServiceIDFormatterTest {
 
-    @Test
-    void getId() {
-        val appName = "app name";
-        val unitUnderTest = new ServiceIDFormatter(appName);
+    @Nested
+    class GetId {
 
-        Assertions.assertThat(unitUnderTest.getId()).isEqualTo(appName);
+        @Test
+        void should_returnDefinedId_when_called() {
+            val appName = "app name";
+            val unitUnderTest = new ServiceIDFormatter(appName);
+
+            Assertions.assertThat(unitUnderTest.getId()).isEqualTo(appName);
+        }
     }
 }

--- a/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/BezirkIDPermissionEvaluatorImplTest.java
+++ b/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/BezirkIDPermissionEvaluatorImplTest.java
@@ -29,19 +29,19 @@ class BezirkIDPermissionEvaluatorImplTest {
     Authentication auth;
 
     @Nested
-    class TestTokenUserBezirkIdMatches {
+    class TokenUserBezirkIdMatches {
 
         @RegisterExtension
         public LoggerExtension loggerExtension = new LoggerExtension();
 
         @Test
-        void warnOnAuthenticationIsNull() {
+        void should_returnFalseAndCreateLogWarning_when_authenticationIsNull() {
             Assertions.assertThat(unitUnderTest.tokenUserBezirkIdMatches("1234", null)).isFalse();
             Assertions.assertThat(loggerExtension.getFormattedMessages()).contains("No authentication object for bezirkId=1234");
         }
 
         @Test
-        void errorWhileChecking() {
+        void should_returnFalseAndCreateLogError_when_errorWhileCheckingOccurred() {
             Mockito.when(auth.getPrincipal()).thenReturn("1234");
 
             Assertions.assertThat(unitUnderTest.tokenUserBezirkIdMatches("1234", auth)).isFalse();
@@ -49,7 +49,7 @@ class BezirkIDPermissionEvaluatorImplTest {
         }
 
         @Test
-        void bezirkIDMatchesFromToken() {
+        void should_returnTrue_when_bezirkIDMatchesFromToken() {
             val map = new HashMap<>();
             map.put("wahlbezirkid_wahlnummer", "1234");
             map.put("wahlbezirkID", "1234");
@@ -61,7 +61,7 @@ class BezirkIDPermissionEvaluatorImplTest {
         }
 
         @Test
-        void bezirkIDMatchesFromWahlBezirkID() {
+        void should_returnTrue_when_bezirkIDMatchesFromWahlBezirkID() {
             val map = new HashMap<>();
             map.put("wahlbezirkid_wahlnummer", "1234");
             map.put("wahlbezirkID", "4567");
@@ -73,7 +73,7 @@ class BezirkIDPermissionEvaluatorImplTest {
         }
 
         @Test
-        void bezirkIDIsNull() {
+        void should_returnFalse_when_bezirkIDIsNull() {
             val map = new HashMap<>();
             map.put("wahlbezirkid_wahlnummer", "1234");
             map.put("wahlbezirkID", "1234");
@@ -86,7 +86,7 @@ class BezirkIDPermissionEvaluatorImplTest {
         }
 
         @Test
-        void bezirkIDDoesNotMatch() {
+        void should_returnFalse_when_bezirkIDDoesNotMatch() {
             val map = new HashMap<>();
             map.put("wahlbezirkid_wahlnummer", null);
             map.put("wahlbezirkID", "1234");

--- a/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/DummyBezirkIdPermissionEvaluatorImplTest.java
+++ b/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/DummyBezirkIdPermissionEvaluatorImplTest.java
@@ -20,13 +20,13 @@ class DummyBezirkIdPermissionEvaluatorImplTest {
     private final DummyBezirkIdPermissionEvaluatorImpl unitUnderTest = new DummyBezirkIdPermissionEvaluatorImpl();
 
     @Nested
-    class TestTokenUserBezirkIdMatches {
+    class TokenUserBezirkIdMatches {
 
         @RegisterExtension
         public LoggerExtension loggerExtension = new LoggerExtension();
 
         @Test
-        void idMatches() {
+        void should_returnTrue_when_called() {
             Mockito.when(auth.getPrincipal()).thenReturn("1234");
             Assertions.assertThat(unitUnderTest.tokenUserBezirkIdMatches("1234", auth)).isTrue();
         }

--- a/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/ProfilesTest.java
+++ b/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/ProfilesTest.java
@@ -21,7 +21,7 @@ class ProfilesTest {
         private BezirkIDPermissionEvaluator permissionEvaluator;
 
         @Test
-        void evaluatorIsInstanceOfDummyImpl() {
+        void should_haveDummyEvaluatorInContext_when_noBezirkIdCheckIsActive() {
             Assertions.assertThat(permissionEvaluator).isExactlyInstanceOf(DummyBezirkIdPermissionEvaluatorImpl.class);
         }
     }
@@ -36,7 +36,7 @@ class ProfilesTest {
         private BezirkIDPermissionEvaluator permissionEvaluator;
 
         @Test
-        void evaluatorIsInstanceOfBezirkIDPermissionEvaluator() {
+        void should_haveImplementationWithChecksInContext_when_noAdditionalProfilesAreActive() {
             Assertions.assertThat(permissionEvaluator).isExactlyInstanceOf(BezirkIDPermissionEvaluatorImpl.class);
         }
     }

--- a/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/SecurityUtilsTest.java
+++ b/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/SecurityUtilsTest.java
@@ -15,7 +15,7 @@ class SecurityUtilsTest {
     class RunAs {
 
         @Test
-        void userAndPasswortAreSet() {
+        void should_setUserAndPasswortInSecurityContext_when_called() {
             val username = "username";
             val password = "password";
 
@@ -28,7 +28,7 @@ class SecurityUtilsTest {
         }
 
         @Test
-        void authoritiesAreSet() {
+        void should_setAuthoritiesInSecurityContext_when_called() {
             val authority1 = "authority1";
             val authority2 = "authority2";
             val authority3 = "authority3";
@@ -49,13 +49,13 @@ class SecurityUtilsTest {
         }
 
         @Test
-        void nullAuthorityFails() {
+        void should_throwIllegalArgumentException_when_authoritiyIsNull() {
             final String nullAuthority = null;
             Assertions.assertThatThrownBy(() -> SecurityUtils.runAs("", "", nullAuthority)).isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
-        void blankAuthorityFails() {
+        void should_throwIllegalArgumentException_when_authorityIsBlankString() {
             final String blankAuthority = "   ";
             Assertions.assertThatThrownBy(() -> SecurityUtils.runAs("", "", blankAuthority)).isInstanceOf(IllegalArgumentException.class);
         }
@@ -65,7 +65,7 @@ class SecurityUtilsTest {
     class RunWith {
 
         @Test
-        void defaultUserIsSet() {
+        void should_setDefaultUserInSecurityContext_when_called() {
             SecurityUtils.runWith("authority");
 
             val currentSecurityContext = SecurityContextHolder.getContext();
@@ -75,7 +75,7 @@ class SecurityUtilsTest {
         }
 
         @Test
-        void authoritiesAreSet() {
+        void should_setAuthoritiesInSecurityContext_when_authoritiesAreGiven() {
             val authority1 = "authority1";
             val authority2 = "authority2";
             val authority3 = "authority3";
@@ -96,13 +96,13 @@ class SecurityUtilsTest {
         }
 
         @Test
-        void nullAuthorityFails() {
+        void should_throwIllegalArgumentException_when_authorityIsNull() {
             final String nullAuthority = null;
             Assertions.assertThatThrownBy(() -> SecurityUtils.runWith(nullAuthority)).isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
-        void blankAuthorityFails() {
+        void should_throwIllegalArgumentException_when_authorityIsBlank() {
             final String blankAuthority = "   ";
             Assertions.assertThatThrownBy(() -> SecurityUtils.runWith(blankAuthority)).isInstanceOf(IllegalArgumentException.class);
         }
@@ -112,7 +112,7 @@ class SecurityUtilsTest {
     class BuildArgumentsForMissingAuthoritiesVariations {
 
         @Test
-        void buildVariantensForAuthoritiyList() {
+        void should_createStreamWithCombinationsOfAuthoritiesWithOneAuthorityMissingInEachCombination_when_AuthoritiesAreGiven() {
             val authority1 = "authority1";
             val authority2 = "authority2";
             val authority3 = "authority3";


### PR DESCRIPTION
# Beschreibung:

- Tests entsprechend Namenskonvetion angepasst
- der nicht angepasst Tests wird mit #668 entfernt

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] [Codingconventions](https://it-at-m.github.io/Wahllokalsystem/technik/coding_conventions/) beachtet
- [x] ~~Doku aktualisiert~~ - nichts zu tun
- [x] ~~Swagger-API vollständig~~ - nichts zu tun
- [x] ~~Unit-Tests gepflegt~~ - nichts zu tun
- [X] ~~Integrationstests gepflegt~~ - nichts zu tun
- [X] ~~Beispiel-Requests gepflegt~~ - nichts zu tun

# Referenzen[^1]:

Closes #557

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Introduced nested classes in various test files to improve organization and clarity.
	- Renamed test methods across multiple classes for enhanced readability and intent.
	- Restructured test cases in `WlsExceptionDTOTest`, `ExceptionFactoryTest`, and others for better maintainability.

- **Bug Fixes**
	- Adjusted assertions in several tests to ensure they align with new method names and maintain expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->