### PR TITLE
Fix Label für PRs mit Ergebnismeldungsservice

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,7 +19,7 @@
 "service-eai":
   - changed-files:
       - any-glob-to-any-file: [ 'wls-eai-service/**' ]
-"ergebnismeldung":
+"service-ergebnismeldung":
   - changed-files:
       - any-glob-to-any-file: [ 'wls-ergebnismeldung-service/**' ]
 "service-gui-admin":


### PR DESCRIPTION
# Beschreibung:

`ergebnismeldung` -> `service-ergebnismeldung`

Labels: https://github.com/it-at-m/Wahllokalsystem/labels  
[`service-ergebnismeldung`](https://github.com/it-at-m/Wahllokalsystem/issues?q=label%3A%22service-ergebnismeldung%22+is%3Aopen)

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

# Referenzen[^1]:

Verwandt mit Issue #895 

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
   - Updated internal labeling configuration to enhance categorization for related service files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->