### PR TITLE
add WithMockUserAsJwt Annotation

### DIFF
--- a/wls-common/testing/pom.xml
+++ b/wls-common/testing/pom.xml
@@ -30,6 +30,18 @@
             <artifactId>spring-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
         </dependency>

--- a/wls-common/testing/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/WithMockUserAsJwt.java
+++ b/wls-common/testing/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/WithMockUserAsJwt.java
@@ -1,0 +1,35 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.testing;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@WithSecurityContext(factory = WithMockUserAsJwtSecurityContextFactory.class)
+public @interface WithMockUserAsJwt {
+
+    String value() default "user";
+
+    String[] authorities() default {};
+
+    String[] claimProperties() default {};
+
+    String claimPropertiesSeparator() default "=";
+
+    int issuedBeforeHours() default 1;
+
+    int expiredInHours() default 1;
+
+    @AliasFor(annotation = WithSecurityContext.class)
+    TestExecutionEvent setupBefore() default TestExecutionEvent.TEST_METHOD;
+
+}

--- a/wls-common/testing/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/WithMockUserAsJwtSecurityContextFactory.java
+++ b/wls-common/testing/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/WithMockUserAsJwtSecurityContextFactory.java
@@ -61,7 +61,20 @@ public final class WithMockUserAsJwtSecurityContextFactory implements WithSecuri
     }
 
     private Map<String, Object> createClaimsMap(final String[] concatenatedClaimProperties, final String keyValueSeparator) {
-        return Arrays.stream(concatenatedClaimProperties).map(concatenatedClaimProperty -> concatenatedClaimProperty.split(keyValueSeparator))
+        return Arrays.stream(concatenatedClaimProperties)
+                .map(concatenatedClaimProperty -> this.getSplittedClaimProperty(concatenatedClaimProperty, keyValueSeparator))
                 .collect(Collectors.toMap(propertyAsArray -> propertyAsArray[0], propertyAsArray -> propertyAsArray[1]));
+    }
+
+    private String[] getSplittedClaimProperty(final String concatenatedClaimProperty, final String keyValueSeparator) {
+        val indexOfKeyValueSeparator = concatenatedClaimProperty.indexOf(keyValueSeparator);
+        if (indexOfKeyValueSeparator > 0) {
+            return new String[] {
+                    concatenatedClaimProperty.substring(0, indexOfKeyValueSeparator),
+                    concatenatedClaimProperty.substring(indexOfKeyValueSeparator + keyValueSeparator.length())
+            };
+        } else {
+            throw new IllegalArgumentException("claim " + concatenatedClaimProperty + " does not match required format");
+        }
     }
 }

--- a/wls-common/testing/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/WithMockUserAsJwtSecurityContextFactory.java
+++ b/wls-common/testing/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/WithMockUserAsJwtSecurityContextFactory.java
@@ -1,0 +1,67 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.testing;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import org.springframework.util.Assert;
+
+/*
+ * inspired by org.springframework.security.test.context.support.WithMockUserSecurityContextFactory
+ */
+public final class WithMockUserAsJwtSecurityContextFactory implements WithSecurityContextFactory<WithMockUserAsJwt> {
+
+    private SecurityContextHolderStrategy securityContextHolderStrategy = SecurityContextHolder
+            .getContextHolderStrategy();
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockUserAsJwt withUser) {
+        val username = withUser.value();
+        Assert.notNull(username, () -> withUser + " cannot have null username on both username and value properties");
+
+        val issuedAt = Instant.now().minus(withUser.issuedBeforeHours(), ChronoUnit.HOURS);
+        val expiresAt = Instant.now().plus(withUser.expiredInHours(), ChronoUnit.HOURS);
+        val headers = Map.of("jwtDummyHeader", (Object) "jwtDummyValue");
+
+        val claims = new HashMap<String, Object>();
+        claims.put("dummyClaim", "dummyClaimValue");
+        claims.putAll(createClaimsMap(withUser.claimProperties(), withUser.claimPropertiesSeparator()));
+
+        val jwt = new Jwt(username, issuedAt, expiresAt, headers, claims);
+
+        List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+        for (String authority : withUser.authorities()) {
+            grantedAuthorities.add(new SimpleGrantedAuthority(authority));
+        }
+
+        val authentication = new JwtAuthenticationToken(jwt, grantedAuthorities);
+
+        val context = this.securityContextHolderStrategy.createEmptyContext();
+        context.setAuthentication(authentication);
+        return context;
+    }
+
+    @Autowired(required = false)
+    void setSecurityContextHolderStrategy(SecurityContextHolderStrategy securityContextHolderStrategy) {
+        this.securityContextHolderStrategy = securityContextHolderStrategy;
+    }
+
+    private Map<String, Object> createClaimsMap(final String[] concatenatedClaimProperties, final String keyValueSeparator) {
+        return Arrays.stream(concatenatedClaimProperties).map(concatenatedClaimProperty -> concatenatedClaimProperty.split(keyValueSeparator))
+                .collect(Collectors.toMap(propertyAsArray -> propertyAsArray[0], propertyAsArray -> propertyAsArray[1]));
+    }
+}

--- a/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/WithMockUserAsJwtSecurityContextFactoryTest.java
+++ b/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/WithMockUserAsJwtSecurityContextFactoryTest.java
@@ -1,0 +1,112 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.testing;
+
+import java.util.List;
+import java.util.Map;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+class WithMockUserAsJwtSecurityContextFactoryTest {
+
+    private final WithMockUserAsJwtSecurityContextFactory unitUnderTest = new WithMockUserAsJwtSecurityContextFactory();
+
+    @Nested
+    class CreateSecurityContext {
+
+        @Test
+        void should_createSecurityContextWithAuthorities_when_authoritiesAreGivenInTheAnnotation() {
+            val securityContext = unitUnderTest.createSecurityContext(getAnnotation(TestClassWithAuthoritiesInAnnotations.class));
+
+            val jwtAuthentication = (JwtAuthenticationToken) securityContext.getAuthentication();
+            val authorities = jwtAuthentication.getAuthorities();
+
+            val expectedAuthorities = List.of(new SimpleGrantedAuthority("Authority1"), new SimpleGrantedAuthority("Authority2"));
+
+            Assertions.assertThat(authorities).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(expectedAuthorities);
+        }
+
+        @Test
+        void should_createSecurityContextWithEmptyAuthoritiesList_when_noAuthoritiesAreGivenInTheAnnotation() {
+            val securityContext = unitUnderTest.createSecurityContext(getAnnotation(TestClassWithNoPropertiesSetInTheAnnotation.class));
+
+            val jwtAuthentication = (JwtAuthenticationToken) securityContext.getAuthentication();
+            val authorities = jwtAuthentication.getAuthorities();
+
+            Assertions.assertThat(authorities).isEmpty();
+        }
+
+        @Test
+        void should_setUsernameInJwtToken_when_usernameIsGivenInTheAnnotation() {
+            val securityContext = unitUnderTest.createSecurityContext(getAnnotation(TestClassWithUsernameInAnnotation.class));
+
+            val jwtAuthentication = (JwtAuthenticationToken) securityContext.getAuthentication();
+            val username = jwtAuthentication.getToken().getTokenValue();
+
+            Assertions.assertThat(username).isEqualTo("username");
+        }
+
+        @Test
+        void should_hasDefaultUsername_when_usernameIsNotGivenInTheAnnotation() {
+            val securityContext = unitUnderTest.createSecurityContext(getAnnotation(TestClassWithNoPropertiesSetInTheAnnotation.class));
+
+            val jwtAuthentication = (JwtAuthenticationToken) securityContext.getAuthentication();
+            val username = jwtAuthentication.getToken().getTokenValue();
+
+            Assertions.assertThat(username).isEqualTo("user");
+        }
+
+        @Test
+        void should_addClaimWithDefaultKeyValueSeparator_when_claimsAreGivenInTheAnnotation() {
+            val securityContext = unitUnderTest.createSecurityContext(getAnnotation(TestClassWithClaimsInAnnotation.class));
+
+            val jwtAuthentication = (JwtAuthenticationToken) securityContext.getAuthentication();
+            val claims = jwtAuthentication.getToken().getClaims();
+
+            Assertions.assertThat(claims).contains(Map.entry("key1", "value1"));
+            Assertions.assertThat(claims).contains(Map.entry("key2", "value2"));
+        }
+
+        @Test
+        void should_addClaimByDefineKeyValueSeparator_when_claimsAndSeparatorAreGivenInTheAnnotation() {
+            val securityContext = unitUnderTest.createSecurityContext(getAnnotation(TestClassWithClaimsAndClaimSeparatorInAnnotation.class));
+
+            val jwtAuthentication = (JwtAuthenticationToken) securityContext.getAuthentication();
+            val claims = jwtAuthentication.getToken().getClaims();
+
+            Assertions.assertThat(claims).contains(Map.entry("key1", "value1"));
+            Assertions.assertThat(claims).contains(Map.entry("key2", "value2"));
+        }
+
+        private WithMockUserAsJwt getAnnotation(Class<?> clazz) {
+            return clazz.getAnnotation(WithMockUserAsJwt.class);
+        }
+
+    }
+
+}
+
+@WithMockUserAsJwt
+class TestClassWithNoPropertiesSetInTheAnnotation {
+
+}
+
+@WithMockUserAsJwt(authorities = { "Authority1", "Authority2" })
+class TestClassWithAuthoritiesInAnnotations {
+}
+
+@WithMockUserAsJwt(value = "username")
+class TestClassWithUsernameInAnnotation {
+}
+
+@WithMockUserAsJwt(claimProperties = { "key1=value1", "key2=value2" })
+class TestClassWithClaimsInAnnotation {
+
+}
+
+@WithMockUserAsJwt(claimProperties = { "key1;value1", "key2;value2" }, claimPropertiesSeparator = ";")
+class TestClassWithClaimsAndClaimSeparatorInAnnotation {
+
+}

--- a/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/WithMockUserAsJwtSecurityContextFactoryTest.java
+++ b/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/WithMockUserAsJwtSecurityContextFactoryTest.java
@@ -80,6 +80,14 @@ class WithMockUserAsJwtSecurityContextFactoryTest {
             Assertions.assertThat(claims).contains(Map.entry("key2", "value2"));
         }
 
+        @Test
+        void should_throwException_when_claimPropertyDoesNotContainTheSeparator() {
+            Assertions.assertThatException()
+                    .isThrownBy(() -> unitUnderTest.createSecurityContext(getAnnotation(TestClassWithClaimMismatchingTheRequiredFormatInAnnotation.class)))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+        }
+
         private WithMockUserAsJwt getAnnotation(Class<?> clazz) {
             return clazz.getAnnotation(WithMockUserAsJwt.class);
         }
@@ -108,5 +116,10 @@ class TestClassWithClaimsInAnnotation {
 
 @WithMockUserAsJwt(claimProperties = { "key1;value1", "key2;value2" }, claimPropertiesSeparator = ";")
 class TestClassWithClaimsAndClaimSeparatorInAnnotation {
+
+}
+
+@WithMockUserAsJwt(claimProperties = { "key=value" }, claimPropertiesSeparator = ";")
+class TestClassWithClaimMismatchingTheRequiredFormatInAnnotation {
 
 }


### PR DESCRIPTION
# Beschreibung:

Die Annotation gibt es bereits in den Services Ergebnismeldung und Infomanagement. Für Tests im Wahlvorstand wird die Annoatation ebenfalls benötigt. Um nicht noch mehr Duplikate an Code zu erstellen soll die Annotation nach common wandern.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [X] [Naming Conventions][naming-conventions-link] beachtet
- [X] Doku aktualisiert - ich sehe keine Relevanz für die Doku
- [X] Swagger-API vollständig - keine Verbindung zu API
- [X] Unit-Tests gepflegt - für die Factory in Bezug auf authorities und claims
- [X] Integrationstests gepflegt - keine - nicht Teil des funktionalen Codes
- [x] Beispiel-Requests gepflegt - keine Verbindung zu API

# Referenzen[^1]:

Verwandt mit Issue #879

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced security support through new dependencies that bolster JWT and OAuth2 functionalities.
  - Added a test-specific feature to simulate JWT-based user authentication scenarios for improved testing flexibility.

- **Tests**
  - Implemented comprehensive test cases to ensure accurate simulation and verification of security contexts, including authority assignment, username configuration, and custom claim handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->