### PR TITLE
Verwendung der AuthDetailsRetriever um Informationen für BezirkIDCheck zu erhalten

### DIFF
--- a/wls-common/security/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/security/BezirkIDPermissionEvaluatorImpl.java
+++ b/wls-common/security/src/main/java/de/muenchen/oss/wahllokalsystem/wls/common/security/BezirkIDPermissionEvaluatorImpl.java
@@ -1,6 +1,9 @@
 package de.muenchen.oss.wahllokalsystem.wls.common.security;
 
-import java.util.Map;
+import de.muenchen.oss.wahllokalsystem.wls.common.security.authentication.AuthDetailRetriever;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,6 +13,7 @@ import org.springframework.stereotype.Component;
 
 @Component(value = "bezirkIdPermissionEvaluator")
 @Profile("!" + Profiles.NO_BEZIRKS_ID_CHECK)
+@RequiredArgsConstructor
 public class BezirkIDPermissionEvaluatorImpl implements BezirkIDPermissionEvaluator {
 
     private static final Logger LOG = LoggerFactory.getLogger(BezirkIDPermissionEvaluatorImpl.class);
@@ -17,6 +21,8 @@ public class BezirkIDPermissionEvaluatorImpl implements BezirkIDPermissionEvalua
     private static final String AUTH_DETAILS_MAP_KEY_WAHLBEZIRK_ID = "wahlbezirkID";
 
     private static final String AUTH_DETAILS_MAP_KEY_WAHLBEZIRKID_WAHLNUMMER = "wahlbezirkid_wahlnummer";
+
+    private final List<AuthDetailRetriever> authDetailRetrievers;
 
     @Override
     public boolean tokenUserBezirkIdMatches(String bezirkId, Authentication auth) {
@@ -26,8 +32,8 @@ public class BezirkIDPermissionEvaluatorImpl implements BezirkIDPermissionEvalua
         }
         LOG.debug("tokenUserBezirkIdMatches {}, {}", bezirkId, auth.getPrincipal());
         try {
-            val bezirkIDFromToken = getBezirkID(auth);
-            val wahlbezirkid_wahlnummer = getWahlbezirkid_wahlnummer(auth);
+            val bezirkIDFromToken = getBezirkID(auth).orElse(null);
+            val wahlbezirkid_wahlnummer = getWahlbezirkid_wahlnummer(auth).orElse(null);
             val bezirkIdMatches = (bezirkId != null)
                     && (bezirkId.equals(bezirkIDFromToken) || (wahlbezirkid_wahlnummer != null && wahlbezirkid_wahlnummer.contains(bezirkId)));
             LOG.debug("Check bezirkId {} from request against username {}, bezirkId {} from token or wahlbezirkid_wahlnummer {}. RESULT = {}",
@@ -43,13 +49,17 @@ public class BezirkIDPermissionEvaluatorImpl implements BezirkIDPermissionEvalua
         }
     }
 
-    private String getBezirkID(final Authentication auth) {
-        val details = (Map) auth.getDetails();
-        return (String) details.get(AUTH_DETAILS_MAP_KEY_WAHLBEZIRK_ID);
+    private Optional<String> getBezirkID(final Authentication auth) {
+        return getClaim(auth, AUTH_DETAILS_MAP_KEY_WAHLBEZIRK_ID);
     }
 
-    private String getWahlbezirkid_wahlnummer(final Authentication auth) {
-        val details = (Map) auth.getDetails();
-        return (String) details.get(AUTH_DETAILS_MAP_KEY_WAHLBEZIRKID_WAHLNUMMER);
+    private Optional<String> getWahlbezirkid_wahlnummer(final Authentication auth) {
+        return getClaim(auth, AUTH_DETAILS_MAP_KEY_WAHLBEZIRKID_WAHLNUMMER);
+    }
+
+    private Optional<String> getClaim(final Authentication authentication, final String claimKey) {
+        val retriever = authDetailRetrievers.stream().filter(r -> r.canHandle(authentication)).findFirst();
+        return retriever.flatMap(authDetailRetriever -> authDetailRetriever.getDetail(claimKey, authentication));
+
     }
 }

--- a/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/BezirkIDPermissionEvaluatorImplTest.java
+++ b/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/BezirkIDPermissionEvaluatorImplTest.java
@@ -1,7 +1,9 @@
 package de.muenchen.oss.wahllokalsystem.wls.common.security;
 
+import de.muenchen.oss.wahllokalsystem.wls.common.security.authentication.AuthDetailRetriever;
 import de.muenchen.oss.wahllokalsystem.wls.common.testing.LoggerExtension;
-import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
 import lombok.val;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
@@ -16,7 +18,9 @@ import org.springframework.security.core.Authentication;
 @ExtendWith(MockitoExtension.class)
 class BezirkIDPermissionEvaluatorImplTest {
 
-    private final BezirkIDPermissionEvaluatorImpl unitUnderTest = new BezirkIDPermissionEvaluatorImpl();
+    AuthDetailRetriever authDetailRetriever = Mockito.mock(AuthDetailRetriever.class);
+
+    private final BezirkIDPermissionEvaluatorImpl unitUnderTest = new BezirkIDPermissionEvaluatorImpl(List.of(authDetailRetriever));
 
     @Mock
     Authentication auth;
@@ -36,6 +40,7 @@ class BezirkIDPermissionEvaluatorImplTest {
         @Test
         void should_returnFalseAndCreateLogError_when_errorWhileCheckingOccurred() {
             Mockito.when(auth.getPrincipal()).thenReturn("1234");
+            Mockito.doThrow(new RuntimeException("error")).when(authDetailRetriever).canHandle(auth);
 
             Assertions.assertThat(unitUnderTest.tokenUserBezirkIdMatches("1234", auth)).isFalse();
             Assertions.assertThat(loggerExtension.getFormattedMessages()).contains("Error while checking bezirkId.");
@@ -43,36 +48,33 @@ class BezirkIDPermissionEvaluatorImplTest {
 
         @Test
         void should_returnTrue_when_bezirkIDMatchesFromToken() {
-            val map = new HashMap<>();
-            map.put("wahlbezirkid_wahlnummer", "1234");
-            map.put("wahlbezirkID", "1234");
+            val wahlbezirkID = "1234";
 
-            Mockito.when(auth.getPrincipal()).thenReturn("1234");
-            Mockito.when(auth.getDetails()).thenReturn(map);
+            Mockito.when(authDetailRetriever.canHandle(auth)).thenReturn(true);
+            Mockito.when(authDetailRetriever.getDetail("wahlbezirkID", auth)).thenReturn(Optional.of(wahlbezirkID));
+            Mockito.when(authDetailRetriever.getDetail("wahlbezirkid_wahlnummer", auth)).thenReturn(Optional.empty());
 
             Assertions.assertThat(unitUnderTest.tokenUserBezirkIdMatches("1234", auth)).isTrue();
         }
 
         @Test
         void should_returnTrue_when_bezirkIDMatchesFromWahlBezirkID() {
-            val map = new HashMap<>();
-            map.put("wahlbezirkid_wahlnummer", "1234");
-            map.put("wahlbezirkID", "4567");
+            val wahlbezirkid_wahlnummer = "1234";
 
-            Mockito.when(auth.getPrincipal()).thenReturn("1234");
-            Mockito.when(auth.getDetails()).thenReturn(map);
+            Mockito.when(authDetailRetriever.canHandle(auth)).thenReturn(true);
+            Mockito.when(authDetailRetriever.getDetail("wahlbezirkID", auth)).thenReturn(Optional.empty());
+            Mockito.when(authDetailRetriever.getDetail("wahlbezirkid_wahlnummer", auth)).thenReturn(Optional.of(wahlbezirkid_wahlnummer));
 
             Assertions.assertThat(unitUnderTest.tokenUserBezirkIdMatches("1234", auth)).isTrue();
         }
 
         @Test
         void should_returnFalse_when_bezirkIDIsNull() {
-            val map = new HashMap<>();
-            map.put("wahlbezirkid_wahlnummer", "1234");
-            map.put("wahlbezirkID", "1234");
+            val wahlbezirkID = "1234";
 
-            Mockito.when(auth.getPrincipal()).thenReturn("1234");
-            Mockito.when(auth.getDetails()).thenReturn(map);
+            Mockito.when(authDetailRetriever.canHandle(auth)).thenReturn(true);
+            Mockito.when(authDetailRetriever.getDetail("wahlbezirkID", auth)).thenReturn(Optional.empty());
+            Mockito.when(authDetailRetriever.getDetail("wahlbezirkid_wahlnummer", auth)).thenReturn(Optional.empty());
 
             Assertions.assertThat(unitUnderTest.tokenUserBezirkIdMatches(null, auth)).isFalse();
             Assertions.assertThat(loggerExtension.getFormattedMessages().size()).isEqualTo(0);
@@ -80,15 +82,19 @@ class BezirkIDPermissionEvaluatorImplTest {
 
         @Test
         void should_returnFalse_when_bezirkIDDoesNotMatch() {
-            val map = new HashMap<>();
-            map.put("wahlbezirkid_wahlnummer", null);
-            map.put("wahlbezirkID", "1234");
-
-            Mockito.when(auth.getPrincipal()).thenReturn("1234");
-            Mockito.when(auth.getDetails()).thenReturn(map);
+            Mockito.when(authDetailRetriever.canHandle(auth)).thenReturn(true);
+            Mockito.when(authDetailRetriever.getDetail("wahlbezirkID", auth)).thenReturn(Optional.empty());
+            Mockito.when(authDetailRetriever.getDetail("wahlbezirkid_wahlnummer", auth)).thenReturn(Optional.of("1234"));
 
             Assertions.assertThat(unitUnderTest.tokenUserBezirkIdMatches("4567", auth)).isFalse();
             Assertions.assertThat(loggerExtension.getFormattedMessages().size()).isEqualTo(0);
+        }
+
+        @Test
+        void should_returnFalse_when_noHandlerForAuthenticationIsGiven() {
+            Mockito.when(authDetailRetriever.canHandle(auth)).thenReturn(false);
+
+            Assertions.assertThat(unitUnderTest.tokenUserBezirkIdMatches("1234", auth)).isFalse();
         }
     }
 }


### PR DESCRIPTION
# Beschreibung:

Die aktuelle Implementierung funktioniert nicht bei unser Authentifizierung. Daher wurde das Verfahren dass wir in den Services einsetzten um Informationen aus dem Claim zu bekommen übernommen. Die WahlbezirkID zur Prüfung ist wie die WahlbezirkArt auch im Claim enthalten.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [X] [Naming Conventions][naming-conventions-link] beachtet
- [x] Doku aktualisiert - nicht relevant
- [X] Swagger-API vollständig - nicht relevant
- [x] Unit-Tests gepflegt - bestehende Tests aktualisiert
- [X] Integrationstests gepflegt - nicht relevant
- [X] Beispiel-Requests gepflegt - nicht relevant

# Referenzen[^1]:

Verwandt mit Issue #879

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced authentication detail processing for improved reliability and safer handling of user claims.
  
- **Tests**
  - Updated test scenarios to better simulate authentication behavior and error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->