### PR TITLE
Response mit Code von WlsException ais OpenAPI-Spec entfernt

### DIFF
--- a/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/rest/wahllokalbenutzer/WahllokalBenutzerController.java
+++ b/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/rest/wahllokalbenutzer/WahllokalBenutzerController.java
@@ -37,10 +37,6 @@ public class WahllokalBenutzerController {
                     @ApiResponse(
                             responseCode = "400", description = "Benutzer können nicht generiert werden.",
                             content = { @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class)) }
-                    ),
-                    @ApiResponse(
-                            responseCode = "165", description = "Anfrageparameter sind fehlerhaft",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class))
                     )
             }
     )
@@ -60,10 +56,6 @@ public class WahllokalBenutzerController {
                     @ApiResponse(
                             responseCode = "400", description = "Benutzer können nicht exportiert werden.",
                             content = { @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class)) }
-                    ),
-                    @ApiResponse(
-                            responseCode = "165", description = "Anfrageparameter sind fehlerhaft",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class))
                     )
             }
     )
@@ -77,8 +69,7 @@ public class WahllokalBenutzerController {
     @ApiResponses(
             value = {
                     @ApiResponse(responseCode = "200", description = "Benutzer erfolgreich gelöscht."),
-                    @ApiResponse(responseCode = "400", description = "Benutzer können wegen Client-Kommunikationsfehler nicht gelöscht werden."),
-                    @ApiResponse(responseCode = "165", description = "Anfrageparameter sind fehlerhaft")
+                    @ApiResponse(responseCode = "400", description = "Benutzer können wegen Client-Kommunikationsfehler nicht gelöscht werden.")
             }
     )
     @ResponseStatus(HttpStatus.OK)


### PR DESCRIPTION
# Beschreibung:

Response bei WahllokalBenutzerController entfernt die keinen HttpStatus darstellen sondern einen Code in der WlsException

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] [Naming Conventions][naming-conventions-link] beachtet - keine Codeänderung
- [x] Doku aktualisiert - nicht relevant
- [x] Swagger-API vollständig
- [X] Unit-Tests gepflegt - keine Codeänderung
- [X] Integrationstests gepflegt - keine Codeänderung
- [x] Beispiel-Requests gepflegt - keine Änderung an API

# Referenzen[^1]:

Verwandt mit Issue #

Closes #858

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to present clearer, more consistent error messages for client response issues.
  - Removed specific error details related to faulty request parameters, streamlining the information displayed to API consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->