### PR TITLE
771 einhaltung der regeln für beforeeach methoden

### DIFF
--- a/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/archunit/ArchUnitTest.java
+++ b/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/archunit/ArchUnitTest.java
@@ -32,6 +32,7 @@ public class ArchUnitTest {
 
     public static Stream<Arguments> allServiceClassesRulesToVerify() {
         return Stream.of(
-                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED));
+                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED),
+                Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
     }
 }

--- a/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/archunit/ArchUnitTest.java
+++ b/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/archunit/ArchUnitTest.java
@@ -25,12 +25,12 @@ public class ArchUnitTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("allServiceClassesRulesToVerify")
+    @MethodSource("allTestClassesRulesToVerify")
     void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 
-    public static Stream<Arguments> allServiceClassesRulesToVerify() {
+    public static Stream<Arguments> allTestClassesRulesToVerify() {
         return Stream.of(
                 Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED),
                 Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));

--- a/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/archunit/ArchUnitTest.java
+++ b/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/archunit/ArchUnitTest.java
@@ -26,7 +26,7 @@ public class ArchUnitTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("allServiceClassesRulesToVerify")
-    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+    void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 

--- a/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/UserInfoAuthoritiesServiceTest.java
+++ b/wls-admin-service/src/test/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/UserInfoAuthoritiesServiceTest.java
@@ -41,7 +41,7 @@ class UserInfoAuthoritiesServiceTest {
     UserInfoAuthoritiesService unitUnderTest;
 
     @BeforeEach
-    void setUp() {
+    void setup() {
         val restTemplateBuilder = new RestTemplateBuilder(new RestTemplateCustomizer[0]) {
             @Override
             public RestTemplate build() {

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/archunit/ArchUnitTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/archunit/ArchUnitTest.java
@@ -26,7 +26,7 @@ public class ArchUnitTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("allServiceClassesRulesToVerify")
-    void should_verifyArchUnitRuleForAlshould_verifyArchUnitRuleForAllTestClassesOfService_when_runninglClassesOfService_when_running(final ArgumentsAccessor arguments) {
+    void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/archunit/ArchUnitTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/archunit/ArchUnitTest.java
@@ -32,6 +32,7 @@ public class ArchUnitTest {
 
     public static Stream<Arguments> allServiceClassesRulesToVerify() {
         return Stream.of(
-                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED));
+                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED),
+                Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
     }
 }

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/archunit/ArchUnitTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/archunit/ArchUnitTest.java
@@ -26,7 +26,7 @@ public class ArchUnitTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("allServiceClassesRulesToVerify")
-    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+    void should_verifyArchUnitRuleForAlshould_verifyArchUnitRuleForAllTestClassesOfService_when_runninglClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/archunit/ArchUnitTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/archunit/ArchUnitTest.java
@@ -25,12 +25,12 @@ public class ArchUnitTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("allServiceClassesRulesToVerify")
+    @MethodSource("allTestClassesRulesToVerify")
     void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 
-    public static Stream<Arguments> allServiceClassesRulesToVerify() {
+    public static Stream<Arguments> allTestClassesRulesToVerify() {
         return Stream.of(
                 Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED),
                 Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/UserInfoAuthoritiesServiceTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/UserInfoAuthoritiesServiceTest.java
@@ -3,7 +3,6 @@ package de.muenchen.oss.wahllokalsystem.authservice.configuration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import lombok.val;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +41,7 @@ class UserInfoAuthoritiesServiceTest {
     UserInfoAuthoritiesService unitUnderTest;
 
     @BeforeEach
-    void setUp() {
+    void setup() {
         val restTemplateBuilder = new RestTemplateBuilder(new RestTemplateCustomizer[0]) {
             @Override
             public RestTemplate build() {

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/rest/session/SessionControllerIntegrationTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/rest/session/SessionControllerIntegrationTest.java
@@ -5,12 +5,13 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.muenchen.oss.wahllokalsystem.authservice.MicroServiceApplication;
 import de.muenchen.oss.wahllokalsystem.authservice.configuration.Profiles;
 import de.muenchen.oss.wahllokalsystem.authservice.rest.OAuthServerSessions;
+import de.muenchen.oss.wahllokalsystem.authservice.utils.Authorities;
 import de.muenchen.oss.wahllokalsystem.wls.common.testing.SecurityUtils;
-
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -21,7 +22,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,7 +30,6 @@ import org.springframework.session.Session;
 import org.springframework.session.SessionRepository;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import de.muenchen.oss.wahllokalsystem.authservice.utils.Authorities;
 
 @SpringBootTest(
         classes = { MicroServiceApplication.class },
@@ -57,7 +56,7 @@ class SessionControllerIntegrationTest {
     SessionRepository sessionRepository;
 
     @BeforeEach
-    void setUp() {
+    void setup() {
         purgeSessions();
         SecurityUtils.runWith(Authorities.ROLE_ADMIN);
     }

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/rest/session/SessionCreationTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/rest/session/SessionCreationTest.java
@@ -1,6 +1,7 @@
 package de.muenchen.oss.wahllokalsystem.authservice.rest.session;
 
 import static de.muenchen.oss.wahllokalsystem.authservice.TestConstants.SPRING_TEST_PROFILE;
+
 import de.muenchen.oss.wahllokalsystem.authservice.MicroServiceApplication;
 import de.muenchen.oss.wahllokalsystem.authservice.configuration.Profiles;
 import java.net.URI;
@@ -60,7 +61,7 @@ class SessionCreationTest {
     SessionRegistry sessionRegistry;
 
     @BeforeEach
-    public void setUp() throws SQLException {
+    public void setup() throws SQLException {
         conn = DriverManager.getConnection(dataSourceUrl, dataSourceUsername, dataSourcePassword);
         purgeSessions();
     }

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/service/CryptoServiceTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/service/CryptoServiceTest.java
@@ -38,7 +38,7 @@ class CryptoServiceTest {
     CryptoService unitUnderTest;
 
     @BeforeEach
-    void setUp() {
+    void setup() {
         unitUnderTest.setEncryptedPrefix(ENCRYPTION_PREFIX);
     }
 

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/archunit/ArchUnitTest.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/archunit/ArchUnitTest.java
@@ -32,6 +32,7 @@ public class ArchUnitTest {
 
     public static Stream<Arguments> allServiceClassesRulesToVerify() {
         return Stream.of(
-                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED));
+                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED),
+                Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
     }
 }

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/archunit/ArchUnitTest.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/archunit/ArchUnitTest.java
@@ -25,12 +25,12 @@ public class ArchUnitTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("allServiceClassesRulesToVerify")
+    @MethodSource("allTestClassesRulesToVerify")
     void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 
-    public static Stream<Arguments> allServiceClassesRulesToVerify() {
+    public static Stream<Arguments> allTestClassesRulesToVerify() {
         return Stream.of(
                 Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED),
                 Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/archunit/ArchUnitTest.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/archunit/ArchUnitTest.java
@@ -26,7 +26,7 @@ public class ArchUnitTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("allServiceClassesRulesToVerify")
-    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+    void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/configuration/UserInfoAuthoritiesServiceTest.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/configuration/UserInfoAuthoritiesServiceTest.java
@@ -41,7 +41,7 @@ class UserInfoAuthoritiesServiceTest {
     UserInfoAuthoritiesService unitUnderTest;
 
     @BeforeEach
-    void setUp() {
+    void setup() {
         val restTemplateBuilder = new RestTemplateBuilder(new RestTemplateCustomizer[0]) {
             @Override
             public RestTemplate build() {

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/rest/ungueltigewahlscheine/UngueltigeWahlscheineControllerTest.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/rest/ungueltigewahlscheine/UngueltigeWahlscheineControllerTest.java
@@ -51,7 +51,7 @@ class UngueltigeWahlscheineControllerTest {
     class GetUngueltigeWahlscheine {
 
         @BeforeEach
-        void setUp() {
+        void setup() {
             unitUnderTest.ungueltigeWahlscheineFileNameSuffix = ".csv";
         }
 

--- a/wls-briefwahl-service/pom.xml
+++ b/wls-briefwahl-service/pom.xml
@@ -37,7 +37,8 @@
         <org.projectlombok.mapstructbinding.version>0.2.0</org.projectlombok.mapstructbinding.version>
         <org.springdoc.version>2.6.0</org.springdoc.version>
         <org.mapstruct.version>1.6.3</org.mapstruct.version>
-        <wls.common.version>1.2.0</wls.common.version>
+        <wls.common.version>1.3.0</wls.common.version>
+        <com.tngtech.archunit.version>1.4.0</com.tngtech.archunit.version>
     </properties>
 
     <dependencyManagement>
@@ -209,6 +210,12 @@
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>testing</artifactId>
             <version>${wls.common.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <version>${com.tngtech.archunit.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/wls-briefwahl-service/src/test/java/de/muenchen/oss/wahllokalsystem/briefwahlservice/archunit/ArchUnitTest.java
+++ b/wls-briefwahl-service/src/test/java/de/muenchen/oss/wahllokalsystem/briefwahlservice/archunit/ArchUnitTest.java
@@ -26,7 +26,7 @@ public class ArchUnitTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("allServiceClassesRulesToVerify")
-    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+    void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 

--- a/wls-briefwahl-service/src/test/java/de/muenchen/oss/wahllokalsystem/briefwahlservice/archunit/ArchUnitTest.java
+++ b/wls-briefwahl-service/src/test/java/de/muenchen/oss/wahllokalsystem/briefwahlservice/archunit/ArchUnitTest.java
@@ -1,0 +1,36 @@
+package de.muenchen.oss.wahllokalsystem.briefwahlservice.archunit;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import de.muenchen.oss.wahllokalsystem.briefwahlservice.MicroServiceApplication;
+import de.muenchen.oss.wahllokalsystem.wls.common.testing.archunit.rule.MethodRules;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class ArchUnitTest {
+
+    private static JavaClasses allTestClasses;
+
+    @BeforeAll
+    static void init() {
+        allTestClasses = new ClassFileImporter()
+                .withImportOption(new ImportOption.OnlyIncludeTests())
+                .importPackages(MicroServiceApplication.class.getPackage().getName());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("allServiceClassesRulesToVerify")
+    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+        arguments.get(1, ArchRule.class).check(allTestClasses);
+    }
+
+    public static Stream<Arguments> allServiceClassesRulesToVerify() {
+        return Stream.of(Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
+    }
+}

--- a/wls-briefwahl-service/src/test/java/de/muenchen/oss/wahllokalsystem/briefwahlservice/archunit/ArchUnitTest.java
+++ b/wls-briefwahl-service/src/test/java/de/muenchen/oss/wahllokalsystem/briefwahlservice/archunit/ArchUnitTest.java
@@ -25,12 +25,12 @@ public class ArchUnitTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("allServiceClassesRulesToVerify")
+    @MethodSource("allTestClassesRulesToVerify")
     void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 
-    public static Stream<Arguments> allServiceClassesRulesToVerify() {
+    public static Stream<Arguments> allTestClassesRulesToVerify() {
         return Stream.of(Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
     }
 }

--- a/wls-briefwahl-service/src/test/java/de/muenchen/oss/wahllokalsystem/briefwahlservice/configuration/UserInfoAuthoritiesServiceTest.java
+++ b/wls-briefwahl-service/src/test/java/de/muenchen/oss/wahllokalsystem/briefwahlservice/configuration/UserInfoAuthoritiesServiceTest.java
@@ -41,7 +41,7 @@ class UserInfoAuthoritiesServiceTest {
     UserInfoAuthoritiesService unitUnderTest;
 
     @BeforeEach
-    void setUp() {
+    void setup() {
         val restTemplateBuilder = new RestTemplateBuilder(new RestTemplateCustomizer[0]) {
             @Override
             public RestTemplate build() {

--- a/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/archunit/ArchUnitTest.java
+++ b/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/archunit/ArchUnitTest.java
@@ -26,7 +26,7 @@ public class ArchUnitTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("allTestClassesRulesToVerify")
-    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+    void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 

--- a/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/archunit/ArchUnitTest.java
+++ b/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/archunit/ArchUnitTest.java
@@ -32,6 +32,7 @@ public class ArchUnitTest {
 
     public static Stream<Arguments> allTestClassesRulesToVerify() {
         return Stream.of(
-                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED));
+                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED),
+                Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
     }
 }

--- a/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/configuration/UserInfoAuthoritiesServiceTest.java
+++ b/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/configuration/UserInfoAuthoritiesServiceTest.java
@@ -41,7 +41,7 @@ class UserInfoAuthoritiesServiceTest {
     UserInfoAuthoritiesService unitUnderTest;
 
     @BeforeEach
-    void setUp() {
+    void setup() {
         val restTemplateBuilder = new RestTemplateBuilder(new RestTemplateCustomizer[0]) {
             @Override
             public RestTemplate build() {

--- a/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/service/BroadcastServiceSecurityTest.java
+++ b/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/service/BroadcastServiceSecurityTest.java
@@ -36,7 +36,7 @@ public class BroadcastServiceSecurityTest {
     BroadcastService broadcastService;
 
     @BeforeEach
-    void setUp() {
+    void setup() {
         Assertions.assertThat(broadcastService).isNotNull();
         SecurityContextHolder.clearContext();
     }

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/archunit/ArchUnitTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/archunit/ArchUnitTest.java
@@ -1,0 +1,36 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.exception.archunit;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import de.muenchen.oss.wahllokalsystem.wls.common.exception.FachlicheWlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.testing.archunit.rule.MethodRules;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class ArchUnitTest {
+
+    private static JavaClasses allTestClasses;
+
+    @BeforeAll
+    static void init() {
+        allTestClasses = new ClassFileImporter()
+                .withImportOption(new ImportOption.OnlyIncludeTests())
+                .importPackages(FachlicheWlsException.class.getPackage().getName());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("allServiceClassesRulesToVerify")
+    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+        arguments.get(1, ArchRule.class).check(allTestClasses);
+    }
+
+    public static Stream<Arguments> allServiceClassesRulesToVerify() {
+        return Stream.of(Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
+    }
+}

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/archunit/ArchUnitTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/archunit/ArchUnitTest.java
@@ -26,7 +26,7 @@ public class ArchUnitTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("allServiceClassesRulesToVerify")
-    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+    void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/archunit/ArchUnitTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/archunit/ArchUnitTest.java
@@ -25,12 +25,12 @@ public class ArchUnitTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("allServiceClassesRulesToVerify")
+    @MethodSource("allTestClassesRulesToVerify")
     void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 
-    public static Stream<Arguments> allServiceClassesRulesToVerify() {
+    public static Stream<Arguments> allTestClassesRulesToVerify() {
         return Stream.of(Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
     }
 }

--- a/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/archunit/ArchUnitTest.java
+++ b/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/archunit/ArchUnitTest.java
@@ -26,7 +26,7 @@ public class ArchUnitTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("allServiceClassesRulesToVerify")
-    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+    void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 

--- a/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/archunit/ArchUnitTest.java
+++ b/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/archunit/ArchUnitTest.java
@@ -1,0 +1,36 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.security.archunit;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import de.muenchen.oss.wahllokalsystem.wls.common.security.OAuth2TokenInterceptor;
+import de.muenchen.oss.wahllokalsystem.wls.common.testing.archunit.rule.MethodRules;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class ArchUnitTest {
+
+    private static JavaClasses allTestClasses;
+
+    @BeforeAll
+    static void init() {
+        allTestClasses = new ClassFileImporter()
+                .withImportOption(new ImportOption.OnlyIncludeTests())
+                .importPackages(OAuth2TokenInterceptor.class.getPackage().getName());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("allServiceClassesRulesToVerify")
+    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+        arguments.get(1, ArchRule.class).check(allTestClasses);
+    }
+
+    public static Stream<Arguments> allServiceClassesRulesToVerify() {
+        return Stream.of(Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
+    }
+}

--- a/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/archunit/ArchUnitTest.java
+++ b/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/archunit/ArchUnitTest.java
@@ -25,12 +25,12 @@ public class ArchUnitTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("allServiceClassesRulesToVerify")
+    @MethodSource("allTestClassesRulesToVerify")
     void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 
-    public static Stream<Arguments> allServiceClassesRulesToVerify() {
+    public static Stream<Arguments> allTestClassesRulesToVerify() {
         return Stream.of(Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
     }
 }

--- a/wls-eai-service/pom.xml
+++ b/wls-eai-service/pom.xml
@@ -36,6 +36,8 @@
         <org.projectlombok.mapstructbinding.version>0.2.0</org.projectlombok.mapstructbinding.version>
         <org.springdoc.version>2.6.0</org.springdoc.version>
         <org.mapstruct.version>1.6.3</org.mapstruct.version>
+        <wls.common.version>1.3.0</wls.common.version>
+        <com.tngtech.archunit.version>1.4.0</com.tngtech.archunit.version>
     </properties>
 
     <dependencyManagement>
@@ -108,7 +110,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>exception</artifactId>
-            <version>1.1.0</version>
+            <version>${wls.common.version}</version>
         </dependency>
 
         <!-- json etc. -->
@@ -206,7 +208,13 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>testing</artifactId>
-            <version>1.1.0</version>
+            <version>${wls.common.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <version>${com.tngtech.archunit.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/wls-eai-service/src/test/java/de/muenchen/oss/wahllokalsystem/eaiservice/archunit/ArchUnitTest.java
+++ b/wls-eai-service/src/test/java/de/muenchen/oss/wahllokalsystem/eaiservice/archunit/ArchUnitTest.java
@@ -26,7 +26,7 @@ public class ArchUnitTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("allServiceClassesRulesToVerify")
-    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+    void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 

--- a/wls-eai-service/src/test/java/de/muenchen/oss/wahllokalsystem/eaiservice/archunit/ArchUnitTest.java
+++ b/wls-eai-service/src/test/java/de/muenchen/oss/wahllokalsystem/eaiservice/archunit/ArchUnitTest.java
@@ -1,0 +1,36 @@
+package de.muenchen.oss.wahllokalsystem.eaiservice.archunit;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import de.muenchen.oss.wahllokalsystem.eaiservice.MicroServiceApplication;
+import de.muenchen.oss.wahllokalsystem.wls.common.testing.archunit.rule.MethodRules;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class ArchUnitTest {
+
+    private static JavaClasses allTestClasses;
+
+    @BeforeAll
+    static void init() {
+        allTestClasses = new ClassFileImporter()
+                .withImportOption(new ImportOption.OnlyIncludeTests())
+                .importPackages(MicroServiceApplication.class.getPackage().getName());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("allServiceClassesRulesToVerify")
+    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+        arguments.get(1, ArchRule.class).check(allTestClasses);
+    }
+
+    public static Stream<Arguments> allServiceClassesRulesToVerify() {
+        return Stream.of(Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
+    }
+}

--- a/wls-eai-service/src/test/java/de/muenchen/oss/wahllokalsystem/eaiservice/archunit/ArchUnitTest.java
+++ b/wls-eai-service/src/test/java/de/muenchen/oss/wahllokalsystem/eaiservice/archunit/ArchUnitTest.java
@@ -25,12 +25,12 @@ public class ArchUnitTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("allServiceClassesRulesToVerify")
+    @MethodSource("allTestClassesRulesToVerify")
     void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 
-    public static Stream<Arguments> allServiceClassesRulesToVerify() {
+    public static Stream<Arguments> allTestClassesRulesToVerify() {
         return Stream.of(Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
     }
 }

--- a/wls-eai-service/src/test/java/de/muenchen/oss/wahllokalsystem/eaiservice/configuration/UserInfoAuthoritiesServiceTest.java
+++ b/wls-eai-service/src/test/java/de/muenchen/oss/wahllokalsystem/eaiservice/configuration/UserInfoAuthoritiesServiceTest.java
@@ -41,7 +41,7 @@ class UserInfoAuthoritiesServiceTest {
     UserInfoAuthoritiesService unitUnderTest;
 
     @BeforeEach
-    void setUp() {
+    void setup() {
         val restTemplateBuilder = new RestTemplateBuilder(new RestTemplateCustomizer[0]) {
             @Override
             public RestTemplate build() {

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/archunit/ArchUnitTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/archunit/ArchUnitTest.java
@@ -26,7 +26,7 @@ public class ArchUnitTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("allTestClassesRulesToVerify")
-    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+    void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/archunit/ArchUnitTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/archunit/ArchUnitTest.java
@@ -32,6 +32,7 @@ public class ArchUnitTest {
 
     public static Stream<Arguments> allTestClassesRulesToVerify() {
         return Stream.of(
-                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED));
+                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED),
+                Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
     }
 }

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/configuration/UserInfoAuthoritiesServiceTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/configuration/UserInfoAuthoritiesServiceTest.java
@@ -41,7 +41,7 @@ class UserInfoAuthoritiesServiceTest {
     UserInfoAuthoritiesService unitUnderTest;
 
     @BeforeEach
-    void setUp() {
+    void setup() {
         val restTemplateBuilder = new RestTemplateBuilder(new RestTemplateCustomizer[0]) {
             @Override
             public RestTemplate build() {

--- a/wls-infomanagement-service/src/test/java/de/muenchen/oss/wahllokalsystem/infomanagementservice/archunit/ArchUnitTest.java
+++ b/wls-infomanagement-service/src/test/java/de/muenchen/oss/wahllokalsystem/infomanagementservice/archunit/ArchUnitTest.java
@@ -26,7 +26,7 @@ public class ArchUnitTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("allTestClassesRulesToVerify")
-    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+    void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 

--- a/wls-infomanagement-service/src/test/java/de/muenchen/oss/wahllokalsystem/infomanagementservice/archunit/ArchUnitTest.java
+++ b/wls-infomanagement-service/src/test/java/de/muenchen/oss/wahllokalsystem/infomanagementservice/archunit/ArchUnitTest.java
@@ -32,6 +32,7 @@ public class ArchUnitTest {
 
     public static Stream<Arguments> allTestClassesRulesToVerify() {
         return Stream.of(
-                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED));
+                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED),
+                Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
     }
 }

--- a/wls-infomanagement-service/src/test/java/de/muenchen/oss/wahllokalsystem/infomanagementservice/configuration/UserInfoAuthoritiesServiceTest.java
+++ b/wls-infomanagement-service/src/test/java/de/muenchen/oss/wahllokalsystem/infomanagementservice/configuration/UserInfoAuthoritiesServiceTest.java
@@ -41,7 +41,7 @@ class UserInfoAuthoritiesServiceTest {
     UserInfoAuthoritiesService unitUnderTest;
 
     @BeforeEach
-    void setUp() {
+    void setup() {
         val restTemplateBuilder = new RestTemplateBuilder(new RestTemplateCustomizer[0]) {
             @Override
             public RestTemplate build() {

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/archunit/ArchUnitTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/archunit/ArchUnitTest.java
@@ -26,7 +26,7 @@ public class ArchUnitTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("allTestClassesRulesToVerify")
-    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+    void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/archunit/ArchUnitTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/archunit/ArchUnitTest.java
@@ -32,6 +32,7 @@ public class ArchUnitTest {
 
     public static Stream<Arguments> allTestClassesRulesToVerify() {
         return Stream.of(
-                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED));
+                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED),
+                Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
     }
 }

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/UserInfoAuthoritiesServiceTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/UserInfoAuthoritiesServiceTest.java
@@ -41,7 +41,7 @@ class UserInfoAuthoritiesServiceTest {
     UserInfoAuthoritiesService unitUnderTest;
 
     @BeforeEach
-    void setUp() {
+    void setup() {
         val restTemplateBuilder = new RestTemplateBuilder(new RestTemplateCustomizer[0]) {
             @Override
             public RestTemplate build() {

--- a/wls-vorfaelleundvorkommnisse-service/src/test/java/de/muenchen/oss/wahllokalsystem/vorfaelleundvorkommnisseservice/archunit/ArchUnitTest.java
+++ b/wls-vorfaelleundvorkommnisse-service/src/test/java/de/muenchen/oss/wahllokalsystem/vorfaelleundvorkommnisseservice/archunit/ArchUnitTest.java
@@ -26,7 +26,7 @@ public class ArchUnitTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("allTestClassesRulesToVerify")
-    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+    void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 

--- a/wls-vorfaelleundvorkommnisse-service/src/test/java/de/muenchen/oss/wahllokalsystem/vorfaelleundvorkommnisseservice/archunit/ArchUnitTest.java
+++ b/wls-vorfaelleundvorkommnisse-service/src/test/java/de/muenchen/oss/wahllokalsystem/vorfaelleundvorkommnisseservice/archunit/ArchUnitTest.java
@@ -32,6 +32,7 @@ public class ArchUnitTest {
 
     public static Stream<Arguments> allTestClassesRulesToVerify() {
         return Stream.of(
-                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED));
+                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED),
+                Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
     }
 }

--- a/wls-vorfaelleundvorkommnisse-service/src/test/java/de/muenchen/oss/wahllokalsystem/vorfaelleundvorkommnisseservice/configuration/UserInfoAuthoritiesServiceTest.java
+++ b/wls-vorfaelleundvorkommnisse-service/src/test/java/de/muenchen/oss/wahllokalsystem/vorfaelleundvorkommnisseservice/configuration/UserInfoAuthoritiesServiceTest.java
@@ -41,7 +41,7 @@ class UserInfoAuthoritiesServiceTest {
     UserInfoAuthoritiesService unitUnderTest;
 
     @BeforeEach
-    void setUp() {
+    void setup() {
         val restTemplateBuilder = new RestTemplateBuilder(new RestTemplateCustomizer[0]) {
             @Override
             public RestTemplate build() {

--- a/wls-wahlvorbereitung-service/pom.xml
+++ b/wls-wahlvorbereitung-service/pom.xml
@@ -37,7 +37,8 @@
         <org.projectlombok.mapstructbinding.version>0.2.0</org.projectlombok.mapstructbinding.version>
         <org.springdoc.version>2.6.0</org.springdoc.version>
         <org.mapstruct.version>1.6.3</org.mapstruct.version>
-        <wls.common.version>1.2.0</wls.common.version>
+        <wls.common.version>1.3.0</wls.common.version>
+        <com.tngtech.archunit.version>1.4.0</com.tngtech.archunit.version>
     </properties>
 
     <dependencyManagement>
@@ -209,6 +210,12 @@
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>testing</artifactId>
             <version>${wls.common.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <version>${com.tngtech.archunit.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/archunit/ArchUnitTest.java
+++ b/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/archunit/ArchUnitTest.java
@@ -1,0 +1,36 @@
+package de.muenchen.oss.wahllokalsystem.wahlvorbereitungservice.archunit;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import de.muenchen.oss.wahllokalsystem.wahlvorbereitungservice.MicroServiceApplication;
+import de.muenchen.oss.wahllokalsystem.wls.common.testing.archunit.rule.MethodRules;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class ArchUnitTest {
+
+    private static JavaClasses allTestClasses;
+
+    @BeforeAll
+    static void init() {
+        allTestClasses = new ClassFileImporter()
+                .withImportOption(new ImportOption.OnlyIncludeTests())
+                .importPackages(MicroServiceApplication.class.getPackage().getName());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("allServiceClassesRulesToVerify")
+    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+        arguments.get(1, ArchRule.class).check(allTestClasses);
+    }
+
+    public static Stream<Arguments> allServiceClassesRulesToVerify() {
+        return Stream.of(Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
+    }
+}

--- a/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/archunit/ArchUnitTest.java
+++ b/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/archunit/ArchUnitTest.java
@@ -26,7 +26,7 @@ public class ArchUnitTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("allServiceClassesRulesToVerify")
-    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+    void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 

--- a/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/archunit/ArchUnitTest.java
+++ b/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/archunit/ArchUnitTest.java
@@ -25,12 +25,12 @@ public class ArchUnitTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("allServiceClassesRulesToVerify")
+    @MethodSource("allTestClassesRulesToVerify")
     void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 
-    public static Stream<Arguments> allServiceClassesRulesToVerify() {
+    public static Stream<Arguments> allTestClassesRulesToVerify() {
         return Stream.of(Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
     }
 }

--- a/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/configuration/UserInfoAuthoritiesServiceTest.java
+++ b/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/configuration/UserInfoAuthoritiesServiceTest.java
@@ -41,7 +41,7 @@ class UserInfoAuthoritiesServiceTest {
     UserInfoAuthoritiesService unitUnderTest;
 
     @BeforeEach
-    void setUp() {
+    void setup() {
         val restTemplateBuilder = new RestTemplateBuilder(new RestTemplateCustomizer[0]) {
             @Override
             public RestTemplate build() {

--- a/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/service/waehlerverzeichnis/WaehlerverzeichnisServiceSecurityTest.java
+++ b/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/service/waehlerverzeichnis/WaehlerverzeichnisServiceSecurityTest.java
@@ -39,7 +39,7 @@ public class WaehlerverzeichnisServiceSecurityTest {
     BezirkIDPermissionEvaluator bezirkIDPermissionEvaluator;
 
     @BeforeEach
-    void setUp() {
+    void setup() {
         SecurityContextHolder.clearContext();
     }
 

--- a/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/archunit/ArchUnitTest.java
+++ b/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/archunit/ArchUnitTest.java
@@ -26,7 +26,7 @@ public class ArchUnitTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("allTestClassesRulesToVerify")
-    void should_verifyArchUnitRuleForAllClassesOfService_when_running(final ArgumentsAccessor arguments) {
+    void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allTestClasses);
     }
 

--- a/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/archunit/ArchUnitTest.java
+++ b/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/archunit/ArchUnitTest.java
@@ -32,6 +32,7 @@ public class ArchUnitTest {
 
     public static Stream<Arguments> allTestClassesRulesToVerify() {
         return Stream.of(
-                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED));
+                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED),
+                Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
     }
 }

--- a/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/configuration/UserInfoAuthoritiesServiceTest.java
+++ b/wls-wahlvorstand-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/configuration/UserInfoAuthoritiesServiceTest.java
@@ -41,7 +41,7 @@ class UserInfoAuthoritiesServiceTest {
     UserInfoAuthoritiesService unitUnderTest;
 
     @BeforeEach
-    void setUp() {
+    void setup() {
         val restTemplateBuilder = new RestTemplateBuilder(new RestTemplateCustomizer[0]) {
             @Override
             public RestTemplate build() {


### PR DESCRIPTION
# Beschreibung:

- archunit testname angepasst, da er sich nur auf testklassen bezieht
- archunit rule für beforeEach annotationen hinzugefügt
  - entsprechende anpassungen von methodennamen in den services vorgenommen
- wls-common gehoben in
  - briefwahl-service
  - eai-service
  - wahlvorbereitung-service

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [ ] ~Doku aktualisiert~ folgt in issue #850 

# Referenzen[^1]:

Closes #771

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Standardized naming conventions across test suites for improved consistency.
  - Expanded automated architectural tests to enforce naming standards and enhance coverage.

- **Chores**
  - Upgraded dependency versions to improve compatibility.
  - Added a new testing library to strengthen the project's test framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->