### PR TITLE
756 instabile tests bei authservice

### DIFF
--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/rest/UserControllerIntegrationTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/rest/UserControllerIntegrationTest.java
@@ -79,6 +79,7 @@ public class UserControllerIntegrationTest {
             userRepository.deleteUsersByWahltagID("wahltagID");
             authorityRepository.deleteAll();
             permissionRepository.deleteAll();
+            loginAttemptRepository.deleteAll();
         });
     }
 

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/rest/WahllokalBenutzerControllerIntegrationTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/rest/WahllokalBenutzerControllerIntegrationTest.java
@@ -67,9 +67,11 @@ class WahllokalBenutzerControllerIntegrationTest {
 
     @AfterEach
     void tearDown() {
-        transactionTemplate.executeWithoutResult(status -> entityManager.createQuery("DELETE FROM User").executeUpdate());
-        permissionRepository.deleteAll();
-        authorityRepository.deleteAll();
+        transactionTemplate.executeWithoutResult(status -> {
+            entityManager.createQuery("DELETE FROM User").executeUpdate();
+            permissionRepository.deleteAll();
+            authorityRepository.deleteAll();
+        });
     }
 
     @Nested


### PR DESCRIPTION
# Beschreibung:

- Verbesserung des Aufräumens der Datenbank nach Integrationstests

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] Integrationstests gepflegt

# Referenzen[^1]:

Closes #756

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced test cleanup logic in `UserControllerIntegrationTest` by adding login attempt repository clearing
	- Refactored transaction management in `WahllokalBenutzerControllerIntegrationTest` to consolidate database cleanup operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->