### PR TITLE
Update Doku bei Backendendclientgenerierung - Verwendung von OAuth2TokenInterceptor in Clientconfiguration

### DIFF
--- a/docs/src/technik/guides/api-client-generation/how-to-create-client-from-open-api-json.md
+++ b/docs/src/technik/guides/api-client-generation/how-to-create-client-from-open-api-json.md
@@ -97,14 +97,14 @@ Des Weiteren wird für die abschließende Konfiguration der Beans `wls-common:ex
 <dependency>
     <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
     <artifactId>exception</artifactId>
-    <version>1.2.0</version> <!-- bzw. die aktuelle latest-Version -->
+    <version>1.2.0</version>
 </dependency>
 
 <!-- Required for OAuth2TokenInterceptor -->
 <dependency>
    <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
    <artifactId>security</artifactId>
-   <version>1.2.0</version> <!-- bzw. die aktuelle latest-Version -->
+   <version>1.2.0</version>
 </dependency>
 ```
 

--- a/docs/src/technik/guides/api-client-generation/how-to-create-client-from-open-api-json.md
+++ b/docs/src/technik/guides/api-client-generation/how-to-create-client-from-open-api-json.md
@@ -106,31 +106,19 @@ Des Weiteren wird für die abschließende Konfiguration der Beans `wls-common:ex
 Damit der generierte Client verwendet werden kann, muss dem Spring-Context noch ein `RestTemplate` hinzugefügt werden:
 
 ```java
+import de.muenchen.oss.wahllokalsystem.wls.common.security.OAuth2TokenInterceptor;
 
 @Configuration
 public class ClientConfiguration {
 
     @Bean
-    public RestTemplate restTemplate(final WlsResponseErrorHandler wlsResponseErrorHandler) {
+    public RestTemplate restTemplate(final WlsResponseErrorHandler wlsResponseErrorHandler, final OAuth2TokenInterceptor oAuth2TokenInterceptor) {
         val restTemplate = new RestTemplate();
 
         /* definieren des Errorhandlers für Antworten vom externen Service */
         restTemplate.setErrorHandler(wlsResponseErrorHandler);
         /* Ergänzen eines Interceptors um den Bearer-Token an den nächsten Service weiter zu geben */
-        restTemplate.getInterceptors().add((request, body, execution) -> {
-            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-            if (authentication == null) {
-                return execution.execute(request, body);
-            }
-
-            if (!(authentication.getCredentials() instanceof AbstractOAuth2Token)) {
-                return execution.execute(request, body);
-            }
-
-            val token = (AbstractOAuth2Token) authentication.getCredentials();
-            request.getHeaders().setBearerAuth(token.getTokenValue());
-            return execution.execute(request, body);
-        });
+        restTemplate.getInterceptors().add(oAuth2TokenInterceptor);
 
         return restTemplate;
     }

--- a/docs/src/technik/guides/api-client-generation/how-to-create-client-from-open-api-json.md
+++ b/docs/src/technik/guides/api-client-generation/how-to-create-client-from-open-api-json.md
@@ -90,14 +90,21 @@ Damit die generierten Klassen compiliert werden können, muss folgende Dependenc
 </dependency>
 ```
 
-Des Weiteren wird für die abschließende Konfiguration der Beans `wls-common:exception` benötigt:
+Des Weiteren wird für die abschließende Konfiguration der Beans `wls-common:exception` und `wls-common:security` benötigt:
 
 ```xml
 
 <dependency>
     <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
     <artifactId>exception</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version> <!-- bzw. die aktuelle latest-Version -->
+</dependency>
+
+<!-- Required for OAuth2TokenInterceptor -->
+<dependency>
+   <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
+   <artifactId>security</artifactId>
+   <version>1.2.0</version> <!-- bzw. die aktuelle latest-Version -->
 </dependency>
 ```
 


### PR DESCRIPTION
# Beschreibung:

- Anstelle der anonymen Klasse wird der `OAuth2TokenInterceptor` aus wls-common via Dependency Injection verwendet.
- notwendiger Import wurde ebenfalls ergänzt

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Dokumentation -->
### Dokumentation
- [x] ~~Links geprüft~~ keine Links ergänzt oder verändert
# Referenzen[^1]:

Verwandt mit Issue #323 

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the API client’s token management workflow to improve authentication reliability and streamline error handling during external communications.
  
- **Documentation**
  - Updated the client generation guide for clearer, more accurate instructions on setting up API integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->