### PR TITLE
776 ungewollte api änderung bei stimmabgabevermerken

### DIFF
--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/domain/stimmabgabevermerke/Wahldaten.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/domain/stimmabgabevermerke/Wahldaten.java
@@ -58,7 +58,7 @@ public class Wahldaten {
     @NotNull
     @Size(min = 1)
     @ToString.Include
-    private Set<EingenommenerWahlschein> eingenommenewahlscheine = new LinkedHashSet<>();
+    private Set<EingenommenerWahlschein> eingenommeneWahlscheine = new LinkedHashSet<>();
 
     public void addVermerk(Vermerk vermerk) {
         vermerke.add(vermerk);

--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/stimmabgabevermerke/WahldatenDTO.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/stimmabgabevermerke/WahldatenDTO.java
@@ -7,5 +7,5 @@ public record WahldatenDTO(@NotNull String wahlbezirkID,
                            @NotNull String wahlID,
                            @NotNull long waehlerverzeichnisNummer,
                            @NotNull Set<VermerkDTO> vermerke,
-                           @NotNull Set<EingenommenerWahlscheinDTO> eingenommenewahlscheine) {
+                           @NotNull Set<EingenommenerWahlscheinDTO> eingenommeneWahlscheine) {
 }

--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/ergebnismeldung/ErgebnismeldungMappingService.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/ergebnismeldung/ErgebnismeldungMappingService.java
@@ -120,7 +120,7 @@ public class ErgebnismeldungMappingService {
         val wahldatenOfWahl = wahldatenSet.stream().filter(wahldaten -> wahldaten.getBezirkUndWahlIDUndWaehlerverzeichnisnummer().getWahlID().equals(wahlID))
                 .findFirst().orElse(null);
         if (wahldatenOfWahl != null) {
-            long eingenommeneWahlscheine = wahldatenOfWahl.getEingenommenewahlscheine().stream().mapToLong(EingenommenerWahlschein::getAnzahl).sum();
+            long eingenommeneWahlscheine = wahldatenOfWahl.getEingenommeneWahlscheine().stream().mapToLong(EingenommenerWahlschein::getAnzahl).sum();
             bWerte.setB2(eingenommeneWahlscheine);
 
             long erfassteStimmabgabevermerke = wahldatenOfWahl.getVermerke().stream()

--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/stimmabgabevermerke/WahldatenModel.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/stimmabgabevermerke/WahldatenModel.java
@@ -8,5 +8,5 @@ public record WahldatenModel(
         @NotNull String wahlID,
         @NotNull Long waehlerverzeichnisNummer,
         @NotNull Set<VermerkModel> vermerke,
-        @NotNull Set<EingenommenerWahlscheinModel> eingenommenewahlscheine) {
+        @NotNull Set<EingenommenerWahlscheinModel> eingenommeneWahlscheine) {
 }

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/stimmabgabevermerke/StimmabgabevermerkeControllerIntegrationTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/stimmabgabevermerke/StimmabgabevermerkeControllerIntegrationTest.java
@@ -220,7 +220,7 @@ public class StimmabgabevermerkeControllerIntegrationTest {
         emptyWahldaten
                 .setBezirkUndWahlIDUndWaehlerverzeichnisnummer(new BezirkUndWahlIDUndWaehlerverzeichnisnummer(wahlbezirkID, wahlID, waehlerverzeichnisNummer));
         List.of(vermerk1, vermerk2).forEach(emptyWahldaten::addVermerk);
-        emptyWahldaten.getEingenommenewahlscheine().addAll(List.of(wahlschein1, wahlschein2, wahlschein3));
+        emptyWahldaten.getEingenommeneWahlscheine().addAll(List.of(wahlschein1, wahlschein2, wahlschein3));
 
         return emptyWahldaten;
     }

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/stimmabgabevermerke/StimmabgabevermerkeDTOMapperTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/rest/stimmabgabevermerke/StimmabgabevermerkeDTOMapperTest.java
@@ -82,7 +82,7 @@ public class StimmabgabevermerkeDTOMapperTest {
                                     (sz) -> sz.stimmzettelart().name().equals(stimmzettelart.name())))))
                     .isTrue();
             Assertions.assertThat(result.wahldaten().stream().allMatch(
-                    (wahldatenModel) -> wahldatenModel.eingenommenewahlscheine().stream().allMatch(
+                    (wahldatenModel) -> wahldatenModel.eingenommeneWahlscheine().stream().allMatch(
                             (wahlschein) -> wahlschein.stimmzettelart().name().equals(stimmzettelart.name()))))
                     .isTrue();
         }
@@ -152,7 +152,7 @@ public class StimmabgabevermerkeDTOMapperTest {
                                     (sz) -> sz.stimmzettelart().name().equals(stimmzettelart.name())))))
                     .isTrue();
             Assertions.assertThat(result.wahldaten().stream().allMatch(
-                    (wahldatenDTO) -> wahldatenDTO.eingenommenewahlscheine().stream().allMatch(
+                    (wahldatenDTO) -> wahldatenDTO.eingenommeneWahlscheine().stream().allMatch(
                             (wahlschein) -> wahlschein.stimmzettelart().name().equals(stimmzettelart.name()))))
                     .isTrue();
         }

--- a/wls-ergebnismeldung-service/src/test/resources/sendErgebnismeldung.http
+++ b/wls-ergebnismeldung-service/src/test/resources/sendErgebnismeldung.http
@@ -137,7 +137,7 @@ Content-Type: application/json
       "waehlerverzeichnisNummer": 1,
       "wahlbezirkID": "wahlbezirkID",
       "wahlID": "wahlID01",
-      "eingenommenewahlscheine": [
+      "eingenommeneWahlscheine": [
         {
           "anzahl": 2,
           "stimmzettelart": "KLEIN"

--- a/wls-ergebnismeldung-service/src/test/resources/stimmabgabevermerke.http
+++ b/wls-ergebnismeldung-service/src/test/resources/stimmabgabevermerke.http
@@ -20,7 +20,7 @@ Content-Type: application/json
       "waehlerverzeichnisNummer": 1,
       "wahlbezirkID": "wahlbezirkID",
       "wahlID": "wahlID1",
-      "eingenommenewahlscheine": [
+      "eingenommeneWahlscheine": [
         {
           "anzahl": 2,
           "stimmzettelart": "KLEIN"
@@ -54,7 +54,7 @@ Content-Type: application/json
       "waehlerverzeichnisNummer": 1,
       "wahlbezirkID": "wahlbezirkID",
       "wahlID": "wahlID2",
-      "eingenommenewahlscheine": [
+      "eingenommeneWahlscheine": [
         {
           "anzahl": 2,
           "stimmzettelart": "KLEIN"
@@ -101,7 +101,7 @@ Content-Type: application/json
       "waehlerverzeichnisNummer": 1,
       "wahlbezirkID": "wahlbezirkID1",
       "wahlID": "other Wahl",
-      "eingenommenewahlscheine": [
+      "eingenommeneWahlscheine": [
         {
           "anzahl": 2,
           "stimmzettelart": "KLEIN"


### PR DESCRIPTION
# Beschreibung:

Im Unterschied zum bisherigen Datenmodell aus WLS2.0 in dem unter `Stimmabgabevermerke -> Wahldaten` sich die Property "eingenommeneWahlscheine" befindet, wurde hier versehentlich "eingenommenewahlscheine" (klein "W") implementiert.

Dies wurde nun gem. dem vorhandenen Datenmodell korrigiert.

## Definition of Done (DoD):


- [X] ist angepasst in DTO, Model und Entität

- [ ] Datenbank wird mit neuem Flyway-Skript angepasst - nicht notwendig, da es nur eine Datenbanktabelle "EINGENOMMENEWAHLSCHEINE" durchgehend großgeschrieben existiert, also von der Änderung nicht betroffen ist.

<!-- Backend -->
### Backend ###
- [X] Unit-Tests gepflegt


Referenziert: #776 

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized naming for ballot collection data across the system for improved consistency.
- **Tests**
  - Updated unit and integration tests to align with the new naming standards.
- **Chore**
  - Revised API request payloads to adopt the standardized field naming for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->