### PR TITLE
622-ergaenzen-der-apiresponses-annotation-admin-service

### DIFF
--- a/wls-admin-service/pom.xml
+++ b/wls-admin-service/pom.xml
@@ -36,7 +36,7 @@
         <org.projectlombok.mapstructbinding.version>0.2.0</org.projectlombok.mapstructbinding.version>
         <org.mapstruct.version>1.6.3</org.mapstruct.version>
         <org.springdoc.version>2.6.0</org.springdoc.version>
-        <wls.common.version>1.3.0</wls.common.version>
+        <wls.common.version>1.4.0</wls.common.version>
         <com.tngtech.archunit.version>1.4.0</com.tngtech.archunit.version>
     </properties>
 
@@ -169,10 +169,14 @@
             <artifactId>security</artifactId>
             <version>${wls.common.version}</version>
         </dependency>
-
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>exception</artifactId>
+            <version>${wls.common.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
+            <artifactId>swagger</artifactId>
             <version>${wls.common.version}</version>
         </dependency>
 

--- a/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/MicroServiceApplication.java
+++ b/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/MicroServiceApplication.java
@@ -28,7 +28,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
                 "org.springframework.data.jpa.convert.threeten",
                 "de.muenchen.oss.wahllokalsystem.adminservice",
                 "de.muenchen.oss.wahllokalsystem.wls.common.exception",
-                "de.muenchen.oss.wahllokalsystem.wls.common.security"
+                "de.muenchen.oss.wahllokalsystem.wls.common.security",
+                "de.muenchen.oss.wahllokalsystem.wls.common.swagger"
         }
 )
 public class MicroServiceApplication {

--- a/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/rest/konfigurierterwahltag/KonfigurierteWahltageController.java
+++ b/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/rest/konfigurierterwahltag/KonfigurierteWahltageController.java
@@ -1,10 +1,7 @@
 package de.muenchen.oss.wahllokalsystem.adminservice.rest.konfigurierterwahltag;
 
 import de.muenchen.oss.wahllokalsystem.adminservice.service.konfigurierterwahltag.KonfigurierteWahltageService;
-import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExceptionDTO;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -36,12 +33,7 @@ public class KonfigurierteWahltageController {
                             responseCode = "200", description = "Die konfigurierten Wahltage wurden erfolgreich geliefert."
                     ),
                     @ApiResponse(
-                            responseCode = "400", description = "Validierung der Anfrage war nicht erfolgreich",
-                            content = { @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class)) }
-                    ),
-                    @ApiResponse(
-                            responseCode = "500", description = "Problem beim Verarbeiten der Anfrage.",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class))
+                            responseCode = "204", description = "Keine konfigurierten Wahltage vorhanden"
                     )
             }
     )
@@ -61,14 +53,7 @@ public class KonfigurierteWahltageController {
                     @ApiResponse(
                             responseCode = "200", description = "Die konfigurierten Wahltage wurden erfolgreich geliefert."
                     ),
-                    @ApiResponse(
-                            responseCode = "400", description = "Validierung der Anfrage war nicht erfolgreich",
-                            content = { @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class)) }
-                    ),
-                    @ApiResponse(
-                            responseCode = "500", description = "Problem beim Verarbeiten der Anfrage.",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class))
-                    )
+
             }
     )
     @PostMapping("konfigurierterWahltag")

--- a/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/rest/wahlen/WahlenController.java
+++ b/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/rest/wahlen/WahlenController.java
@@ -58,7 +58,7 @@ public class WahlenController {
     )
     @PostMapping("/wahlen/{wahltagID}")
     public ResponseEntity<?> updateWahlen(@RequestBody final List<WahlDTO> wahlen,
-                                          @PathVariable("wahltagID") final String wahltagID) {
+            @PathVariable("wahltagID") final String wahltagID) {
         wahlenService.updateWahlen(wahlenDTOMapper.toModelList(wahlen), wahltagID);
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/rest/wahlen/WahlenController.java
+++ b/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/rest/wahlen/WahlenController.java
@@ -1,10 +1,8 @@
 package de.muenchen.oss.wahllokalsystem.adminservice.rest.wahlen;
 
 import de.muenchen.oss.wahllokalsystem.adminservice.service.wahlen.WahlenService;
-import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExceptionDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -37,14 +35,6 @@ public class WahlenController {
                     @ApiResponse(
                             responseCode = "204", description = "Es existieren keine Wahlen zu den entsprechenden Kriterien.",
                             content = { @Content() }
-                    ),
-                    @ApiResponse(
-                            responseCode = "400", description = "Validierung der Anfrage war nicht erfolgreich.",
-                            content = { @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class)) }
-                    ),
-                    @ApiResponse(
-                            responseCode = "500", description = "Probleme bei der Verarbeitung der Anfrage.",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class))
                     )
             }
     )
@@ -63,20 +53,12 @@ public class WahlenController {
             responses = {
                     @ApiResponse(
                             responseCode = "200", description = "Die Wahlen wurden erfolgreich gespeichert."
-                    ),
-                    @ApiResponse(
-                            responseCode = "400", description = "Validierung der Anfrage war nicht erfolgreich.",
-                            content = { @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class)) }
-                    ),
-                    @ApiResponse(
-                            responseCode = "500", description = "Probleme bei der Verarbeitung der Anfrage.",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class))
                     )
             }
     )
     @PostMapping("/wahlen/{wahltagID}")
     public ResponseEntity<?> updateWahlen(@RequestBody final List<WahlDTO> wahlen,
-            @PathVariable("wahltagID") final String wahltagID) {
+                                          @PathVariable("wahltagID") final String wahltagID) {
         wahlenService.updateWahlen(wahlenDTOMapper.toModelList(wahlen), wahltagID);
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/rest/wahllokalbenutzer/WahllokalBenutzerController.java
+++ b/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/rest/wahllokalbenutzer/WahllokalBenutzerController.java
@@ -1,7 +1,6 @@
 package de.muenchen.oss.wahllokalsystem.adminservice.rest.wahllokalbenutzer;
 
 import de.muenchen.oss.wahllokalsystem.adminservice.service.wahllokalbenutzer.WahllokalBenutzerService;
-import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExceptionDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -33,10 +32,6 @@ public class WahllokalBenutzerController {
                     @ApiResponse(
                             responseCode = "200", description = "Benutzer erfolgreich generiert.",
                             content = @Content(mediaType = "application/json", schema = @Schema(implementation = CsvFileDTO.class))
-                    ),
-                    @ApiResponse(
-                            responseCode = "400", description = "Benutzer können nicht generiert werden.",
-                            content = { @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class)) }
                     )
             }
     )
@@ -52,10 +47,6 @@ public class WahllokalBenutzerController {
                     @ApiResponse(
                             responseCode = "200", description = "Benutzer erfolgreich exportiert.",
                             content = { @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = CsvFileDTO.class))) }
-                    ),
-                    @ApiResponse(
-                            responseCode = "400", description = "Benutzer können nicht exportiert werden.",
-                            content = { @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class)) }
                     )
             }
     )
@@ -68,8 +59,7 @@ public class WahllokalBenutzerController {
     @Operation(description = "Löscht alle Benutzerdaten aller Wahllokale fuer eine WahlId mithilfe einer wahltagID.")
     @ApiResponses(
             value = {
-                    @ApiResponse(responseCode = "200", description = "Benutzer erfolgreich gelöscht."),
-                    @ApiResponse(responseCode = "400", description = "Benutzer können wegen Client-Kommunikationsfehler nicht gelöscht werden.")
+                    @ApiResponse(responseCode = "200", description = "Benutzer erfolgreich gelöscht.")
             }
     )
     @ResponseStatus(HttpStatus.OK)

--- a/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/rest/wahltage/WahltageController.java
+++ b/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/rest/wahltage/WahltageController.java
@@ -1,10 +1,8 @@
 package de.muenchen.oss.wahllokalsystem.adminservice.rest.wahltage;
 
 import de.muenchen.oss.wahllokalsystem.adminservice.service.wahltage.WahltageService;
-import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExceptionDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -33,10 +31,6 @@ public class WahltageController {
                     @ApiResponse(
                             responseCode = "204", description = "Es existieren keine Wahltage.",
                             content = { @Content() }
-                    ),
-                    @ApiResponse(
-                            responseCode = "500", description = "Probleme bei der Verarbeitung der Anfrage",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class))
                     )
             }
     )

--- a/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/rest/wahltermindaten/WahltermindatenController.java
+++ b/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/rest/wahltermindaten/WahltermindatenController.java
@@ -1,10 +1,7 @@
 package de.muenchen.oss.wahllokalsystem.adminservice.rest.wahltermindaten;
 
 import de.muenchen.oss.wahllokalsystem.adminservice.service.wahltermindaten.WahltermindatenService;
-import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExceptionDTO;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,14 +25,6 @@ public class WahltermindatenController {
             responses = {
                     @ApiResponse(
                             responseCode = "200", description = "Die Wahltermindaten wurden erfolgreich importiert."
-                    ),
-                    @ApiResponse(
-                            responseCode = "400", description = "Validierung der Anfrage war nicht erfolgreich",
-                            content = { @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class)) }
-                    ),
-                    @ApiResponse(
-                            responseCode = "500", description = "Fehler während des Imports.",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class))
                     )
             }
     )
@@ -50,14 +39,6 @@ public class WahltermindatenController {
             responses = {
                     @ApiResponse(
                             responseCode = "200", description = "Die Wahltermindaten wurden erfolgreich gelöscht."
-                    ),
-                    @ApiResponse(
-                            responseCode = "400", description = "Validierung der Anfrage war nicht erfolgreich",
-                            content = { @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class)) }
-                    ),
-                    @ApiResponse(
-                            responseCode = "500", description = "Fehler während des Löschvorgangs.",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = WlsExceptionDTO.class))
                     )
             }
     )


### PR DESCRIPTION
# Beschreibung:

- neue default config für swagger hinzugefügt
- api-responses angepasst, falls nötig

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] Swagger-API vollständig



# Referenzen[^1]:

Verwandt mit Issue #

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded the `wls.common` dependency and added a new integration for Swagger to enhance API documentation.

- **Refactor**
  - Streamlined several API endpoints by simplifying response annotations, removing redundant error details, and focusing on clearer success and “no content” responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->