### PR TITLE
738 jwt token um claim wahlbezirkArt anreichern

### DIFF
--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/SecurityConfiguration.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/SecurityConfiguration.java
@@ -10,12 +10,14 @@ import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import de.muenchen.oss.wahllokalsystem.authservice.security.CustomUsernamePasswordAuthenticationFilter;
+import de.muenchen.oss.wahllokalsystem.authservice.security.WahlbezirkArtTokenCustomizer;
 import de.muenchen.oss.wahllokalsystem.authservice.service.UserService;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.SecureRandom;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration;
@@ -54,6 +56,7 @@ import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
 @EnableWebSecurity
 @EnableMethodSecurity(securedEnabled = true)
 @Import(RestTemplateAutoConfiguration.class)
+@Slf4j
 public class SecurityConfiguration {
 
     private final String LOGIN_PATH = "/login";
@@ -176,5 +179,10 @@ public class SecurityConfiguration {
     @Bean
     public ConcurrentSessionControlAuthenticationStrategy concurrentSessionControlAuthenticationStrategy(SessionRegistry sessionRegistry) {
         return new ConcurrentSessionControlAuthenticationStrategy(sessionRegistry);
+    }
+
+    @Bean
+    public WahlbezirkArtTokenCustomizer wahlbezirkArtTokenCustomizer(final UserService userService) {
+        return new WahlbezirkArtTokenCustomizer(userService);
     }
 }

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/security/WahlbezirkArtTokenCustomizer.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/security/WahlbezirkArtTokenCustomizer.java
@@ -1,0 +1,28 @@
+package de.muenchen.oss.wahllokalsystem.authservice.security;
+
+import de.muenchen.oss.wahllokalsystem.authservice.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
+import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
+import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenCustomizer;
+
+@RequiredArgsConstructor
+@Slf4j
+public class WahlbezirkArtTokenCustomizer implements OAuth2TokenCustomizer<JwtEncodingContext> {
+
+    private final UserService userService;
+
+    @Override
+    public void customize(JwtEncodingContext context) {
+        if (OAuth2TokenType.ACCESS_TOKEN.equals(context.getTokenType())) {
+            val user = userService.getUser(context.getPrincipal().getName());
+            if (user.isPresent()) {
+                context.getClaims().claims(claims -> claims.put("wahlbezirksArt", user.get().wahlbezirksArt()));
+            } else {
+                log.warn("no user found with {}", context.getPrincipal().getName());
+            }
+        }
+    }
+}

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserService.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/service/UserService.java
@@ -162,6 +162,7 @@ public class UserService {
         return usersToCSVString(persistedUsers);
     }
 
+    @Transactional
     public Optional<UserModel> getUser(String name) {
         val user = userRepository.findByUsername(name);
         return user.map(userModelMapper::toModel);

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/LdapConfigurationTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/LdapConfigurationTest.java
@@ -9,11 +9,13 @@ import de.muenchen.oss.wahllokalsystem.authservice.domain.Permission;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.PermissionRepository;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.User;
 import de.muenchen.oss.wahllokalsystem.authservice.domain.UserRepository;
+import de.muenchen.oss.wahllokalsystem.authservice.domain.Wahlbezirksart;
 import de.muenchen.oss.wahllokalsystem.authservice.rest.UserDTO;
 import java.net.URI;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -101,11 +103,13 @@ class LdapConfigurationTest {
 
         @Test
         void should_accessSecureResource_when_loggingInWithToken() throws Exception {
+            val userWahlbezirkArt = Wahlbezirksart.BWB;
+
             transactionTemplate.executeWithoutResult(status -> {
                 val savedPermission = permissionRepository.save(new Permission("permission"));
                 val authorityToSave = new Authority("WLS_WAHLVORSTAND", new HashSet<>(Set.of(savedPermission)), Collections.emptySet());
                 val authoritySaved = authorityRepository.save(authorityToSave);
-                val userToSave = new User(EMBEDDED_LDAP_USER, null, null, true, true, WAHLTAG_ID, null, null, null, null, null,
+                val userToSave = new User(EMBEDDED_LDAP_USER, null, null, true, true, WAHLTAG_ID, null, null, null, userWahlbezirkArt, null,
                         new HashSet<>(Set.of(authoritySaved)),
                         null);
                 userRepository.save(userToSave);
@@ -181,6 +185,10 @@ class LdapConfigurationTest {
             val tokenResponse = restTemplate.exchange(tokenRequest, String.class);
 
             val token = objectMapper.readValue(tokenResponse.getBody(), Token.class).getAccess_token();
+
+            val tokenPayload = Base64.getDecoder().decode(token.split("\\.")[1].getBytes());
+            val tokenPayloadAsMap = objectMapper.readValue(tokenPayload, Map.class);
+            Assertions.assertThat(tokenPayloadAsMap.get("wahlbezirksArt")).isEqualTo(userWahlbezirkArt.name());
 
             //user endpoint
             val userRequestHeaders = new HttpHeaders();

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/security/WahlbezirkArtTokenCustomizerTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/security/WahlbezirkArtTokenCustomizerTest.java
@@ -1,0 +1,87 @@
+package de.muenchen.oss.wahllokalsystem.authservice.security;
+
+import de.muenchen.oss.wahllokalsystem.authservice.service.UserModel;
+import de.muenchen.oss.wahllokalsystem.authservice.service.UserService;
+import de.muenchen.oss.wahllokalsystem.authservice.service.WahlbezirksartModel;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.Optional;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
+import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
+
+@ExtendWith(MockitoExtension.class)
+class WahlbezirkArtTokenCustomizerTest {
+
+    @Mock
+    UserService userService;
+
+    @InjectMocks
+    WahlbezirkArtTokenCustomizer unitUnderTest;
+
+    @Nested
+    class Customize {
+
+        @Test
+        void should_doNothing_when_tokenTypeIsNotAccessToken() {
+            val mockedJwtContext = Mockito.mock(JwtEncodingContext.class);
+
+            Mockito.when(mockedJwtContext.getTokenType()).thenReturn(OAuth2TokenType.REFRESH_TOKEN);
+
+            unitUnderTest.customize(mockedJwtContext);
+
+            Mockito.verifyNoMoreInteractions(mockedJwtContext);
+            Mockito.verifyNoInteractions(userService);
+        }
+
+        @Test
+        void should_addWahlbezirkArtOfUser_when_tokenTypeIsAccessTokenAndUserIsFound() {
+            val username = "username";
+            val wahlbezirkArt = WahlbezirksartModel.BWB;
+
+            val jwtContext = JwtEncodingContext.with(JwsHeader.with(MacAlgorithm.HS256), JwtClaimsSet.builder()).context(context -> {
+                context.put(OAuth2TokenType.class, OAuth2TokenType.ACCESS_TOKEN);
+                context.put(Authentication.class.getName().concat(".PRINCIPAL"), new TestingAuthenticationToken(username, ""));
+            }).build();
+
+            val mockedUser = new UserModel(username, "", true, "", LocalDate.now(), "", "", wahlbezirkArt, "", Collections.emptySet(), "");
+
+            Mockito.when(userService.getUser(username)).thenReturn(Optional.of(mockedUser));
+
+            unitUnderTest.customize(jwtContext);
+
+            jwtContext.getClaims().claims(claims -> Assertions.assertThat(claims).contains(Assertions.entry("wahlbezirksArt", wahlbezirkArt)));
+        }
+
+        @Test
+        void should_doNothing_when_tokenTypeIsAccessTokenAndUserIsNotFound() {
+            val username = "username";
+            val wahlbezirkArt = WahlbezirksartModel.BWB;
+
+            val jwtContext = JwtEncodingContext.with(JwsHeader.with(MacAlgorithm.HS256), JwtClaimsSet.builder()).context(context -> {
+                context.put(OAuth2TokenType.class, OAuth2TokenType.ACCESS_TOKEN);
+                context.put(Authentication.class.getName().concat(".PRINCIPAL"), new TestingAuthenticationToken(username, ""));
+            }).build();
+
+            Mockito.when(userService.getUser(username)).thenReturn(Optional.empty());
+
+            unitUnderTest.customize(jwtContext);
+
+            jwtContext.getClaims().claims(claims -> Assertions.assertThat(claims).doesNotContain(Assertions.entry("wahlbezirksArt", wahlbezirkArt)));
+        }
+    }
+
+}


### PR DESCRIPTION
# Beschreibung:

- TokenCustomizer erstellt der nur bei Security eingebunden wird
  - Die SecurityConfiguration wird verwenden wenn `no-security` nicht aktiv ist
  - Deshalb nicht die `@Component`-Annotation an den Customizer gesetzt
- `@Transactional` musste ergänzt werden um aus dem Customizer auf den User zuzugreifen.
  - eine Optimierung wäre im Service eine Methode anzubieten die nur die Basisinformationen des Users liefert, d.h. nur dass was in der User-Tabelle steht: Issue -> #782 

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Doku aktualisiert - nichts zu tun
- [x] Swagger-API vollständig - nichts zu tun
- [x] Unit-Tests gepflegt
- [x] Integrationstests gepflegt
- [x] Beispiel-Requests gepflegt - nichts zu tun

# Referenzen[^1]:

Verwandt mit Issue #

Closes #738

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced authentication service with custom token generation
  - Added ability to include user's Wahlbezirksart (electoral district type) in JWT tokens

- **Tests**
  - Added comprehensive test coverage for new token customization functionality
  - Implemented test scenarios for different token generation conditions

- **Security Improvements**
  - Introduced new method to retrieve user details during token generation
  - Added custom claim processing for user authentication tokens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->