### PR TITLE
535 release für wls common bauen - 1.2.0

### DIFF
--- a/wls-common/exception/pom.xml
+++ b/wls-common/exception/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0</version>
     </parent>
 
     <artifactId>exception</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.2.0</version>
     <description>Übergreifende Exception Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>HEAD</tag>
+      <tag>wls-common/1.2.0</tag>
   </scm>
 
     <dependencies>
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>testing</artifactId>
-            <version>1.2.0-SNAPSHOT</version>
+            <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/wls-common/exception/pom.xml
+++ b/wls-common/exception/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>exception</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0-SNAPSHOT</version>
     <description>Übergreifende Exception Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>wls-common/1.2.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>testing</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/wls-common/monitoring/pom.xml
+++ b/wls-common/monitoring/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0</version>
     </parent>
 
     <artifactId>monitoring</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.2.0</version>
     <description>Übergreifende Monitoring Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>HEAD</tag>
+      <tag>wls-common/1.2.0</tag>
   </scm>
 
     <build>

--- a/wls-common/monitoring/pom.xml
+++ b/wls-common/monitoring/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>monitoring</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0-SNAPSHOT</version>
     <description>Übergreifende Monitoring Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>wls-common/1.2.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
     <artifactId>parent</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0-SNAPSHOT</version>
     <name>wls-common</name>
     <packaging>pom</packaging>
     <description>Serviceübergreifende Aspekte</description>
@@ -72,7 +72,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-        <tag>wls-common/1.2.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <profiles>

--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
     <artifactId>parent</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.2.0</version>
     <name>wls-common</name>
     <packaging>pom</packaging>
     <description>Serviceübergreifende Aspekte</description>
@@ -72,7 +72,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-common/1.2.0</tag>
     </scm>
 
     <profiles>

--- a/wls-common/security/pom.xml
+++ b/wls-common/security/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0</version>
     </parent>
 
     <artifactId>security</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.2.0</version>
     <description>Uebergreifende Security Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>HEAD</tag>
+      <tag>wls-common/1.2.0</tag>
   </scm>
 
     <dependencies>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>exception</artifactId>
-            <version>1.2.0-SNAPSHOT</version>
+            <version>1.2.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>testing</artifactId>
-            <version>1.2.0-SNAPSHOT</version>
+            <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/wls-common/security/pom.xml
+++ b/wls-common/security/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>security</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0-SNAPSHOT</version>
     <description>Uebergreifende Security Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>wls-common/1.2.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>exception</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>testing</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/wls-common/testing/pom.xml
+++ b/wls-common/testing/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>testing</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0-SNAPSHOT</version>
     <description>Übergreifende Aspekte für das Testing</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-        <tag>wls-common/1.2.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencies>

--- a/wls-common/testing/pom.xml
+++ b/wls-common/testing/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0</version>
     </parent>
 
     <artifactId>testing</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.2.0</version>
     <description>Übergreifende Aspekte für das Testing</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-common/1.2.0</tag>
     </scm>
 
     <dependencies>


### PR DESCRIPTION
# Beschreibung:

- Neue Release-Version erstellt: https://central.sonatype.com/search?q=de.muenchen.oss.wahllokalsystem&sort=published
- Releasenotes angepasst: https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-common%2F1.2.0

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

# Referenzen[^1]:

Closes #535 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated project version from `1.2.0-SNAPSHOT` to `1.3.0-SNAPSHOT` across multiple modules:
		- Exception module
		- Monitoring module
		- Security module
		- Testing module
		- Parent project `wls-common`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->