### PR TITLE
Fix Typos in Ergebnismeldungsservice

### DIFF
--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/exception/ExceptionConstants.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/exception/ExceptionConstants.java
@@ -50,6 +50,6 @@ public class ExceptionConstants {
     public static final ExceptionDataWrapper POST_STIMMABGABEVERMERKE_PARAMETER_UNVOLLSTAENDIG = new ExceptionDataWrapper("609",
             "postStimmabgabevermerke: Parameter unvollstaendig");
     public static final ExceptionDataWrapper STIMMABGABEVERMERKE_UNSAVEABLE = new ExceptionDataWrapper("620",
-            "postStimmabgabevermerke: Die Stimmabgabevermerke konnten nicht gespeichtert werden.");
+            "postStimmabgabevermerke: Die Stimmabgabevermerke konnten nicht gespeichert werden.");
 
 }

--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/awerte/AsyncProgressController.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/awerte/AsyncProgressController.java
@@ -24,7 +24,7 @@ public class AsyncProgressController {
     @ApiResponses(
             value = {
                     @ApiResponse(
-                            responseCode = "200", description = "Auskunft über Bearbeitungzustand erhalten",
+                            responseCode = "200", description = "Auskunft über Bearbeitungszustand erhalten",
                             content = { @Content(mediaType = "application/json", schema = @Schema(implementation = AsyncProgressDTO.class)) }
                     ),
                     @ApiResponse(

--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/awerte/AWerteModelMapper.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/awerte/AWerteModelMapper.java
@@ -7,7 +7,7 @@ import org.mapstruct.Mapper;
 @Mapper
 public interface AWerteModelMapper {
 
-    List<AWerte> fromListOfAWerteModeltoListOfAWerteEntity(List<AWerteModel> aWerteModelList);
+    List<AWerte> fromListOfAWerteModelToListOfAWerteEntity(List<AWerteModel> aWerteModelList);
 
     List<AWerteModel> fromListOfAWerteEntityToListOfAWerteModel(List<AWerte> aWerteEntityList);
 }

--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/awerte/AbstractAWerteService.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/awerte/AbstractAWerteService.java
@@ -32,7 +32,7 @@ public abstract class AbstractAWerteService {
 
         if (aWerteList != null && !aWerteList.isEmpty()) {
             try {
-                aWerteRepository.saveAll(aWerteModelMapper.fromListOfAWerteModeltoListOfAWerteEntity(aWerteList));
+                aWerteRepository.saveAll(aWerteModelMapper.fromListOfAWerteModelToListOfAWerteEntity(aWerteList));
             } catch (Exception e) {
                 log.error("#getAWerte unsaveable: " + e.getMessage(), e);
             }

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/client/MonitoringClientTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/client/MonitoringClientTest.java
@@ -57,13 +57,13 @@ class MonitoringClientTest {
             val uhrzeit = LocalDateTime.now();
 
             val mockedDTOToSend = Mockito.mock(SendungsdatenDTO.class);
-            val mockedApiWlsExcepton = TechnischeWlsException.withCode("").buildWithMessage("api call failed");
+            val mockedApiWlsException = TechnischeWlsException.withCode("").buildWithMessage("api call failed");
 
             Mockito.when(statusClientMapper.toSendungsdatenDTO(eq(bezirkUndWahlID), eq(uhrzeit))).thenReturn(mockedDTOToSend);
-            Mockito.doThrow(mockedApiWlsExcepton).when(wahllokalZustandControllerApi).postSchnellmeldungSendungsuhrzeit(mockedDTOToSend);
+            Mockito.doThrow(mockedApiWlsException).when(wahllokalZustandControllerApi).postSchnellmeldungSendungsuhrzeit(mockedDTOToSend);
 
             Assertions.assertThatException().isThrownBy(() -> unitUnderTest.postSchnellmeldungSendungsuhrzeit(bezirkUndWahlID, uhrzeit))
-                    .isSameAs(mockedApiWlsExcepton);
+                    .isSameAs(mockedApiWlsException);
         }
 
         @Test
@@ -106,13 +106,13 @@ class MonitoringClientTest {
             val uhrzeit = LocalDateTime.now();
 
             val mockedDTOToSend = Mockito.mock(DruckdatenDTO.class);
-            val mockedApiWlsExcepton = TechnischeWlsException.withCode("").buildWithMessage("api call failed");
+            val mockedApiWlsException = TechnischeWlsException.withCode("").buildWithMessage("api call failed");
 
             Mockito.when(statusClientMapper.toDruckdatenDTO(eq(bezirkUndWahlID), eq(uhrzeit))).thenReturn(mockedDTOToSend);
-            Mockito.doThrow(mockedApiWlsExcepton).when(wahllokalZustandControllerApi).postSchnellmeldungDruckuhrzeit(mockedDTOToSend);
+            Mockito.doThrow(mockedApiWlsException).when(wahllokalZustandControllerApi).postSchnellmeldungDruckuhrzeit(mockedDTOToSend);
 
             Assertions.assertThatException().isThrownBy(() -> unitUnderTest.postSchnellmeldungDruckuhrzeit(bezirkUndWahlID, uhrzeit))
-                    .isSameAs(mockedApiWlsExcepton);
+                    .isSameAs(mockedApiWlsException);
         }
 
         @Test
@@ -155,13 +155,13 @@ class MonitoringClientTest {
             val uhrzeit = LocalDateTime.now();
 
             val mockedDTOToSend = Mockito.mock(SendungsdatenDTO.class);
-            val mockedApiWlsExcepton = TechnischeWlsException.withCode("").buildWithMessage("api call failed");
+            val mockedApiWlsException = TechnischeWlsException.withCode("").buildWithMessage("api call failed");
 
             Mockito.when(statusClientMapper.toSendungsdatenDTO(eq(bezirkUndWahlID), eq(uhrzeit))).thenReturn(mockedDTOToSend);
-            Mockito.doThrow(mockedApiWlsExcepton).when(wahllokalZustandControllerApi).postNiederschriftSendungsuhrzeit(mockedDTOToSend);
+            Mockito.doThrow(mockedApiWlsException).when(wahllokalZustandControllerApi).postNiederschriftSendungsuhrzeit(mockedDTOToSend);
 
             Assertions.assertThatException().isThrownBy(() -> unitUnderTest.postNiederschriftSendungsuhrzeit(bezirkUndWahlID, uhrzeit))
-                    .isSameAs(mockedApiWlsExcepton);
+                    .isSameAs(mockedApiWlsException);
         }
 
         @Test
@@ -204,13 +204,13 @@ class MonitoringClientTest {
             val uhrzeit = LocalDateTime.now();
 
             val mockedDTOToSend = Mockito.mock(DruckdatenDTO.class);
-            val mockedApiWlsExcepton = TechnischeWlsException.withCode("").buildWithMessage("api call failed");
+            val mockedApiWlsException = TechnischeWlsException.withCode("").buildWithMessage("api call failed");
 
             Mockito.when(statusClientMapper.toDruckdatenDTO(eq(bezirkUndWahlID), eq(uhrzeit))).thenReturn(mockedDTOToSend);
-            Mockito.doThrow(mockedApiWlsExcepton).when(wahllokalZustandControllerApi).postNiederschriftDruckuhrzeit(mockedDTOToSend);
+            Mockito.doThrow(mockedApiWlsException).when(wahllokalZustandControllerApi).postNiederschriftDruckuhrzeit(mockedDTOToSend);
 
             Assertions.assertThatException().isThrownBy(() -> unitUnderTest.postNiederschriftDruckuhrzeit(bezirkUndWahlID, uhrzeit))
-                    .isSameAs(mockedApiWlsExcepton);
+                    .isSameAs(mockedApiWlsException);
         }
 
         @Test

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/awerte/AWerteControllerIntegrationTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/awerte/AWerteControllerIntegrationTest.java
@@ -106,7 +106,7 @@ public class AWerteControllerIntegrationTest {
             api.perform(request).andExpect(status().isOk()).andReturn();
 
             val aWerteFromRepo = awerteRepository.findByBezirkUndWahlID_WahlbezirkID(wahlbezirkID);
-            val expectedEntities = aWerteModelMapper.fromListOfAWerteModeltoListOfAWerteEntity(
+            val expectedEntities = aWerteModelMapper.fromListOfAWerteModelToListOfAWerteEntity(
                     aWerteClientMapper.fromRemoteClientListOfWahlberechtigteDtoToListOfAWerteModel(eaiWahlberechtigte));
 
             Assertions.assertThat(aWerteFromRepo).usingRecursiveComparison().isEqualTo(expectedEntities);

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/awerte/AsyncProgressControllerIntegrationTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/awerte/AsyncProgressControllerIntegrationTest.java
@@ -62,7 +62,7 @@ public class AsyncProgressControllerIntegrationTest {
         }
 
         @Test
-        void should_returnHttpStatus500WithWlsException_when_anExceptionOccured() throws Exception {
+        void should_returnHttpStatus500WithWlsException_when_anExceptionOccurred() throws Exception {
             val exceptionMessage = "mapping failed";
             Mockito.when(asyncProgressDTOMapper.toDTO(any())).thenThrow(new RuntimeException(exceptionMessage));
 

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/awerte/AWerteModelMapperTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/awerte/AWerteModelMapperTest.java
@@ -14,13 +14,13 @@ class AWerteModelMapperTest {
     private final AWerteModelMapper unitUnderTest = Mappers.getMapper(AWerteModelMapper.class);
 
     @Nested
-    class FromListOfAWerteModeltoListOfAWerteEntity {
+    class FromListOfAWerteModelToListOfAWerteEntity {
         @Test
         void should_returnListOfAWerteEntity_when_listOfAWerteModelIsGiven() {
             val wahlbezirkID = "wahlbezirkID";
             val modelsToMap = createListOfAWerteModels(wahlbezirkID);
 
-            val result = unitUnderTest.fromListOfAWerteModeltoListOfAWerteEntity(modelsToMap);
+            val result = unitUnderTest.fromListOfAWerteModelToListOfAWerteEntity(modelsToMap);
 
             val expectedResult = createListOfAWerteEntities(wahlbezirkID);
             Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(expectedResult);

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/awerte/AWerteServiceSecurityTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/awerte/AWerteServiceSecurityTest.java
@@ -66,7 +66,7 @@ class AWerteServiceSecurityTest {
         }
 
         @Test
-        void should_grantAccessAndThrowNoException_when_allAuthoritiesAdminGetAwerteIsValid() throws Exception {
+        void should_grantAccessAndThrowNoException_when_allAuthoritiesAdminGetAWerteIsValid() throws Exception {
             SecurityUtils.runWith(Authorities.ALL_AUTHORITIES_ADMIN_GET_AWERTE);
 
             val wahlbezirkID = "wahlbezirkID";

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/awerte/AWerteServiceTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/awerte/AWerteServiceTest.java
@@ -58,7 +58,7 @@ class AWerteServiceTest {
             val result = unitUnderTest.getAWerte(wahlbezirkID);
 
             Mockito.verify(aWerteValidator, times(1)).validWahlbezirkIDParamOrThrow(Mockito.any());
-            Mockito.verify(aWerteModelMapper, times(1)).fromListOfAWerteModeltoListOfAWerteEntity(Mockito.any());
+            Mockito.verify(aWerteModelMapper, times(1)).fromListOfAWerteModelToListOfAWerteEntity(Mockito.any());
 
             Assertions.assertThat(result).isEqualTo(aWerteModelListFromClient);
         }
@@ -67,7 +67,7 @@ class AWerteServiceTest {
         void should_saveEaiDataInRepo_when_eaiDataFound() {
             val wahlbezirkID = "wahlbezirkID1";
             val aWerteModelListFromClient = createListOfAWerteModels(wahlbezirkID);
-            val mappedAWerteEntityList = aWerteModelMapper.fromListOfAWerteModeltoListOfAWerteEntity(aWerteModelListFromClient);
+            val mappedAWerteEntityList = aWerteModelMapper.fromListOfAWerteModelToListOfAWerteEntity(aWerteModelListFromClient);
 
             Mockito.when(aWerteClient.getAWerte(wahlbezirkID)).thenReturn(aWerteModelListFromClient);
 

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/awerte/AsyncAWerteServiceTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/awerte/AsyncAWerteServiceTest.java
@@ -20,7 +20,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class AsyncAwerteServiceTest {
+class AsyncAWerteServiceTest {
 
     @Mock
     AsyncProgress asyncProgress;
@@ -62,7 +62,7 @@ class AsyncAwerteServiceTest {
             Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.initialiseAWerte(wahlbezirkIDs));
             Mockito.verify(asyncProgress, times(3)).setAWerteNext(Mockito.any());
             Mockito.verify(aWerteValidator, times(3)).validWahlbezirkIDParamOrThrow(Mockito.any());
-            Mockito.verify(aWerteModelMapper, times(3)).fromListOfAWerteModeltoListOfAWerteEntity(Mockito.any());
+            Mockito.verify(aWerteModelMapper, times(3)).fromListOfAWerteModelToListOfAWerteEntity(Mockito.any());
             Mockito.verify(aWerteRepository, times(3)).saveAll(Mockito.any());
 
         }

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/begruendung/BegruendungServiceSecurityTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/begruendung/BegruendungServiceSecurityTest.java
@@ -2,6 +2,7 @@ package de.muenchen.oss.wahllokalsystem.ergebnismeldungservice.service.begruendu
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.notNull;
+
 import de.muenchen.oss.wahllokalsystem.ergebnismeldungservice.MicroServiceApplication;
 import de.muenchen.oss.wahllokalsystem.ergebnismeldungservice.TestConstants;
 import de.muenchen.oss.wahllokalsystem.ergebnismeldungservice.configuration.Profiles;
@@ -101,7 +102,7 @@ class BegruendungServiceSecurityTest {
         }
 
         @Test
-        void should_throwAccessDeniedException_when_allRequiredAthoritiesArePresentButBezirkIDEvaluatorReturnsFalse() {
+        void should_throwAccessDeniedException_when_allRequiredAuthoritiesArePresentButBezirkIDEvaluatorReturnsFalse() {
             SecurityUtils.runWith(Authorities.ALL_AUTHORITIES_SET_BEGRUENDUNG);
             val wahlbezirkID = "wahlbezirkID";
             val wahlID = "wahlID";

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/status/StatusServiceSecurityTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/status/StatusServiceSecurityTest.java
@@ -96,7 +96,7 @@ class StatusServiceSecurityTest {
         }
 
         @Test
-        void should_throwAccessDeniedException_when_allRequiredAthoritiesArePresentButBezirkIDEvaluatorReturnsFalse() {
+        void should_throwAccessDeniedException_when_allRequiredAuthoritiesArePresentButBezirkIDEvaluatorReturnsFalse() {
             SecurityUtils.runWith(Authorities.ALL_AUTHORITIES_SET_STATUS);
 
             val wahlbezirkID = "wahlbezirkID";

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/utils/WithMockUserAsJwtSecurityContextFactory.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/utils/WithMockUserAsJwtSecurityContextFactory.java
@@ -60,8 +60,8 @@ final public class WithMockUserAsJwtSecurityContextFactory implements WithSecuri
         this.securityContextHolderStrategy = securityContextHolderStrategy;
     }
 
-    private Map<String, Object> createClaimsMap(final String[] concatedClaimProperties, final String keyValueSeparator) {
-        return Arrays.stream(concatedClaimProperties).map(concatedClaimProperty -> concatedClaimProperty.split(keyValueSeparator))
+    private Map<String, Object> createClaimsMap(final String[] concatenatedClaimProperties, final String keyValueSeparator) {
+        return Arrays.stream(concatenatedClaimProperties).map(concatenatedClaimProperty -> concatenatedClaimProperty.split(keyValueSeparator))
                 .collect(Collectors.toMap(propertyAsArray -> propertyAsArray[0], propertyAsArray -> propertyAsArray[1]));
     }
 }


### PR DESCRIPTION
# Beschreibung:

Ausschließlich Korrektur von Rechtschreibfehlern auf die in #753 verwiesen wurde

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

# Referenzen[^1]:

Verwandt mit Issue #753

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected several typographical errors in method names, variable names, and error messages across multiple files
	- Fixed spelling mistakes in test method names and class names
	- Improved naming consistency in the codebase

- **Style**
	- Updated method and variable names to follow consistent naming conventions
	- Corrected capitalization in class and method names

<!-- end of auto-generated comment: release notes by coderabbit.ai -->