### PR TITLE
734 verwendung von validate bei integrationtest

### DIFF
--- a/wls-ergebnismeldung-service/src/main/resources/db/migrations/h2/V5_0__removeNotNullFromBegruendungGrund2.sql
+++ b/wls-ergebnismeldung-service/src/main/resources/db/migrations/h2/V5_0__removeNotNullFromBegruendungGrund2.sql
@@ -1,0 +1,2 @@
+ALTER TABLE Begruendung
+    ALTER COLUMN grund2 VARCHAR(1024) NULL;

--- a/wls-ergebnismeldung-service/src/main/resources/db/migrations/oracle/V5_0__removeNotNullFromBegruendungGrund2.sql
+++ b/wls-ergebnismeldung-service/src/main/resources/db/migrations/oracle/V5_0__removeNotNullFromBegruendungGrund2.sql
@@ -1,0 +1,2 @@
+ALTER TABLE Begruendung
+    MODIFY (grund2 NULL);

--- a/wls-ergebnismeldung-service/src/test/resources/application-test.yml
+++ b/wls-ergebnismeldung-service/src/test/resources/application-test.yml
@@ -13,11 +13,7 @@ spring:
   jpa:
     database: H2
     hibernate:
-      # always drop and create the db should be the best
-      # configuration for local (development) mode. this
-      # is also the default, that spring offers by convention.
-      # but here explicite:
-      ddl-auto: create-drop
+      ddl-auto: validate
       naming.physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     # Logging for database operation
     show-sql: true

--- a/wls-ergebnismeldung-service/src/test/resources/begruendung.http
+++ b/wls-ergebnismeldung-service/src/test/resources/begruendung.http
@@ -26,3 +26,19 @@ Content-Type: application/json
   "nachzaehlung": true,
   "unstimmigkeiten": true
 }
+
+### Begründung ohne Grund 2
+POST {{ WLS_ERGEBNISMELDUNG_SERVICE_URL }}/businessActions/begruendung/wbz-1/1/LTW_BZW_A
+Authorization: Bearer {{$auth.token("auth-service")}}
+Content-Type: application/json
+
+{
+  "bezirkUndWahlIDStapelart": {
+    "wahlbezirkID": "wahlbezirkID",
+    "wahlID": "wahlID",
+    "stapelart": "LTW_BZW_A"
+  },
+  "grund1": "ohne Grund 2",
+  "nachzaehlung": true,
+  "unstimmigkeiten": true
+}

--- a/wls-ergebnismeldung-service/src/test/resources/begruendung.http
+++ b/wls-ergebnismeldung-service/src/test/resources/begruendung.http
@@ -6,6 +6,10 @@ Authorization: Bearer {{$auth.token("auth-service")}}
 GET {{ WLS_ERGEBNISMELDUNG_SERVICE_URL }}/businessActions/begruendung/wbz-1/1/LTW_BZW_A
 Authorization: Bearer {{$auth.token("auth-service")}}
 
+### GET Begruendung sent by POST
+GET {{ WLS_ERGEBNISMELDUNG_SERVICE_URL }}/businessActions/begruendung/wahlbezirkID/wahlID/LTW_BZW_A
+Authorization: Bearer {{$auth.token("auth-service")}}
+
 ### Initialisiere Begruendung (needs profile 'dummy.clients', stores Begruendung entity in local DB retrieved from DummyClient )
 POST {{ WLS_ERGEBNISMELDUNG_SERVICE_URL }}/businessActions/begruendung/wbz-1/1/LTW_BZW_A
 Authorization: Bearer {{$auth.token("auth-service")}}


### PR DESCRIPTION
# Beschreibung:

- Anpassung der `application-test.yml`
- Fix bei Begründung notwendig

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] [Codingconventions](https://it-at-m.github.io/Wahllokalsystem/technik/coding_conventions/) beachtet
- [X] Beispiel-Requests gepflegt

# Referenzen[^1]:

Closes #734

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Database Changes**
	- Modified the `grund2` column in the `Begruendung` table to allow null values across different database platforms (H2 and Oracle)

- **Test Configuration**
	- Updated database schema validation setting from `create-drop` to `validate` in test environment

- **API Updates**
	- Added new GET and POST requests for retrieving and creating "Begruendung" data with optional second reason

<!-- end of auto-generated comment: release notes by coderabbit.ai -->