### PR TITLE
create wahlvorstandwriteDTO for post operation

### DIFF
--- a/wls-wahlvorstand-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandController.java
+++ b/wls-wahlvorstand-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandController.java
@@ -81,8 +81,8 @@ public class WahlvorstandController {
             }
     )
     @PostMapping("/{wahlbezirkID}")
-    public ResponseEntity<?> postWahlvorstand(@RequestBody WahlvorstandDTO wahlvorstandBody) {
-        wahlvorstandService.postWahlvorstand(wahlvorstandDTOMapper.toModel(wahlvorstandBody));
+    public ResponseEntity<?> postWahlvorstand(@PathVariable("wahlbezirkID") final String wahlbezirkID, @RequestBody WahlvorstandWriteDTO wahlvorstandBody) {
+        wahlvorstandService.postWahlvorstand(wahlvorstandDTOMapper.toModel(wahlbezirkID, wahlvorstandBody));
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/wls-wahlvorstand-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandDTOMapper.java
+++ b/wls-wahlvorstand-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandDTOMapper.java
@@ -8,5 +8,5 @@ public interface WahlvorstandDTOMapper {
 
     WahlvorstandDTO toDTO(WahlvorstandModel model);
 
-    WahlvorstandModel toModel(WahlvorstandDTO dto);
+    WahlvorstandModel toModel(String wahlbezirkID, WahlvorstandWriteDTO dto);
 }

--- a/wls-wahlvorstand-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandWriteDTO.java
+++ b/wls-wahlvorstand-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandWriteDTO.java
@@ -1,0 +1,10 @@
+package de.muenchen.oss.wahllokalsystem.wahlvorstandservice.rest.wahlvorstand;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record WahlvorstandWriteDTO(LocalDateTime anwesenheitBeginn,
+                                   List<WahlvorstandsmitgliedDTO> wahlvorstandsmitglieder) {
+}

--- a/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandControllerIntegrationTest.java
+++ b/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandControllerIntegrationTest.java
@@ -142,7 +142,7 @@ public class WahlvorstandControllerIntegrationTest {
         )
         void should_saveWahlvorstand_when_newDataSuccessfullySaved() throws Exception {
             val wahlbezirkID = "wahlbezirkID";
-            val mockedWahlvorstandDTO = TestDataFactory.CreateWahlvorstandDto.withWahlbezirkID(wahlbezirkID);
+            val mockedWahlvorstandDTO = TestDataFactory.CreateWahlvorstandWriteDto.withData();
 
             WireMock.stubFor(WireMock.put("/wahlvorstaende/anwesenheit")
                     .willReturn(WireMock.aResponse().withHeader("Content-Type", "application/json")
@@ -153,7 +153,7 @@ public class WahlvorstandControllerIntegrationTest {
             api.perform(request).andExpect(status().isOk()).andReturn();
 
             val wahlvorstandFromRepo = wahlvorstandRepository.findById(wahlbezirkID).get();
-            val expectedWahlvorstand = wahlvorstandModelMapper.toEntity(wahlvorstandDTOMapper.toModel(mockedWahlvorstandDTO));
+            val expectedWahlvorstand = wahlvorstandModelMapper.toEntity(wahlvorstandDTOMapper.toModel(wahlbezirkID, mockedWahlvorstandDTO));
             Assertions.assertThat(wahlvorstandFromRepo).usingRecursiveComparison().isEqualTo(expectedWahlvorstand);
         }
 
@@ -168,7 +168,7 @@ public class WahlvorstandControllerIntegrationTest {
             wahlvorstandRepository.save(wahlvorstandToOverride);
             val wahlvorstandBeforeOverridden = wahlvorstandRepository.findById(wahlbezirkID).get();
 
-            val mockedWahlvorstandDTO = TestDataFactory.CreateWahlvorstandDto.withWahlbezirkID(wahlbezirkID);
+            val mockedWahlvorstandDTO = TestDataFactory.CreateWahlvorstandWriteDto.withData();
             WireMock.stubFor(WireMock.put("/wahlvorstaende/anwesenheit")
                     .willReturn(WireMock.aResponse().withHeader("Content-Type", "application/json")
                             .withStatus(HttpStatus.OK.value())));
@@ -178,7 +178,7 @@ public class WahlvorstandControllerIntegrationTest {
             api.perform(request).andExpect(status().isOk()).andReturn();
 
             val wahlvorstandFromRepo = wahlvorstandRepository.findById(wahlbezirkID).get();
-            val expectedWahlvorstand = wahlvorstandModelMapper.toEntity(wahlvorstandDTOMapper.toModel(mockedWahlvorstandDTO));
+            val expectedWahlvorstand = wahlvorstandModelMapper.toEntity(wahlvorstandDTOMapper.toModel(wahlbezirkID, mockedWahlvorstandDTO));
 
             Assertions.assertThat(wahlvorstandFromRepo).usingRecursiveComparison().isEqualTo(expectedWahlvorstand);
             Assertions.assertThat(wahlvorstandBeforeOverridden.getWahlvorstandsmitglieder()).isNotEqualTo(wahlvorstandFromRepo.getWahlvorstandsmitglieder());

--- a/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandControllerTest.java
+++ b/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandControllerTest.java
@@ -91,12 +91,13 @@ public class WahlvorstandControllerTest {
 
         @Test
         void should_notThrowException_when_newDataSaved() {
-            val mockedWahlvorstandDto = TestDataFactory.CreateWahlvorstandDto.withData();
-            val mockedWahlvorstandModel = TestDataFactory.CreateWahlvorstandModel.fromDto(mockedWahlvorstandDto);
+            val wahlbezirkID = "wahlbezirkID";
+            val mockedWahlvorstandDto = TestDataFactory.CreateWahlvorstandWriteDto.withData();
+            val mockedWahlvorstandModel = TestDataFactory.CreateWahlvorstandModel.fromDto(wahlbezirkID, mockedWahlvorstandDto);
 
-            Mockito.when(wahlvorstandDTOMapper.toModel(mockedWahlvorstandDto)).thenReturn(mockedWahlvorstandModel);
+            Mockito.when(wahlvorstandDTOMapper.toModel(wahlbezirkID, mockedWahlvorstandDto)).thenReturn(mockedWahlvorstandModel);
 
-            Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.postWahlvorstand(mockedWahlvorstandDto));
+            Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.postWahlvorstand(wahlbezirkID, mockedWahlvorstandDto));
             Mockito.verify(wahlvorstandService).postWahlvorstand(mockedWahlvorstandModel);
         }
     }

--- a/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandDTOMapperTest.java
+++ b/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/rest/wahlvorstand/WahlvorstandDTOMapperTest.java
@@ -34,15 +34,16 @@ public class WahlvorstandDTOMapperTest {
 
         @Test
         void should_returnNull_when_givenNull() {
-            Assertions.assertThat(unitUnderTest.toModel(null)).isNull();
+            Assertions.assertThat(unitUnderTest.toModel(null, null)).isNull();
         }
 
         @Test
         void should_returnWahlvorstandModel_when_givenWahlvorstandDTO() {
-            val mockedWahlvorstandDTO = TestDataFactory.CreateWahlvorstandDto.withData();
-            val expectedWahlvorstandModel = TestDataFactory.CreateWahlvorstandModel.fromDto(mockedWahlvorstandDTO);
+            val wahlbezirkID = "wahlbezirkID";
+            val mockedWahlvorstandDTO = TestDataFactory.CreateWahlvorstandWriteDto.withData();
+            val expectedWahlvorstandModel = TestDataFactory.CreateWahlvorstandModel.fromDto(wahlbezirkID, mockedWahlvorstandDTO);
 
-            val result = unitUnderTest.toModel(mockedWahlvorstandDTO);
+            val result = unitUnderTest.toModel(wahlbezirkID, mockedWahlvorstandDTO);
             Assertions.assertThat(result).isEqualTo(expectedWahlvorstandModel);
         }
     }

--- a/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/utils/TestDataFactory.java
+++ b/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/utils/TestDataFactory.java
@@ -6,6 +6,7 @@ import de.muenchen.oss.wahllokalsystem.wahlvorstandservice.domain.wahlvorstand.W
 import de.muenchen.oss.wahllokalsystem.wahlvorstandservice.eai.infomanagement.model.KonfigurierterWahltagDTO;
 import de.muenchen.oss.wahllokalsystem.wahlvorstandservice.rest.wahlvorstand.FunktionDTO;
 import de.muenchen.oss.wahllokalsystem.wahlvorstandservice.rest.wahlvorstand.WahlvorstandDTO;
+import de.muenchen.oss.wahllokalsystem.wahlvorstandservice.rest.wahlvorstand.WahlvorstandWriteDTO;
 import de.muenchen.oss.wahllokalsystem.wahlvorstandservice.rest.wahlvorstand.WahlvorstandsmitgliedDTO;
 import de.muenchen.oss.wahllokalsystem.wahlvorstandservice.service.wahlvorstand.FunktionModel;
 import de.muenchen.oss.wahllokalsystem.wahlvorstandservice.service.wahlvorstand.KonfigurierterWahltagModel;
@@ -61,14 +62,14 @@ public class TestDataFactory {
             return new WahlvorstandModel("wahlbezirkID", LocalDateTime.now().withNano(0), wahlvorstandsmitgliedModelList);
         }
 
-        public static WahlvorstandModel fromDto(WahlvorstandDTO wahlvorstandDto) {
+        public static WahlvorstandModel fromDto(final String wahlbezirkID, WahlvorstandWriteDTO wahlvorstandDto) {
             List<WahlvorstandsmitgliedModel> wahlvorstandsmitgliedModelList = wahlvorstandDto.wahlvorstandsmitglieder().stream()
                     .map(mitglied -> new WahlvorstandsmitgliedModel(
                             mitglied.identifikator(), mitglied.familienname(), mitglied.vorname(), MapFunktion.funktionDtoToFunktionModel(mitglied.funktion()),
                             mitglied.funktionsname(), mitglied.anwesend()))
                     .toList();
 
-            return new WahlvorstandModel(wahlvorstandDto.wahlbezirkID(), wahlvorstandDto.anwesenheitBeginn(), wahlvorstandsmitgliedModelList);
+            return new WahlvorstandModel(wahlbezirkID, wahlvorstandDto.anwesenheitBeginn(), wahlvorstandsmitgliedModelList);
         }
 
         public static WahlvorstandModel fallback(String wahlbezirkID) {
@@ -115,6 +116,16 @@ public class TestDataFactory {
                     mitglied.funktionsname(), mitglied.anwesend()))
                     .toList();
             return new WahlvorstandDTO(model.wahlbezirkID(), model.anwesenheitBeginn(), wahlvorstandsmitgliedDtoList);
+        }
+    }
+
+    public static class CreateWahlvorstandWriteDto {
+
+        public static WahlvorstandWriteDTO withData() {
+            List<WahlvorstandsmitgliedDTO> wahlvorstandsmitgliedDtoList = new ArrayList<>();
+            wahlvorstandsmitgliedDtoList.add(CreateWahlvorstandsmitgliedDto.withData());
+
+            return new WahlvorstandWriteDTO(LocalDateTime.now().withNano(0), wahlvorstandsmitgliedDtoList);
         }
     }
 

--- a/wls-wahlvorstand-service/src/test/resources/http.request/wahlvorstand.http
+++ b/wls-wahlvorstand-service/src/test/resources/http.request/wahlvorstand.http
@@ -12,7 +12,6 @@ Authorization: Bearer {{$auth.token("auth-service")}}
 Content-Type: application/json
 
 {
-  "wahlbezirkID": "wahlbezirkID",
   "anwesenheitBeginn": "2024-06-09T23:59:12.123",
   "wahlvorstandsmitglieder": [
     {


### PR DESCRIPTION
# Beschreibung:

Die Pfadvariable `wahlbezirkID` beim Post wurde nicht verwendet. Weder gab es eine Annotation noch einen Parameter. Daher ist keine Generierung eines Clients möglich.

Als Lösung habe ich die WahlbezirkID aus dem RequestBody entfernt. Beim Mapping zum Model wird die Pfadvariable verwendet. Dies ist mit dem Altsystem insofern kompatibel als das im Frontend der Wert für die Pfadvariable aus dem RequestBody genommen wurde.

Das theoretische Szenario das die WahlbezirkID in der URL mit dem Requestbody nicht übereinstimmt, ist somit nicht gegeben gewesen.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Doku aktualisiert - nichts zu tun
- [x] Swagger-API vollständig - nichts manuell zu erledigen
- [x] Unit-Tests gepflegt
- [x] Integrationstests gepflegt
- [x] Beispiel-Requests gepflegt - Post angepasst

# Referenzen[^1]:

Verwandt mit Issue #

Closes #824

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The voting board endpoint now accepts a district identifier via the URL instead of within the request body.
  - The request payload has been updated with a refined structure that includes start time details and a list of board members.

- **Refactor**
  - Internal data mapping processes have been streamlined to align with the enhanced API contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->