### PR TITLE
Inkludieren von Profil dummy.clients bei Profil local

### DIFF
--- a/wls-admin-service/src/main/resources/application.yml
+++ b/wls-admin-service/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
     group:
       local:
         - db-h2
+        - dummy.clients
   flyway:
     locations:
       - classpath:db/migrations/{vendor}


### PR DESCRIPTION
# Beschreibung:

Analog zu den anderen Services, welche auch auf andere Service zugreifen, wird jetzt auch beim Admin-Service im Rahmen von `local` `das Profile `dummy.clients` verwendet.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

# Referenzen[^1]:

Verwandt mit Issue #

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the local development configuration by adding an additional client option, enhancing support for local testing scenarios without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->