### PR TITLE
use wahlbezirkID path variable instead of wahlbezirkID in requestbody

### DIFF
--- a/wls-wahlvorstand-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandController.java
+++ b/wls-wahlvorstand-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandController.java
@@ -81,8 +81,9 @@ public class WahlvorstandController {
             }
     )
     @PostMapping("/{wahlbezirkID}")
-    public ResponseEntity<?> postWahlvorstand(@RequestBody WahlvorstandDTO wahlvorstandBody) {
-        wahlvorstandService.postWahlvorstand(wahlvorstandDTOMapper.toModel(wahlvorstandBody));
+    public ResponseEntity<?> postWahlvorstand(@PathVariable("wahlbezirkID") final String wahlbezirkID,
+            @RequestBody WahlvorstandDTO wahlvorstandBody) {
+        wahlvorstandService.postWahlvorstand(wahlvorstandDTOMapper.toModel(wahlbezirkID, wahlvorstandBody));
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/wls-wahlvorstand-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandDTO.java
+++ b/wls-wahlvorstand-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandDTO.java
@@ -5,7 +5,6 @@ import java.util.List;
 import lombok.Builder;
 
 @Builder
-public record WahlvorstandDTO(String wahlbezirkID,
-                              LocalDateTime anwesenheitBeginn,
+public record WahlvorstandDTO(LocalDateTime anwesenheitBeginn,
                               List<WahlvorstandsmitgliedDTO> wahlvorstandsmitglieder) {
 }

--- a/wls-wahlvorstand-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandDTOMapper.java
+++ b/wls-wahlvorstand-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandDTOMapper.java
@@ -8,5 +8,5 @@ public interface WahlvorstandDTOMapper {
 
     WahlvorstandDTO toDTO(WahlvorstandModel model);
 
-    WahlvorstandModel toModel(WahlvorstandDTO dto);
+    WahlvorstandModel toModel(String wahlbezirkID, WahlvorstandDTO dto);
 }

--- a/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/configuration/SecurityConfigurationTest.java
+++ b/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/configuration/SecurityConfigurationTest.java
@@ -4,6 +4,7 @@ import static de.muenchen.oss.wahllokalsystem.wahlvorstandservice.TestConstants.
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.muenchen.oss.wahllokalsystem.wahlvorstandservice.MicroServiceApplication;
 import de.muenchen.oss.wahllokalsystem.wahlvorstandservice.rest.wahlvorstand.WahlvorstandDTO;
@@ -109,7 +110,7 @@ class SecurityConfigurationTest {
         @Test
         @WithMockUser
         void should_returnStatusOk_when_postingBusinessActionsWahlvorstand() throws Exception {
-            val requestBody = new WahlvorstandDTO("wahlbezirkID", null, null);
+            val requestBody = new WahlvorstandDTO(null, null);
             val request = MockMvcRequestBuilders.post("/businessActions/wahlvorstand/wahlbezirkID").with(csrf()).contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(requestBody));
 

--- a/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandControllerIntegrationTest.java
+++ b/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandControllerIntegrationTest.java
@@ -142,7 +142,7 @@ public class WahlvorstandControllerIntegrationTest {
         )
         void should_saveWahlvorstand_when_newDataSuccessfullySaved() throws Exception {
             val wahlbezirkID = "wahlbezirkID";
-            val mockedWahlvorstandDTO = TestDataFactory.CreateWahlvorstandDto.withWahlbezirkID(wahlbezirkID);
+            val mockedWahlvorstandDTO = TestDataFactory.CreateWahlvorstandDto.withData();
 
             WireMock.stubFor(WireMock.put("/wahlvorstaende/anwesenheit")
                     .willReturn(WireMock.aResponse().withHeader("Content-Type", "application/json")
@@ -153,7 +153,7 @@ public class WahlvorstandControllerIntegrationTest {
             api.perform(request).andExpect(status().isOk()).andReturn();
 
             val wahlvorstandFromRepo = wahlvorstandRepository.findById(wahlbezirkID).get();
-            val expectedWahlvorstand = wahlvorstandModelMapper.toEntity(wahlvorstandDTOMapper.toModel(mockedWahlvorstandDTO));
+            val expectedWahlvorstand = wahlvorstandModelMapper.toEntity(wahlvorstandDTOMapper.toModel(wahlbezirkID, mockedWahlvorstandDTO));
             Assertions.assertThat(wahlvorstandFromRepo).usingRecursiveComparison().isEqualTo(expectedWahlvorstand);
         }
 
@@ -168,7 +168,7 @@ public class WahlvorstandControllerIntegrationTest {
             wahlvorstandRepository.save(wahlvorstandToOverride);
             val wahlvorstandBeforeOverridden = wahlvorstandRepository.findById(wahlbezirkID).get();
 
-            val mockedWahlvorstandDTO = TestDataFactory.CreateWahlvorstandDto.withWahlbezirkID(wahlbezirkID);
+            val mockedWahlvorstandDTO = TestDataFactory.CreateWahlvorstandDto.withData();
             WireMock.stubFor(WireMock.put("/wahlvorstaende/anwesenheit")
                     .willReturn(WireMock.aResponse().withHeader("Content-Type", "application/json")
                             .withStatus(HttpStatus.OK.value())));
@@ -178,7 +178,7 @@ public class WahlvorstandControllerIntegrationTest {
             api.perform(request).andExpect(status().isOk()).andReturn();
 
             val wahlvorstandFromRepo = wahlvorstandRepository.findById(wahlbezirkID).get();
-            val expectedWahlvorstand = wahlvorstandModelMapper.toEntity(wahlvorstandDTOMapper.toModel(mockedWahlvorstandDTO));
+            val expectedWahlvorstand = wahlvorstandModelMapper.toEntity(wahlvorstandDTOMapper.toModel(wahlbezirkID, mockedWahlvorstandDTO));
 
             Assertions.assertThat(wahlvorstandFromRepo).usingRecursiveComparison().isEqualTo(expectedWahlvorstand);
             Assertions.assertThat(wahlvorstandBeforeOverridden.getWahlvorstandsmitglieder()).isNotEqualTo(wahlvorstandFromRepo.getWahlvorstandsmitglieder());

--- a/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandControllerTest.java
+++ b/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandControllerTest.java
@@ -91,12 +91,13 @@ public class WahlvorstandControllerTest {
 
         @Test
         void should_notThrowException_when_newDataSaved() {
+            val wahlbezirkID = "wahlbezirkID";
             val mockedWahlvorstandDto = TestDataFactory.CreateWahlvorstandDto.withData();
-            val mockedWahlvorstandModel = TestDataFactory.CreateWahlvorstandModel.fromDto(mockedWahlvorstandDto);
+            val mockedWahlvorstandModel = TestDataFactory.CreateWahlvorstandModel.fromDto(wahlbezirkID, mockedWahlvorstandDto);
 
-            Mockito.when(wahlvorstandDTOMapper.toModel(mockedWahlvorstandDto)).thenReturn(mockedWahlvorstandModel);
+            Mockito.when(wahlvorstandDTOMapper.toModel(wahlbezirkID, mockedWahlvorstandDto)).thenReturn(mockedWahlvorstandModel);
 
-            Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.postWahlvorstand(mockedWahlvorstandDto));
+            Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.postWahlvorstand(wahlbezirkID, mockedWahlvorstandDto));
             Mockito.verify(wahlvorstandService).postWahlvorstand(mockedWahlvorstandModel);
         }
     }

--- a/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandDTOMapperTest.java
+++ b/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandDTOMapperTest.java
@@ -34,15 +34,16 @@ public class WahlvorstandDTOMapperTest {
 
         @Test
         void should_returnNull_when_givenNull() {
-            Assertions.assertThat(unitUnderTest.toModel(null)).isNull();
+            Assertions.assertThat(unitUnderTest.toModel(null, null)).isNull();
         }
 
         @Test
         void should_returnWahlvorstandModel_when_givenWahlvorstandDTO() {
+            val wahlbezirkID = "wahlbezirkID";
             val mockedWahlvorstandDTO = TestDataFactory.CreateWahlvorstandDto.withData();
-            val expectedWahlvorstandModel = TestDataFactory.CreateWahlvorstandModel.fromDto(mockedWahlvorstandDTO);
+            val expectedWahlvorstandModel = TestDataFactory.CreateWahlvorstandModel.fromDto(wahlbezirkID, mockedWahlvorstandDTO);
 
-            val result = unitUnderTest.toModel(mockedWahlvorstandDTO);
+            val result = unitUnderTest.toModel(wahlbezirkID, mockedWahlvorstandDTO);
             Assertions.assertThat(result).isEqualTo(expectedWahlvorstandModel);
         }
     }

--- a/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/utils/TestDataFactory.java
+++ b/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/utils/TestDataFactory.java
@@ -61,14 +61,14 @@ public class TestDataFactory {
             return new WahlvorstandModel("wahlbezirkID", LocalDateTime.now().withNano(0), wahlvorstandsmitgliedModelList);
         }
 
-        public static WahlvorstandModel fromDto(WahlvorstandDTO wahlvorstandDto) {
+        public static WahlvorstandModel fromDto(final String wahlbezirkID, WahlvorstandDTO wahlvorstandDto) {
             List<WahlvorstandsmitgliedModel> wahlvorstandsmitgliedModelList = wahlvorstandDto.wahlvorstandsmitglieder().stream()
                     .map(mitglied -> new WahlvorstandsmitgliedModel(
                             mitglied.identifikator(), mitglied.familienname(), mitglied.vorname(), MapFunktion.funktionDtoToFunktionModel(mitglied.funktion()),
                             mitglied.funktionsname(), mitglied.anwesend()))
                     .toList();
 
-            return new WahlvorstandModel(wahlvorstandDto.wahlbezirkID(), wahlvorstandDto.anwesenheitBeginn(), wahlvorstandsmitgliedModelList);
+            return new WahlvorstandModel(wahlbezirkID, wahlvorstandDto.anwesenheitBeginn(), wahlvorstandsmitgliedModelList);
         }
 
         public static WahlvorstandModel fallback(String wahlbezirkID) {
@@ -99,14 +99,7 @@ public class TestDataFactory {
             List<WahlvorstandsmitgliedDTO> wahlvorstandsmitgliedDtoList = new ArrayList<>();
             wahlvorstandsmitgliedDtoList.add(CreateWahlvorstandsmitgliedDto.withData());
 
-            return new WahlvorstandDTO("wahlbezirkID", LocalDateTime.now().withNano(0), wahlvorstandsmitgliedDtoList);
-        }
-
-        public static WahlvorstandDTO withWahlbezirkID(String wahlbezirkID) {
-            List<WahlvorstandsmitgliedDTO> wahlvorstandsmitgliedDtoList = new ArrayList<>();
-            wahlvorstandsmitgliedDtoList.add(CreateWahlvorstandsmitgliedDto.withData());
-
-            return new WahlvorstandDTO(wahlbezirkID, LocalDateTime.now().withNano(0), wahlvorstandsmitgliedDtoList);
+            return new WahlvorstandDTO(LocalDateTime.now().withNano(0), wahlvorstandsmitgliedDtoList);
         }
 
         public static WahlvorstandDTO fromModel(WahlvorstandModel model) {
@@ -114,7 +107,7 @@ public class TestDataFactory {
                     mitglied.identifikator(), mitglied.familienname(), mitglied.vorname(), MapFunktion.funktionModelToFunktionDto(mitglied.funktion()),
                     mitglied.funktionsname(), mitglied.anwesend()))
                     .toList();
-            return new WahlvorstandDTO(model.wahlbezirkID(), model.anwesenheitBeginn(), wahlvorstandsmitgliedDtoList);
+            return new WahlvorstandDTO(model.anwesenheitBeginn(), wahlvorstandsmitgliedDtoList);
         }
     }
 


### PR DESCRIPTION
# Beschreibung:

Die Pfadvariable `wahlbezirkID` beim Post wurde nicht verwendet. Weder gab es eine Annotation noch einen Parameter. Daher ist keine Generierung eines Clients möglich.

Als Lösung habe ich die WahlbezirkID aus dem RequestBody entfernt. Beim Mapping zum Model wird die Pfadvariable verwendet. Dies ist mit dem Altsystem insofern kompatibel als das im Frontend der Wert für die Pfadvariable aus dem RequestBody genommen wurde.

Das theoretische Szenario das die WahlbezirkID in der URL mit dem Requestbody nicht übereinstimmt, ist somit nicht gegeben gewesen.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Doku aktualisiert - kein Update notwendig
- [x] Swagger-API vollständig - kein manuelles Update notwendig
- [x] Unit-Tests gepflegt
- [x] Integrationstests gepflegt
- [ ] Beispiel-Requests gepflegt

# Referenzen[^1]:

Verwandt mit Issue #

Closes #824 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the submission endpoint to now require a regional district identifier in the URL, streamlining how requests are processed.
	- Simplified the data structure for election board submissions to ensure clearer and more consistent data handling.

- **Tests**
	- Updated test cases to align with the new endpoint requirements and data flow, ensuring a smooth integration of the changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->