### PR TITLE
fixed description of getBegruendung in BegruendungController, Correct…

### DIFF
--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/begruendung/BegruendungController.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/begruendung/BegruendungController.java
@@ -1,7 +1,6 @@
 package de.muenchen.oss.wahllokalsystem.ergebnismeldungservice.rest.begruendung;
 
 import de.muenchen.oss.wahllokalsystem.ergebnismeldungservice.domain.common.Stapelart;
-import de.muenchen.oss.wahllokalsystem.ergebnismeldungservice.rest.wahlscheine.WahlscheineDTO;
 import de.muenchen.oss.wahllokalsystem.ergebnismeldungservice.service.begruendung.BegruendungReference;
 import de.muenchen.oss.wahllokalsystem.ergebnismeldungservice.service.begruendung.BegruendungService;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExceptionDTO;
@@ -35,8 +34,8 @@ public class BegruendungController {
     @ApiResponses(
             value = {
                     @ApiResponse(
-                            responseCode = "200", description = "Es existiert eine Begruendung",
-                            content = { @Content(mediaType = "application/json", schema = @Schema(implementation = WahlscheineDTO.class)) }
+                            responseCode = "200", description = "Es existiert eine Begruendung.",
+                            content = { @Content(mediaType = "application/json", schema = @Schema(implementation = BegruendungDTO.class)) }
                     ),
                     @ApiResponse(
                             responseCode = "204", description = "Es existieren keine Begruendungen zu den entsprechenden Kriterien",


### PR DESCRIPTION
Die Beschreibung des return-Wertes der Methode getBegruendung aus BegreundungController war falsch und führte zur Generierung einer falschen Api-Spezifikation in openapi.json. 
WahlscheineDTO war falsch, BegruendungDTO ist richtig

Siehe auch #764 

Closes #764


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated API response documentation for the justification retrieval endpoint
	- Modified response content type from `WahlscheineDTO` to `BegruendungDTO`
	- Added a period to the response description

<!-- end of auto-generated comment: release notes by coderabbit.ai -->