### PR TITLE
805 openapi generator pretends path elements of method parameters in controller to be annotated as path variables

### DIFF
--- a/wls-ergebnismeldung-service/pom.xml
+++ b/wls-ergebnismeldung-service/pom.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-ergebnismeldung-service</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.2.1</version>
     <name>wls_ergebnismeldung_service</name>
 
     <properties>
@@ -315,7 +313,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-ergebnismeldung-service/0.2.1</tag>
     </scm>
 
 
@@ -574,8 +572,8 @@
                         <eclipse>
                             <file>itm-java-codeformat/java_codestyle_formatter.xml</file>
                         </eclipse>
-                        <trimTrailingWhitespace/>
-                        <endWithNewline/>
+                        <trimTrailingWhitespace />
+                        <endWithNewline />
                     </java>
                 </configuration>
                 <executions>

--- a/wls-ergebnismeldung-service/pom.xml
+++ b/wls-ergebnismeldung-service/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-ergebnismeldung-service</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.1-SNAPSHOT</version>
     <name>wls_ergebnismeldung_service</name>
 
     <properties>

--- a/wls-ergebnismeldung-service/pom.xml
+++ b/wls-ergebnismeldung-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-ergebnismeldung-service</artifactId>
-    <version>0.2.1</version>
+    <version>0.2.2-SNAPSHOT</version>
     <name>wls_ergebnismeldung_service</name>
 
     <properties>
@@ -313,7 +313,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-ergebnismeldung-service/0.2.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
 


### PR DESCRIPTION
Nach der API-Korrektur (Klein- zu Großbuchstabe in eingenomene(w)[W]ahlscheine), siehe https://github.com/it-at-m/Wahllokalsystem/issues/776 musste ein neues Release vom Ergebnismeldung-Service gebaut werden, bzw. das neue korrekte openapi.json-File wird für andere Clients benötigt.

Die oben erwähnte Korrektur wurde im https://github.com/it-at-m/Wahllokalsystem/pull/800 bereits reviewed und gemerged.

Danach wurde beim Versuch aus `openapi.json` des so releaseten `ergebnismeldung-service` über den openapi-generator die Clients für den wls-admin-service zu generieren festgestellt, dass im ergebnismeldung-service im Controller in der Methode sendErgebnisse das Objekt-Paramter nicht akzeptiert wurde, sondern der Generator PathVariablen verlangte. So ist #805 entstanden.

#805 wurde im [PR 810](https://github.com/it-at-m/Wahllokalsystem/pull/810) reviewed und gemerged.

Danach wurde manuell die beim PR800 entstandene SNAPSHOT Version auf 0.2.1-SNAPSHOT erhöht, weil ein Release 0.2.0 bereits existierte und wir deshalb ein Release 0.2.1 anstreben.

 Wegen der Trivialität haben wir uns entschieden das Releasen infolge der Korrektur mit dem gleichen Issue zu erledigen, jedoch in einem neuen PR (diesem).

## Definition of Done (DoD):

- [X] es gibt eine Release Version 

- [X] nächste Development Version ist vorhanden


Closes #805 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project version to the latest release.
- **Style**
  - Refined internal configuration formatting to improve consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->