### PR TITLE
index annotation entfernt

### DIFF
--- a/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/domain/wahlen/Wahl.java
+++ b/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/domain/wahlen/Wahl.java
@@ -14,10 +14,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import org.springframework.stereotype.Indexed;
 
 @Entity
-@Indexed
 @Data
 @EqualsAndHashCode
 @NoArgsConstructor

--- a/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/domain/wahltag/Wahltag.java
+++ b/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/domain/wahltag/Wahltag.java
@@ -11,10 +11,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.springframework.stereotype.Indexed;
 
 @Entity
-@Indexed
 @Data
 @EqualsAndHashCode
 @NoArgsConstructor

--- a/wls-briefwahl-service/src/main/java/de/muenchen/oss/wahllokalsystem/briefwahlservice/domain/Wahlbriefdaten.java
+++ b/wls-briefwahl-service/src/main/java/de/muenchen/oss/wahllokalsystem/briefwahlservice/domain/Wahlbriefdaten.java
@@ -8,10 +8,8 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.stereotype.Indexed;
 
 @Entity
-@Indexed
 @NoArgsConstructor
 @AllArgsConstructor
 @Data

--- a/wls-infomanagement-service/src/main/java/de/muenchen/oss/wahllokalsystem/infomanagementservice/domain/konfiguration/Konfiguration.java
+++ b/wls-infomanagement-service/src/main/java/de/muenchen/oss/wahllokalsystem/infomanagementservice/domain/konfiguration/Konfiguration.java
@@ -7,10 +7,8 @@ import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.stereotype.Indexed;
 
 @Entity
-@Indexed
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/wls-infomanagement-service/src/main/java/de/muenchen/oss/wahllokalsystem/infomanagementservice/domain/wahltag/KonfigurierterWahltag.java
+++ b/wls-infomanagement-service/src/main/java/de/muenchen/oss/wahllokalsystem/infomanagementservice/domain/wahltag/KonfigurierterWahltag.java
@@ -7,10 +7,8 @@ import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.stereotype.Indexed;
 
 @Entity
-@Indexed
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/wls-wahlvorbereitung-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/domain/Waehlerverzeichnis.java
+++ b/wls-wahlvorbereitung-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/domain/Waehlerverzeichnis.java
@@ -7,10 +7,8 @@ import jakarta.persistence.Entity;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.stereotype.Indexed;
 
 @Entity
-@Indexed
 @Data
 @NoArgsConstructor
 @AllArgsConstructor


### PR DESCRIPTION
# Beschreibung:

Index-Annotation wurde ersatzlos entfernt, da sie nicht benötigt wird.

# Referenzen[^1]:

Closes #424


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed `@Indexed` annotation from multiple domain classes across different services, potentially changing how these entities are indexed or searched within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->