### PR TITLE
Fix DTOs bei PostErgebnisse und BezirkIDCheck bei getAllErgebnisse

### DIFF
--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/begruendung/BegruendungDTOMapper.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/begruendung/BegruendungDTOMapper.java
@@ -12,7 +12,7 @@ public interface BegruendungDTOMapper {
 
     @Mapping(target = "bezirkUndWahlIDStapelart.wahlbezirkID", source = "wahlbezirkID")
     @Mapping(target = "bezirkUndWahlIDStapelart.wahlID", source = "wahlID")
-    @Mapping(target = "bezirkUndWahlIDStapelart.stapelartDTO", source = "stapelart")
+    @Mapping(target = "bezirkUndWahlIDStapelart.stapelart", source = "stapelart")
     @Mapping(target = "grund", source = "grund1")
     BegruendungDTO toDTO(BegruendungModel model);
 
@@ -20,7 +20,7 @@ public interface BegruendungDTOMapper {
 
     @Mapping(target = "wahlbezirkID", source = "bezirkUndWahlIDStapelart.wahlbezirkID")
     @Mapping(target = "wahlID", source = "bezirkUndWahlIDStapelart.wahlID")
-    @Mapping(target = "stapelart", source = "bezirkUndWahlIDStapelart.stapelartDTO")
+    @Mapping(target = "stapelart", source = "bezirkUndWahlIDStapelart.stapelart")
     @Mapping(target = "grund1", source = "grund")
     BegruendungModel toModel(BegruendungDTO dto);
 

--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/common/BezirkUndWahlIDStapelartDTO.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/common/BezirkUndWahlIDStapelartDTO.java
@@ -2,5 +2,5 @@ package de.muenchen.oss.wahllokalsystem.ergebnismeldungservice.rest.common;
 
 import jakarta.validation.constraints.NotNull;
 
-public record BezirkUndWahlIDStapelartDTO(@NotNull String wahlbezirkID, @NotNull String wahlID, @NotNull StapelartDTO stapelartDTO) {
+public record BezirkUndWahlIDStapelartDTO(@NotNull String wahlbezirkID, @NotNull String wahlID, @NotNull StapelartDTO stapelart) {
 }

--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/ergebnisse/ErgebnisseDTO.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/ergebnisse/ErgebnisseDTO.java
@@ -6,6 +6,6 @@ import java.util.List;
 import lombok.Builder;
 
 @Builder
-public record ErgebnisseDTO(@NotNull BezirkUndWahlIDStapelartDTO bezirkUndWahlIDStapelartDTO,
+public record ErgebnisseDTO(@NotNull BezirkUndWahlIDStapelartDTO bezirkUndWahlIDStapelart,
                             @NotNull List<ErgebnisDTO> ergebnisse) {
 }

--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/ergebnisse/ErgebnisseDTOMapper.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/ergebnisse/ErgebnisseDTOMapper.java
@@ -10,14 +10,14 @@ import org.mapstruct.Mapping;
 @Mapper
 public interface ErgebnisseDTOMapper {
 
-    @Mapping(target = "wahlbezirkID", source = "bezirkUndWahlIDStapelartDTO.wahlbezirkID")
-    @Mapping(target = "wahlID", source = "bezirkUndWahlIDStapelartDTO.wahlID")
-    @Mapping(target = "stapelart", source = "bezirkUndWahlIDStapelartDTO.stapelartDTO")
+    @Mapping(target = "wahlbezirkID", source = "bezirkUndWahlIDStapelart.wahlbezirkID")
+    @Mapping(target = "wahlID", source = "bezirkUndWahlIDStapelart.wahlID")
+    @Mapping(target = "stapelart", source = "bezirkUndWahlIDStapelart.stapelart")
     ErgebnisseModel toModel(ErgebnisseDTO dto);
 
-    @Mapping(target = "bezirkUndWahlIDStapelartDTO.wahlbezirkID", source = "wahlbezirkID")
-    @Mapping(target = "bezirkUndWahlIDStapelartDTO.wahlID", source = "wahlID")
-    @Mapping(target = "bezirkUndWahlIDStapelartDTO.stapelartDTO", source = "stapelart")
+    @Mapping(target = "bezirkUndWahlIDStapelart.wahlbezirkID", source = "wahlbezirkID")
+    @Mapping(target = "bezirkUndWahlIDStapelart.wahlID", source = "wahlID")
+    @Mapping(target = "bezirkUndWahlIDStapelart.stapelart", source = "stapelart")
     ErgebnisseDTO toDTO(ErgebnisseModel entity);
 
     ErgebnisseReference toReferenceModel(String wahlbezirkID, String wahlID, StapelartDTO stapelart);

--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/ergebnisse/ErgebnisseService.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/ergebnisse/ErgebnisseService.java
@@ -42,9 +42,9 @@ public class ErgebnisseService {
 
     @PreAuthorize(
         "hasAuthority('Ergebnismeldung_BUSINESSACTION_GetErgebnisse')"
-                + " and @bezirkIdPermisionEvaluator.tokenUserBezirkIdMatches(#param.wahlbezirkID(), authentication)"
+                + " and @bezirkIdPermisionEvaluator.tokenUserBezirkIdMatches(#wahlbezirkID, authentication)"
     )
-    public List<ErgebnisseModel> getAllErgebnisse(@P("param") @NotNull final String wahlID, @NotNull final String wahlbezirkID) {
+    public List<ErgebnisseModel> getAllErgebnisse(@NotNull final String wahlID, @P("wahlbezirkID") @NotNull final String wahlbezirkID) {
         log.info("#getErgebnisse");
 
         ergebnisseValidator.validIDOrThrow(wahlID, wahlbezirkID,

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/ergebnisse/ErgebnisseServiceSecurityTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/ergebnisse/ErgebnisseServiceSecurityTest.java
@@ -87,6 +87,57 @@ class ErgebnisseServiceSecurityTest {
     }
 
     @Nested
+    class GetAllErgebnisse {
+
+        @Test
+        void should_getAccess_when_allRequiredAuthoritiesArePresent() {
+            SecurityUtils.runWith(Authorities.ALL_AUTHORITIES_GET_ERGEBNISSE);
+
+            val wahlID = "wahlID";
+            val wahlbezirkID = "wahlbezirkID";
+
+            Mockito.when(bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.eq(wahlbezirkID), Mockito.any())).thenReturn(true);
+
+            Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.getAllErgebnisse(wahlID, wahlbezirkID));
+        }
+
+        @Test
+        void should_throwAccessDeniedException_when_allRequiredAuthoritiesArePresentButBezirkIdDoesNotMatch() {
+            SecurityUtils.runWith(Authorities.ALL_AUTHORITIES_GET_ERGEBNISSE);
+
+            val wahlID = "wahlID";
+            val wahlbezirkID = "wahlbezirkID";
+
+            Mockito.when(bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.eq(wahlbezirkID), Mockito.any())).thenReturn(false);
+
+            Assertions.assertThatException()
+                    .isThrownBy(() -> unitUnderTest.getAllErgebnisse(wahlID, wahlbezirkID))
+                    .isInstanceOf(AccessDeniedException.class);
+        }
+
+        @ParameterizedTest
+        @MethodSource("getMissingAuthoritiesVariations")
+        void should_throwAccessDeniedException_when_anyRequiredAuthorityIsMissing(final ArgumentsAccessor arguments) {
+            SecurityUtils.runWith(arguments.get(0, String[].class));
+
+            val wahlID = "wahlID";
+            val wahlbezirkID = "wahlbezirkID";
+
+            Mockito.when(bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.eq(wahlbezirkID), Mockito.any())).thenReturn(true);
+
+            Assertions.assertThatException()
+                    .isThrownBy(() -> unitUnderTest.getAllErgebnisse(wahlID, wahlbezirkID))
+                    .isInstanceOf(AccessDeniedException.class);
+        }
+
+        private static Stream<Arguments> getMissingAuthoritiesVariations() {
+            return SecurityUtils
+                    .buildArgumentsForMissingAuthoritiesVariations(Authorities.ALL_AUTHORITIES_GET_ALL_ERGEBNISSE);
+        }
+
+    }
+
+    @Nested
     class PostErgebnisse {
 
         @Test

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/utils/Authorities.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/utils/Authorities.java
@@ -132,6 +132,11 @@ public class Authorities {
             SERVICE_GET_ERGEBNISSE
     };
 
+    public static final String[] ALL_AUTHORITIES_GET_ALL_ERGEBNISSE = new String[] {
+            REPOSITORY_READ_ERGEBNISSE,
+            SERVICE_GET_ERGEBNISSE
+    };
+
     public static final String[] ALL_AUTHORITIES_SET_ERGEBNISSE_MISSING_WILL_RESULT_IN_WLS_EXCEPTION = new String[] {
             REPOSITORY_WRITE_ERGEBNISSE
     };


### PR DESCRIPTION
# Beschreibung:

- Korrektur DTO bei Ergebnisse: Entfernung von DTO-Suffix bei Properties

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] [Naming Conventions][naming-conventions-link] beachtet - nicht relevant
- [X] Doku aktualisiert - nicht relevant
- [X] Swagger-API vollständig - nicht relevant
- [X] Unit-Tests gepflegt - nicht relevant
- [X] Integrationstests gepflegt - nicht relevant
- [X] Beispiel-Requests gepflegt - nicht relevant

# Referenzen[^1]:

Verwandt mit Issue #

Closes #780

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated parameter and mapping configurations across multiple data transfer objects and mappers
	- Renamed `stapelartDTO` to `stapelart` in various service components
	- Modified mapping references to align with new parameter names in DTO and mapper classes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->