### PR TITLE
Fix Typos bei Begründung in Ergebnismeldungservice

### DIFF
--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/exception/ExceptionConstants.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/exception/ExceptionConstants.java
@@ -43,7 +43,7 @@ public class ExceptionConstants {
     public static final ExceptionDataWrapper POST_BEGRUENDUNG_PARAMETER_UNVOLLSTAENDIG = new ExceptionDataWrapper("103",
             "postBegruendung: Parameter unvollständig.");
     public static final ExceptionDataWrapper BEGRUENDUNG_UNSAVEABLE = new ExceptionDataWrapper("624",
-            "postStatus: Der Status konnte nicht gespeichert werden.");
+            "postBegruendung: Die Begruendung konnte nicht gespeichtert werden.");
 
     public static final ExceptionDataWrapper GET_STIMMABGABEVERMERKE_PARAMETER_UNVOLLSTAENDIG = new ExceptionDataWrapper("608",
             "getStimmabgabevermerke: Parameter unvollstaendig");

--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/exception/ExceptionConstants.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/exception/ExceptionConstants.java
@@ -43,7 +43,7 @@ public class ExceptionConstants {
     public static final ExceptionDataWrapper POST_BEGRUENDUNG_PARAMETER_UNVOLLSTAENDIG = new ExceptionDataWrapper("103",
             "postBegruendung: Parameter unvollständig.");
     public static final ExceptionDataWrapper BEGRUENDUNG_UNSAVEABLE = new ExceptionDataWrapper("624",
-            "postBegruendung: Die Begruendung konnte nicht gespeichtert werden.");
+            "postBegruendung: Die Begruendung konnte nicht gespeichert werden.");
 
     public static final ExceptionDataWrapper GET_STIMMABGABEVERMERKE_PARAMETER_UNVOLLSTAENDIG = new ExceptionDataWrapper("608",
             "getStimmabgabevermerke: Parameter unvollstaendig");

--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/begruendung/BegruendungService.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/begruendung/BegruendungService.java
@@ -51,7 +51,7 @@ public class BegruendungService {
         try {
             begruendungRepository.save(begruendungModelMapper.toEntity(begruendungToAdd));
         } catch (Exception e) {
-            log.error("#postStatus unsaveable:", e);
+            log.error("#postBegruendung unsaveable:", e);
             throw exceptionFactory.createTechnischeWlsException(ExceptionConstants.BEGRUENDUNG_UNSAVEABLE);
         }
     }


### PR DESCRIPTION
# Beschreibung:

- Typos in Fehler- und Logmeldungen gefixt

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

# Referenzen[^1]:

Verwandt mit Issue #

Closes #712

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated error message in exception handling to more accurately describe the context of the error when saving a reason (Begruendung)
	- Corrected log message in `BegruendungService` to match the specific method being executed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->