### PR TITLE
776 ungewollte api änderung bei stimmabgabevermerken

### DIFF
--- a/wls-ergebnismeldung-service/pom.xml
+++ b/wls-ergebnismeldung-service/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-ergebnismeldung-service</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <name>wls_ergebnismeldung_service</name>
 
     <properties>

--- a/wls-ergebnismeldung-service/pom.xml
+++ b/wls-ergebnismeldung-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-ergebnismeldung-service</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1-SNAPSHOT</version>
     <name>wls_ergebnismeldung_service</name>
 
     <properties>
@@ -313,7 +313,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-ergebnismeldung-service/0.2.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-ergebnismeldung-service/pom.xml
+++ b/wls-ergebnismeldung-service/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-ergebnismeldung-service</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.1-SNAPSHOT</version>
     <name>wls_ergebnismeldung_service</name>
 
     <properties>

--- a/wls-ergebnismeldung-service/pom.xml
+++ b/wls-ergebnismeldung-service/pom.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-ergebnismeldung-service</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.0</version>
     <name>wls_ergebnismeldung_service</name>
 
     <properties>
@@ -315,7 +313,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-ergebnismeldung-service/0.2.0</tag>
     </scm>
 
 
@@ -574,8 +572,8 @@
                         <eclipse>
                             <file>itm-java-codeformat/java_codestyle_formatter.xml</file>
                         </eclipse>
-                        <trimTrailingWhitespace/>
-                        <endWithNewline/>
+                        <trimTrailingWhitespace />
+                        <endWithNewline />
                     </java>
                 </configuration>
                 <executions>


### PR DESCRIPTION
# Beschreibung:

Nach der API-Korrektur (Klein- zu Großbuchstabe in eingenomene(w)[W]ahlscheine), siehe #776 musste ein neues Release vom Ergebnismeldung-Service gebaut werden, bzw. das neue korrekte openapi.json-File wird für andere Clients benötigt.

Die oben erwähnte Korrektur wurde im [PR 800](https://github.com/it-at-m/Wahllokalsystem/pull/800) bereits reviewed und gemerged. Wegen der Trivialität haben wir uns entschieden das Releasen infolge der Korrektur mit dem gleichen Issue zu erledigen, jedoch in einem neuen PR (diesem).

## Definition of Done (DoD):
- [X] es gibt eine Release Version
- [X] nächste Development Version ist vorhanden

Closes #776 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project version to the latest snapshot.
  - Improved configuration formatting for enhanced clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->