### PR TITLE
ADR zu i18n erstellen

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -67,6 +67,10 @@ export default withMermaid({
                         {
                             text: 'Frontend-Refarch-Template',
                             link: `${PATH_ADR}adr-frontend-template`
+                        },
+                        {
+                            text: 'Kein i18n von Beginn an',
+                            link: `${PATH_ADR}adr-no-use-of-i18n-at-start`
                         }
                     ]
                 },

--- a/docs/src/technik/adr/adr-no-use-of-i18n-at-start.md
+++ b/docs/src/technik/adr/adr-no-use-of-i18n-at-start.md
@@ -1,0 +1,36 @@
+# Keine Verwendung von i18n von Beginn an
+
+## Status
+
+<adr-status status='accepted'></adr-status>
+
+## Kontext
+
+Analog zur RefArch-[Diskussion](https://github.com/it-at-m/refarch-templates/issues/116) haben wir im Projekt überlegt,
+ob wir i18n einsetzen werden.
+
+Bibliotheken vie [vue-i18n](https://vue-i18n.intlify.dev/) erlauben es auf einfache Weise zwischen Sprachen zu wechseln.
+Dies umfasst sowohl Texte als auch die Formatierung von Zahlen und Daten. In dem die Texte in Ressourcen-Dateien gebündelt werden
+und in den Komponenten über Schlüssel auf die entsprechende Texte referenziert wird, können dieselben Texte leicht
+wiederverwendet werden.
+
+## Entscheidung
+
+Wir haben uns dagegen entschieden, i18n in der aktuellen Phase einzusetzen. WLS ist fürn den Münchner Prozess zur
+Auszählung der Stimmen. Wir gehen aktuell nicht davon aus der Nutzerkreis der Software eine Mehrsprachigkeit erfordert.
+
+Eine spätere Verwendung von i18n hat keinen relevanten erhöhten Aufwand als wenn wir es von Beginn an verwenden würden.
+Alle erstellten Komponenten müssten analysiert und die Texte extrahiert und durch Referenzen ersetzt werden.
+
+## Konsequenzen
+
+### positiv
+
+Die Texte sind direkt in den Komponenten erkennbar was die Verständlichkeit der Komponenten und der Fachdomain erleichtert.
+Es gibt eine Bibliothek weniger, von der wir abhängig sind und die zu Pflegen ist, was die Komplexität geringer hält. 
+
+### negativ
+
+Dieselben Texte, vermutlich einzelne Wörter, lassen sich schwere über mehrere Komponenten hinweg identisch halten.
+
+Wir müssen eigenen Formatierungsfunktionen für Zahlen und Daten erstellen.

--- a/docs/src/technik/adr/adr-no-use-of-i18n-at-start.md
+++ b/docs/src/technik/adr/adr-no-use-of-i18n-at-start.md
@@ -9,14 +9,14 @@
 Analog zur RefArch-[Diskussion](https://github.com/it-at-m/refarch-templates/issues/116) haben wir im Projekt überlegt,
 ob wir i18n einsetzen werden.
 
-Bibliotheken vie [vue-i18n](https://vue-i18n.intlify.dev/) erlauben es auf einfache Weise zwischen Sprachen zu wechseln.
+Bibliotheken wie [vue-i18n](https://vue-i18n.intlify.dev/) erlauben es auf einfache Weise zwischen Sprachen zu wechseln.
 Dies umfasst sowohl Texte als auch die Formatierung von Zahlen und Daten. In dem die Texte in Ressourcen-Dateien gebündelt werden
 und in den Komponenten über Schlüssel auf die entsprechende Texte referenziert wird, können dieselben Texte leicht
 wiederverwendet werden.
 
 ## Entscheidung
 
-Wir haben uns dagegen entschieden, i18n in der aktuellen Phase einzusetzen. WLS ist fürn den Münchner Prozess zur
+Wir haben uns dagegen entschieden, i18n in der aktuellen Phase einzusetzen. WLS ist für den Münchner Prozess zur
 Auszählung der Stimmen. Wir gehen aktuell nicht davon aus der Nutzerkreis der Software eine Mehrsprachigkeit erfordert.
 
 Eine spätere Verwendung von i18n hat keinen relevanten erhöhten Aufwand als wenn wir es von Beginn an verwenden würden.
@@ -31,6 +31,6 @@ Es gibt eine Bibliothek weniger, von der wir abhängig sind und die zu Pflegen i
 
 ### negativ
 
-Dieselben Texte, vermutlich einzelne Wörter, lassen sich schwere über mehrere Komponenten hinweg identisch halten.
+Dieselben Texte, vermutlich einzelne Wörter, lassen sich schwer über mehrere Komponenten hinweg identisch halten.
 
 Wir müssen eigenen Formatierungsfunktionen für Zahlen und Daten erstellen.


### PR DESCRIPTION
# Beschreibung:

Entscheidung dokumentiert, dass wir i18n aktuell nicht einsetzen werden

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Dokumentation -->
### Dokumentation
- [x] Links geprüft

# Referenzen[^1]:

Verwandt mit Issue #

Closes #808

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new sidebar entry in the design decisions section for improved navigation.
  - Introduced a guidance page detailing the current approach to language support, outlining its benefits in clarity and future maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->