### PR TITLE
804 adr zu kapselung von pathvariablen erstellen

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -67,6 +67,10 @@ export default withMermaid({
                         {
                             text: 'Frontend-Refarch-Template',
                             link: `${PATH_ADR}adr-frontend-template`
+                        },
+                        {
+                            text: 'Pfadvariablen als Parameter',
+                            link: `${PATH_ADR}adr-issue804-pathVariableAsMethodArguments`
                         }
                     ]
                 },

--- a/docs/src/technik/adr/adr-issue804-pathVariableAsMethodArguments.md
+++ b/docs/src/technik/adr/adr-issue804-pathVariableAsMethodArguments.md
@@ -6,11 +6,11 @@
 
 ## Kontext
 
-Beim Update der openAPI Beschreibung für den ErgebnismeldungsService kam es beim Build zu einem
+Beim Update der OpenAPI Beschreibung für den ErgebnismeldungsService kam es beim Build zu einem
 [Fehler](https://github.com/it-at-m/Wahllokalsystem/issues/760#issuecomment-2650329956).
-Der Generator war nicht in der Lage aus dem File die notwendigen Klassen zu generieren. Der Grund dafüre war, dass
+Der Generator war nicht in der Lage aus dem File die notwendigen Klassen zu generieren. Der Grund dafür war, dass
 im File beim Endpunkt mit dem Pfad `/businessActions/sendErgebnismeldung/{wahlID}/{wahlbezirkID}/{waehlerverzeichnisNummer}/{meldungsart}/{hauptwahlbezirkID}`
-die Pfadvariablen nicht beschrieben waren. Das openAPI-File wurde so generiert, weil im Controller die Pfadvariablen
+die Pfadvariablen nicht beschrieben waren. Das OpenAPI-File wurde so generiert, weil im Controller die Pfadvariablen
 nicht explizit definiert wurden, sondern in einer Klasse zusammen gefasst waren:
 
 ::: code-group
@@ -135,7 +135,7 @@ public record SendErgebnisParameter(
 Im fehlerhaften `openAPI.json` kann man erkennen, dass die Pfadvariablen nicht deklariert sind. In der `fixed`-Version
 die Pfadvariablen korrekt deklariert.
 
-Um eine korrekte openAPI Spezifikation zu erhalten, aus der die Client-Klassen generiert werden können, könnte die
+Um eine korrekte OpenAPI Spezifikation zu erhalten, aus der die Client-Klassen generiert werden können, könnte die
 Pfadvariablen auch via Annotation definiert werden:
 
 ```java
@@ -158,7 +158,7 @@ public ResponseEntity<?> sendErgebnisse(
 
 ## Entscheidung
 
-Die Pfadvariablen direkt sollen als Parameter der Method definiert werden. Eine Zusammenfassung in eine Klasse darf
+Die Pfadvariablen sollen direkt als Parameter der Method definiert werden. Eine Zusammenfassung in eine Klasse darf
 nicht erfolgen.
 
 ## Konsequenzen

--- a/docs/src/technik/adr/adr-issue804-pathVariableAsMethodArguments.md
+++ b/docs/src/technik/adr/adr-issue804-pathVariableAsMethodArguments.md
@@ -1,0 +1,176 @@
+# Pfadvariablen als Methodenargumente
+
+## Status
+
+<adr-status status='accepted'></adr-status>
+
+## Kontext
+
+Beim Update der openAPI Beschreibung für den ErgebnismeldungsService kam es beim Build zu einem
+[Fehler](https://github.com/it-at-m/Wahllokalsystem/issues/760#issuecomment-2650329956).
+Der Generator war nicht in der Lage aus dem File die notwendigen Klassen zu generieren. Der Grund dafüre war, dass
+im File beim Endpunkt mit dem Pfad `/businessActions/sendErgebnismeldung/{wahlID}/{wahlbezirkID}/{waehlerverzeichnisNummer}/{meldungsart}/{hauptwahlbezirkID}`
+die Pfadvariablen nicht beschrieben waren. Das openAPI-File wurde so generiert, weil im Controller die Pfadvariablen
+nicht explizit definiert wurden, sondern in einer Klasse zusammen gefasst waren:
+
+::: code-group
+
+```java [Controller]
+@PostMapping("{wahlID}/{wahlbezirkID}/{waehlerverzeichnisNummer}/{meldungsart}/{hauptwahlbezirkID}")
+public ResponseEntity<?> sendErgebnisse(
+        @RequestHeader(required = false, name = "forceergebnismeldung") final String forceUpdate,
+        final SendErgebnisParameter sendErgebnisParameter) {
+        }
+```
+
+```java [SendErgebnisParameter]
+public record SendErgebnisParameter(
+        @NotNull String wahlID,
+        @NotNull String wahlbezirkID,
+        @NotNull Long waehlerverzeichnisNummer,
+        @NotNull MeldungsartDTO meldungsart,
+        @NotNull String hauptwahlbezirkID
+) {
+}
+```
+
+```json [openAPI.json fehlerhaft]
+{
+  "/businessActions/sendErgebnismeldung/{wahlID}/{wahlbezirkID}/{waehlerverzeichnisNummer}/{meldungsart}/{hauptwahlbezirkID}": {
+    "post": {
+      "tags": [
+        "ergebnismeldung-controller"
+      ],
+      "description": "Übermitteln einer Ergebnismeldung an das externe System für eine konkrete Wahl eines Wahlbezirkes",
+      "operationId": "sendErgebnisse",
+      "parameters": [
+        {
+          "name": "forceergebnismeldung",
+          "in": "header",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "arg1",
+          "in": "query",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SendErgebnisParameter"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Die Übermittlung war erfolgreich"
+        }
+      }
+    }
+  }
+}
+```
+
+```json [openAPI.json fixed]
+{
+  "/businessActions/sendErgebnismeldung/{wahlID}/{wahlbezirkID}/{waehlerverzeichnisNummer}/{meldungsart}/{hauptwahlbezirkID}": {
+    "post": {
+      "tags": [
+        "ergebnismeldung-controller"
+      ],
+      "description": "Übermitteln einer Ergebnismeldung an das externe System für eine konkrete Wahl eines Wahlbezirkes",
+      "operationId": "sendErgebnisse",
+      "parameters": [
+        {
+          "name": "forceergebnismeldung",
+          "in": "header",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "wahlID",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string" }
+        },
+        {
+          "name": "wahlbezirkID",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string" }
+        },
+        {
+          "name": "waehlerverzeichnisNummer",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "integer", "format": "int64" }
+        },
+        {
+          "name": "meldungsart",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string", "enum": ["V1", "V3"] }
+        },
+        {
+          "name": "hauptwahlbezirkID",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string" }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Die Übermittlung war erfolgreich"
+        }
+      }
+    }
+  }
+}
+```
+
+:::
+
+Im fehlerhaften `openAPI.json` kann man erkennen, dass die Pfadvariablen nicht deklariert sind. In der `fixed`-Version
+die Pfadvariablen korrekt deklariert.
+
+Um eine korrekte openAPI Spezifikation zu erhalten, aus der die Client-Klassen generiert werden können, könnte die
+Pfadvariablen auch via Annotation definiert werden:
+
+```java
+
+@Operation(
+            description = "Übermitteln einer Ergebnismeldung an das externe System für eine konkrete Wahl eines Wahlbezirkes",
+            parameters = { @Parameter(name = "wahlbezirkID", in = ParameterIn.PATH),
+                    @Parameter(name = "wahlID", in = ParameterIn.PATH),
+                    @Parameter(name = "waehlerverzeichnisNummer", in = ParameterIn.PATH, schema = @Schema(implementation = Long.class)),
+                    @Parameter(name = "meldungsart", in = ParameterIn.PATH, schema = @Schema(implementation = MeldungsartDTO.class)),
+                    @Parameter(name = "hauptwahlbezirkID", in = ParameterIn.PATH)
+            }
+    )
+@PostMapping("{wahlID}/{wahlbezirkID}/{waehlerverzeichnisNummer}/{meldungsart}/{hauptwahlbezirkID}")
+public ResponseEntity<?> sendErgebnisse(
+        @RequestHeader(required = false, name = "forceergebnismeldung") final String forceUpdate,
+        final SendErgebnisParameter sendErgebnisParameter) {
+}
+```
+
+## Entscheidung
+
+Die Pfadvariablen direkt sollen als Parameter der Method definiert werden. Eine Zusammenfassung in eine Klasse darf
+nicht erfolgen.
+
+## Konsequenzen
+
+### positiv
+
+Auf diese Weise werden die Pfadvariablen direkt sichtbar. Eine separate Klasse steigert die Komplexität, da die
+Deklaration der Pfadvariablen nicht direkt erkennbar ist.
+
+Bei einer separaten Definition über die Annotation muss zusätzlich sichergestellt werden, dass die Annotationen mit den
+Properties der Klassen übereinstimmen. Was ebenfalls die Komplexität steigern würde.
+
+### negativ
+
+Keine, da sich aktuelle alle Controller nach dieser Entscheidung richten. 

--- a/wls-common/testing/pom.xml
+++ b/wls-common/testing/pom.xml
@@ -26,6 +26,10 @@
             <artifactId>spring-security-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
         </dependency>
@@ -41,6 +45,11 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <version>1.4.0</version>
         </dependency>
     </dependencies>
 

--- a/wls-common/testing/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/archunit/condition/RequestMappingMethodParameterAnnotationCondition.java
+++ b/wls-common/testing/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/archunit/condition/RequestMappingMethodParameterAnnotationCondition.java
@@ -1,0 +1,42 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.testing.archunit.condition;
+
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import java.util.Set;
+import lombok.val;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * Checks that the at least one of the {@link #requiredAnnotations} is given on each parameter
+ */
+public class RequestMappingMethodParameterAnnotationCondition extends ArchCondition<JavaMethod> {
+
+    final Set<Object> requiredAnnotations = Set.of(PathVariable.class, RequestBody.class, RequestParam.class, RequestHeader.class);
+
+    public RequestMappingMethodParameterAnnotationCondition() {
+        super("Checks that the at least one of the requiredAnnotations is given on each parameter");
+    }
+
+    @Override
+    public void check(JavaMethod item, ConditionEvents events) {
+        val methodParameters = item.getParameters();
+        methodParameters.forEach(parameter -> {
+            val rawAnnotationsOfParameter = parameter.getAnnotations().stream().map(archUnitAnnotation -> archUnitAnnotation.getRawType().reflect())
+                    .toList();
+            val parameterHasOneOfRequireAnnotations = requiredAnnotations.stream().anyMatch(rawAnnotationsOfParameter::contains);
+
+            val message = String.format("parameter #%d of method %s in class %s has not one the required annotations %s", parameter.getIndex(),
+                    item.getName(),
+                    item.reflect().getDeclaringClass().getName(), requiredAnnotations);
+
+            if (!parameterHasOneOfRequireAnnotations) {
+                events.add(SimpleConditionEvent.violated(item, message));
+            }
+        });
+    }
+}

--- a/wls-common/testing/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/archunit/rule/MethodRules.java
+++ b/wls-common/testing/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/archunit/rule/MethodRules.java
@@ -1,0 +1,18 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.testing.archunit.rule;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+import com.tngtech.archunit.lang.ArchRule;
+import de.muenchen.oss.wahllokalsystem.wls.common.testing.archunit.condition.RequestMappingMethodParameterAnnotationCondition;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MethodRules {
+
+    public static final ArchRule REQUEST_MAPPING_METHODS_SHOULD_USE_ONLY_ANNOTATED_PARAMETERS = methods()
+            .that().areAnnotatedWith(RequestMapping.class)
+            .or().areMetaAnnotatedWith(RequestMapping.class)
+            .should(new RequestMappingMethodParameterAnnotationCondition());
+}

--- a/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/archunit/condition/RequestMappingMethodParameterAnnotationConditionTest.java
+++ b/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/archunit/condition/RequestMappingMethodParameterAnnotationConditionTest.java
@@ -1,0 +1,131 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.testing.archunit.condition;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.util.VisibleForTesting;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+class RequestMappingMethodParameterAnnotationConditionTest {
+
+    final ArchRule ruleWithConditionUnderTest = methods().that().areAnnotatedWith(VisibleForTesting.class)
+            .should(new RequestMappingMethodParameterAnnotationCondition());
+
+    @Nested
+    class Check {
+
+        @Test
+        void should_throwNoException_when_pathVariableAnnotationIsGiven() {
+            ruleWithConditionUnderTest.check(
+                    new ClassFileImporter(List.of(new ImportOption.OnlyIncludeTests())).importClasses(PathVariableAnnotationIsGivenOnParameter.class));
+        }
+
+        @Test
+        void should_throwNoException_when_RequestParamAnnotationIsGiven() {
+            ruleWithConditionUnderTest.check(
+                    new ClassFileImporter(List.of(new ImportOption.OnlyIncludeTests())).importClasses(RequestParamAnnotationIsGivenOnParameter.class));
+        }
+
+        @Test
+        void should_throwNoException_when_RequestBodyAnnotationIsGiven() {
+            ruleWithConditionUnderTest.check(
+                    new ClassFileImporter(List.of(new ImportOption.OnlyIncludeTests())).importClasses(RequestBodyAnnotationIsGivenOnParameter.class));
+        }
+
+        @Test
+        void should_throwNoException_when_RequestHeaderAnnotationIsGiven() {
+            ruleWithConditionUnderTest.check(
+                    new ClassFileImporter(List.of(new ImportOption.OnlyIncludeTests())).importClasses(RequestHeaderAnnotationIsGivenOnParameter.class));
+        }
+
+        @Test
+        void should_throwNoException_when_methodHasZeroParameters() {
+            ruleWithConditionUnderTest.check(
+                    new ClassFileImporter(List.of(new ImportOption.OnlyIncludeTests())).importClasses(NoParametersAreGiven.class));
+        }
+
+        @Test
+        void should_throwNoException_when_eachParameterHasOneOfTheRequiredAnnotation() {
+            ruleWithConditionUnderTest.check(
+                    new ClassFileImporter(List.of(new ImportOption.OnlyIncludeTests())).importClasses(EachParameterHasOneOfTheRequiredAnnotation.class));
+        }
+
+        @Test
+        void should_throwException_when_noRequiredAnnotationIsGiven() {
+            Assertions.assertThatThrownBy(() -> ruleWithConditionUnderTest.check(
+                    new ClassFileImporter(List.of(new ImportOption.OnlyIncludeTests())).importClasses(NoAnnotationIsGivenOnAnyParameter.class)))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("methodUnderTest")
+                    .hasMessageContaining("#0")
+                    .hasMessageContaining("#1")
+                    .hasMessageContaining(NoAnnotationIsGivenOnAnyParameter.class.getName());
+        }
+    }
+
+}
+
+class PathVariableAnnotationIsGivenOnParameter {
+
+    @VisibleForTesting
+    public void methodUnderTest(@PathVariable final String parameter) {
+
+    }
+}
+
+class RequestHeaderAnnotationIsGivenOnParameter {
+
+    @VisibleForTesting
+    public void methodUnderTest(@PathVariable final String parameter) {
+
+    }
+}
+
+class RequestParamAnnotationIsGivenOnParameter {
+
+    @VisibleForTesting
+    public void methodUnderTest(@PathVariable final String parameter) {
+
+    }
+}
+
+class RequestBodyAnnotationIsGivenOnParameter {
+
+    @VisibleForTesting
+    public void methodUnderTest(@PathVariable final String parameter) {
+
+    }
+}
+
+class NoAnnotationIsGivenOnAnyParameter {
+
+    @VisibleForTesting
+    public void methodUnderTest(final String parameter1, final String parameter2) {
+
+    }
+}
+
+class NoParametersAreGiven {
+
+    @VisibleForTesting
+    public void methodUnderTest() {
+
+    }
+}
+
+class EachParameterHasOneOfTheRequiredAnnotation {
+
+    @VisibleForTesting
+    public void methodUnderTest(@PathVariable final String pathVariableParameter, @RequestParam final String requestParamParameter,
+            @RequestBody final String requestBodyParameter, @RequestHeader final String requestHeaderParameter) {
+
+    }
+}

--- a/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/archunit/condition/RequestMappingMethodParameterAnnotationConditionTest.java
+++ b/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/archunit/condition/RequestMappingMethodParameterAnnotationConditionTest.java
@@ -84,7 +84,7 @@ class PathVariableAnnotationIsGivenOnParameter {
 class RequestHeaderAnnotationIsGivenOnParameter {
 
     @VisibleForTesting
-    public void methodUnderTest(@PathVariable final String parameter) {
+    public void methodUnderTest(@RequestHeader final String parameter) {
 
     }
 }
@@ -92,7 +92,7 @@ class RequestHeaderAnnotationIsGivenOnParameter {
 class RequestParamAnnotationIsGivenOnParameter {
 
     @VisibleForTesting
-    public void methodUnderTest(@PathVariable final String parameter) {
+    public void methodUnderTest(@RequestParam final String parameter) {
 
     }
 }
@@ -100,7 +100,7 @@ class RequestParamAnnotationIsGivenOnParameter {
 class RequestBodyAnnotationIsGivenOnParameter {
 
     @VisibleForTesting
-    public void methodUnderTest(@PathVariable final String parameter) {
+    public void methodUnderTest(@RequestBody final String parameter) {
 
     }
 }


### PR DESCRIPTION
# Beschreibung:
- ADR dokumentiert
- wls-common:testing um archUnit Rule ergänzt die in die anderen Services übernommen werden kann
  - Übernahme der Regel soll mit #819 erfolgen
- Klassenfilter manuell überprüft am ErgebnismeldungService mit `sendErgebnisse`
  - für den Verschlag wurde ein Parameter ohne Annotation ergänzt
  - der Fehler wurde detektiert wenn `RequestMapping` oder `GetMapping` an der Method vorhanden war. Ohne diese Annotationen wurde der Fehler nicht detektiert

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

# wls-common
- [X] Tests zur Condition geschrieben

<!-- Dokumentation -->
### Dokumentation
- [X] Links geprüft

# Referenzen[^1]:

Verwandt mit Issue #

Closes #804

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new sidebar entry under design decisions.
  - Introduced an architectural decision record outlining improved handling of path variables as method parameters.
  
- **Tests**
  - Enhanced testing with new validation checks to ensure proper use of endpoint parameter annotations.
  - Upgraded testing libraries to support improved quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->