### PR TITLE
739 doku für den wahlvorbereitung service fehlt

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -107,6 +107,7 @@ export default withMermaid({
                 {text: 'Infomanagement-Service', link: `${PATH_SERVICES}infomanagement-service/`},
                 {text: 'Monitoring-Service', link: `${PATH_SERVICES}monitoring-service/`},
                 {text: 'Vorfälle und Vorkommnisse-Service', link: `${PATH_SERVICES}vorfaelleundvorkommnisse-service/`},
+                {text: 'Wahlvorbereitung-Service', link: `${PATH_SERVICES}wahlvorbereitungs-service/`},
                 {text: 'Wahlvorstand-Service', link: `${PATH_SERVICES}wahlvorstand-service/`},
             ],
         },

--- a/docs/src/services/wahlvorbereitungs-service/index.md
+++ b/docs/src/services/wahlvorbereitungs-service/index.md
@@ -1,0 +1,16 @@
+# Wahlvorbereitung-Service
+
+Verwaltet Informationen über den Zustand eines Wahlbezirkes vor der Wahlhandlung.
+
+## Abhängigkeiten
+
+Es werden keine weiteren Services für den Betrieb benötigt.
+
+## Daten und Funktionen
+
+Folgende Informationen werden lesend und schreibend verwaltet:
+
+- Ausstattung an Wahlkabinen, -tischen, Urnen und Nebenräumen eines Urnenwahlbezirkes
+- Anzahl der Urnen eines Briefwahlbezirkes
+- Beginn, Ende und Unterbrechungen der Wahlhandlung
+- Informationen zum vorliegenden Wählerverzeichnis

--- a/docs/src/technik/get_started/index.md
+++ b/docs/src/technik/get_started/index.md
@@ -59,7 +59,7 @@ flowchart LR
 | [Infomanagement](/services/infomanagement-service/)                      | 8201 |
 | [Monitoring](/services/monitoring-service/)                              | 8206 |
 | [Vorfälle und Vorkommnisse](/services/vorfaelleundvorkommnisse-service/) | 8204 |
-| Wahlvorbereitung                                                         | 8203 |
+| [Wahlvorbereitung](/services/wahlvorbereitungs-service/)                 | 8203 |
 | [Wahlvorstand](/services/wahlvorstand-service/)                          | 8207 |
 
 ## Benutzer


### PR DESCRIPTION
# Beschreibung:

- Seite mit Beschreibung des Wahlvorbereitungsservice ergänzt
  - alphabetisch in der Seitennavigation eingefügt
- in der Übersicht der Services und deren Ports den Link zur Beschreibung ergänzt

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Dokumentation -->
### Dokumentation
- [x] Links geprüft

# Referenzen[^1]:

Closes #739

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added documentation for the Wahlvorbereitung-Service
	- Updated sidebar configuration to include new service
	- Converted service entry to a hyperlink for improved navigation in technical documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->