### PR TITLE
#771, #772 add test for rules with allowEmpty true

### DIFF
--- a/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/archunit/rule/MethodRulesTest.java
+++ b/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/archunit/rule/MethodRulesTest.java
@@ -30,7 +30,7 @@ public class MethodRulesTest {
     @MethodSource("getRulesAndTestClassesWithoutMatchingCasesThrowingErrors")
     void should_throwError_when_noCasesMatchingRuleWereFound(ArchRule ruleUnderTest) {
         Assertions.assertThatCode(() -> ruleUnderTest.check(new ClassFileImporter()
-                .importClasses(NamingConventionExamplesTest.ExampleTestNamesWithoutAnnotation.class)))
+                .importClasses(NamingConventionExamplesTest.ExampleMethodNamesWithoutAnnotation.class)))
                 .isInstanceOf(AssertionError.class)
                 .satisfies(assertionError -> Assertions.assertThat(assertionError.getMessage())
                         .contains("failed to check any classes"));
@@ -41,6 +41,14 @@ public class MethodRulesTest {
     void should_throwNoError_when_ruleSatisfied(ArchRule ruleUnderTest, Class<?> testClass) {
         Assertions.assertThatCode(() -> ruleUnderTest.check(new ClassFileImporter()
                 .importClasses(testClass)))
+                .doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @MethodSource("getRulesAndTestClassesWithoutMatchingCasesNotThrowingErrors")
+    void should_throwNoError_when_noCasesMatchingRuleWereFoundAndAllowEmptyIsTrue(ArchRule ruleUnderTest) {
+        Assertions.assertThatCode(() -> ruleUnderTest.check(new ClassFileImporter()
+                .importClasses(NamingConventionExamplesTest.ExampleMethodNamesWithoutAnnotation.class)))
                 .doesNotThrowAnyException();
     }
 
@@ -67,5 +75,11 @@ public class MethodRulesTest {
                         NamingConventionExamplesTest.ExampleBeforeEachMethodNameFollowingNamingConventionRule.class),
                 Arguments.of(RULE_AFTER_EACH_NAMING_CONVENTION_MATCHED,
                         NamingConventionExamplesTest.ExampleAfterEachMethodNameFollowingNamingConventionRule.class));
+    }
+
+    private static Stream<Arguments> getRulesAndTestClassesWithoutMatchingCasesNotThrowingErrors() {
+        return Stream.of(
+                Arguments.of(RULE_AFTER_EACH_NAMING_CONVENTION_MATCHED),
+                Arguments.of(RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
     }
 }

--- a/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/archunit/utilityClasses/NamingConventionExamplesTest.java
+++ b/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/archunit/utilityClasses/NamingConventionExamplesTest.java
@@ -95,7 +95,7 @@ public class NamingConventionExamplesTest {
     }
 
     @Nested
-    public class ExampleTestNamesWithoutAnnotation {
+    public class ExampleMethodNamesWithoutAnnotation {
 
         void should_abc_when_def() {
         }


### PR DESCRIPTION
# Beschreibung:

Zusätzlichen Test hinzugefügt, um zu verifizieren, dass Regeln mit dem Anhang `allowEmptyShould(true)` keinen Fehler werfen, wenn sie keine zu prüfenden Fälle gefunden haben.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [ ] ~Doku aktualisiert~ nicht relevant
- [ ] ~Swagger-API vollständig~ nicht relevant
- [x] Unit-Tests gepflegt
- [ ] ~Integrationstests gepflegt~ nicht relevant
- [ ] ~Beispiel-Requests gepflegt~ nicht relevant

# Referenzen[^1]:

Verwandt mit Issue #771, #772

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced test coverage for rule validations, ensuring that scenarios with no applicable cases are handled correctly.
- **Refactor**
	- Updated internal naming conventions for improved clarity in test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->