### PR TITLE
935 wahlbezirkid und wahlbezirkidmitwahlnummer fehlen für bezirkidpermissionevaluator in authentication

### DIFF
--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/SecurityConfiguration.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/SecurityConfiguration.java
@@ -10,7 +10,7 @@ import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import de.muenchen.oss.wahllokalsystem.authservice.security.CustomUsernamePasswordAuthenticationFilter;
-import de.muenchen.oss.wahllokalsystem.authservice.security.WahlbezirkArtTokenCustomizer;
+import de.muenchen.oss.wahllokalsystem.authservice.security.WlsUserTokenCustomizer;
 import de.muenchen.oss.wahllokalsystem.authservice.service.UserService;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -95,22 +95,22 @@ public class SecurityConfiguration {
     public SecurityFilterChain filterChain(HttpSecurity http, SessionRegistry sessionRegistry) throws Exception {
         http
                 .authorizeHttpRequests((requests) -> requests.requestMatchers(
-                        // allow access to /actuator/info
-                        AntPathRequestMatcher.antMatcher("/actuator/info"),
-                        // allow access to /actuator/health for OpenShift Health Check
-                        AntPathRequestMatcher.antMatcher("/actuator/health"),
-                        // allow access to /actuator/health/liveness for OpenShift Liveness Check
-                        AntPathRequestMatcher.antMatcher("/actuator/health/liveness"),
-                        // allow access to /actuator/health/readiness for OpenShift Readiness Check
-                        AntPathRequestMatcher.antMatcher("/actuator/health/readiness"),
-                        // allow access to /actuator/metrics for Prometheus monitoring in OpenShift
-                        AntPathRequestMatcher.antMatcher("/actuator/metrics"),
-                        AntPathRequestMatcher.antMatcher("/v3/api-docs/**"),
-                        AntPathRequestMatcher.antMatcher("/swagger-ui/**"),
-                        AntPathRequestMatcher.antMatcher("/"),
-                        AntPathRequestMatcher.antMatcher("/home"),
-                        AntPathRequestMatcher.antMatcher("/css/*"),
-                        AntPathRequestMatcher.antMatcher("/js/*"))
+                                // allow access to /actuator/info
+                                AntPathRequestMatcher.antMatcher("/actuator/info"),
+                                // allow access to /actuator/health for OpenShift Health Check
+                                AntPathRequestMatcher.antMatcher("/actuator/health"),
+                                // allow access to /actuator/health/liveness for OpenShift Liveness Check
+                                AntPathRequestMatcher.antMatcher("/actuator/health/liveness"),
+                                // allow access to /actuator/health/readiness for OpenShift Readiness Check
+                                AntPathRequestMatcher.antMatcher("/actuator/health/readiness"),
+                                // allow access to /actuator/metrics for Prometheus monitoring in OpenShift
+                                AntPathRequestMatcher.antMatcher("/actuator/metrics"),
+                                AntPathRequestMatcher.antMatcher("/v3/api-docs/**"),
+                                AntPathRequestMatcher.antMatcher("/swagger-ui/**"),
+                                AntPathRequestMatcher.antMatcher("/"),
+                                AntPathRequestMatcher.antMatcher("/home"),
+                                AntPathRequestMatcher.antMatcher("/css/*"),
+                                AntPathRequestMatcher.antMatcher("/js/*"))
                         .permitAll()
                         .anyRequest().authenticated())
                 .oauth2ResourceServer(httpSecurityOAuth2ResourceServerConfigurer -> httpSecurityOAuth2ResourceServerConfigurer
@@ -182,7 +182,7 @@ public class SecurityConfiguration {
     }
 
     @Bean
-    public WahlbezirkArtTokenCustomizer wahlbezirkArtTokenCustomizer(final UserService userService) {
-        return new WahlbezirkArtTokenCustomizer(userService);
+    public WlsUserTokenCustomizer wahlbezirkArtTokenCustomizer(final UserService userService) {
+        return new WlsUserTokenCustomizer(userService);
     }
 }

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/SecurityConfiguration.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/SecurityConfiguration.java
@@ -95,22 +95,22 @@ public class SecurityConfiguration {
     public SecurityFilterChain filterChain(HttpSecurity http, SessionRegistry sessionRegistry) throws Exception {
         http
                 .authorizeHttpRequests((requests) -> requests.requestMatchers(
-                                // allow access to /actuator/info
-                                AntPathRequestMatcher.antMatcher("/actuator/info"),
-                                // allow access to /actuator/health for OpenShift Health Check
-                                AntPathRequestMatcher.antMatcher("/actuator/health"),
-                                // allow access to /actuator/health/liveness for OpenShift Liveness Check
-                                AntPathRequestMatcher.antMatcher("/actuator/health/liveness"),
-                                // allow access to /actuator/health/readiness for OpenShift Readiness Check
-                                AntPathRequestMatcher.antMatcher("/actuator/health/readiness"),
-                                // allow access to /actuator/metrics for Prometheus monitoring in OpenShift
-                                AntPathRequestMatcher.antMatcher("/actuator/metrics"),
-                                AntPathRequestMatcher.antMatcher("/v3/api-docs/**"),
-                                AntPathRequestMatcher.antMatcher("/swagger-ui/**"),
-                                AntPathRequestMatcher.antMatcher("/"),
-                                AntPathRequestMatcher.antMatcher("/home"),
-                                AntPathRequestMatcher.antMatcher("/css/*"),
-                                AntPathRequestMatcher.antMatcher("/js/*"))
+                        // allow access to /actuator/info
+                        AntPathRequestMatcher.antMatcher("/actuator/info"),
+                        // allow access to /actuator/health for OpenShift Health Check
+                        AntPathRequestMatcher.antMatcher("/actuator/health"),
+                        // allow access to /actuator/health/liveness for OpenShift Liveness Check
+                        AntPathRequestMatcher.antMatcher("/actuator/health/liveness"),
+                        // allow access to /actuator/health/readiness for OpenShift Readiness Check
+                        AntPathRequestMatcher.antMatcher("/actuator/health/readiness"),
+                        // allow access to /actuator/metrics for Prometheus monitoring in OpenShift
+                        AntPathRequestMatcher.antMatcher("/actuator/metrics"),
+                        AntPathRequestMatcher.antMatcher("/v3/api-docs/**"),
+                        AntPathRequestMatcher.antMatcher("/swagger-ui/**"),
+                        AntPathRequestMatcher.antMatcher("/"),
+                        AntPathRequestMatcher.antMatcher("/home"),
+                        AntPathRequestMatcher.antMatcher("/css/*"),
+                        AntPathRequestMatcher.antMatcher("/js/*"))
                         .permitAll()
                         .anyRequest().authenticated())
                 .oauth2ResourceServer(httpSecurityOAuth2ResourceServerConfigurer -> httpSecurityOAuth2ResourceServerConfigurer

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/SecurityConfiguration.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/SecurityConfiguration.java
@@ -182,7 +182,7 @@ public class SecurityConfiguration {
     }
 
     @Bean
-    public WlsUserTokenCustomizer wahlbezirkArtTokenCustomizer(final UserService userService) {
+    public WlsUserTokenCustomizer wlsUserTokenCustomizer(final UserService userService) {
         return new WlsUserTokenCustomizer(userService);
     }
 }

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/security/WlsUserTokenCustomizer.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/security/WlsUserTokenCustomizer.java
@@ -21,6 +21,7 @@ public class WlsUserTokenCustomizer implements OAuth2TokenCustomizer<JwtEncoding
             if (user.isPresent()) {
                 context.getClaims().claims(claims -> claims.put("wahlbezirksArt", user.get().wahlbezirksArt()));
                 context.getClaims().claims(claims -> claims.put("wahlbezirkID", user.get().wahlbezirkID()));
+                context.getClaims().claims(claims -> claims.put("wahlbezirkid_wahlnummer", user.get().wbid_wahlnummer()));
             } else {
                 log.warn("no user found with {}", context.getPrincipal().getName());
             }

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/security/WlsUserTokenCustomizer.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/security/WlsUserTokenCustomizer.java
@@ -10,7 +10,7 @@ import org.springframework.security.oauth2.server.authorization.token.OAuth2Toke
 
 @RequiredArgsConstructor
 @Slf4j
-public class WahlbezirkArtTokenCustomizer implements OAuth2TokenCustomizer<JwtEncodingContext> {
+public class WlsUserTokenCustomizer implements OAuth2TokenCustomizer<JwtEncodingContext> {
 
     private final UserService userService;
 
@@ -20,6 +20,7 @@ public class WahlbezirkArtTokenCustomizer implements OAuth2TokenCustomizer<JwtEn
             val user = userService.getUser(context.getPrincipal().getName());
             if (user.isPresent()) {
                 context.getClaims().claims(claims -> claims.put("wahlbezirksArt", user.get().wahlbezirksArt()));
+                context.getClaims().claims(claims -> claims.put("wahlbezirkID", user.get().wahlbezirkID()));
             } else {
                 log.warn("no user found with {}", context.getPrincipal().getName());
             }

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/security/WlsUserTokenCustomizer.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/security/WlsUserTokenCustomizer.java
@@ -19,9 +19,11 @@ public class WlsUserTokenCustomizer implements OAuth2TokenCustomizer<JwtEncoding
         if (OAuth2TokenType.ACCESS_TOKEN.equals(context.getTokenType())) {
             val user = userService.getUser(context.getPrincipal().getName());
             if (user.isPresent()) {
-                context.getClaims().claims(claims -> claims.put("wahlbezirksArt", user.get().wahlbezirksArt()));
-                context.getClaims().claims(claims -> claims.put("wahlbezirkID", user.get().wahlbezirkID()));
-                context.getClaims().claims(claims -> claims.put("wahlbezirkid_wahlnummer", user.get().wbid_wahlnummer()));
+                context.getClaims().claims(claims -> {
+                    claims.put("wahlbezirksArt", user.get().wahlbezirksArt());
+                    claims.put("wahlbezirkID", user.get().wahlbezirkID());
+                    claims.put("wahlbezirkid_wahlnummer", user.get().wbid_wahlnummer());
+                });
             } else {
                 log.warn("no user found with {}", context.getPrincipal().getName());
             }

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/security/WlsUserTokenCustomizerTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/security/WlsUserTokenCustomizerTest.java
@@ -86,6 +86,25 @@ class WlsUserTokenCustomizerTest {
         }
 
         @Test
+        void should_addWbIDWahlnummerOfUser_when_tokenTypeIsAccessTokenAndUserIsFound() {
+            val username = "username";
+            val wbidWahlnummer = "wbidWahlnummer";
+
+            val jwtContext = JwtEncodingContext.with(JwsHeader.with(MacAlgorithm.HS256), JwtClaimsSet.builder()).context(context -> {
+                context.put(OAuth2TokenType.class, OAuth2TokenType.ACCESS_TOKEN);
+                context.put(Authentication.class.getName().concat(".PRINCIPAL"), new TestingAuthenticationToken(username, ""));
+            }).build();
+
+            val mockedUser = new UserModel(username, "", true, "", LocalDate.now(), "", "", null, "", Collections.emptySet(), wbidWahlnummer);
+
+            Mockito.when(userService.getUser(username)).thenReturn(Optional.of(mockedUser));
+
+            unitUnderTest.customize(jwtContext);
+
+            jwtContext.getClaims().claims(claims -> Assertions.assertThat(claims).contains(Assertions.entry("wahlbezirkid_wahlnummer", wbidWahlnummer)));
+        }
+
+        @Test
         void should_doNothing_when_tokenTypeIsAccessTokenAndUserIsNotFound() {
             val username = "username";
             val wahlbezirkArt = WahlbezirksartModel.BWB;

--- a/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/security/WlsUserTokenCustomizerTest.java
+++ b/wls-auth-service/src/test/java/de/muenchen/oss/wahllokalsystem/authservice/security/WlsUserTokenCustomizerTest.java
@@ -24,13 +24,13 @@ import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
 import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
 
 @ExtendWith(MockitoExtension.class)
-class WahlbezirkArtTokenCustomizerTest {
+class WlsUserTokenCustomizerTest {
 
     @Mock
     UserService userService;
 
     @InjectMocks
-    WahlbezirkArtTokenCustomizer unitUnderTest;
+    WlsUserTokenCustomizer unitUnderTest;
 
     @Nested
     class Customize {
@@ -64,6 +64,25 @@ class WahlbezirkArtTokenCustomizerTest {
             unitUnderTest.customize(jwtContext);
 
             jwtContext.getClaims().claims(claims -> Assertions.assertThat(claims).contains(Assertions.entry("wahlbezirksArt", wahlbezirkArt)));
+        }
+
+        @Test
+        void should_addWahlbezirkIDOfUser_when_tokenTypeIsAccessTokenAndUserIsFound() {
+            val username = "username";
+            val wahlbezirkID = "wahlbezirkID";
+
+            val jwtContext = JwtEncodingContext.with(JwsHeader.with(MacAlgorithm.HS256), JwtClaimsSet.builder()).context(context -> {
+                context.put(OAuth2TokenType.class, OAuth2TokenType.ACCESS_TOKEN);
+                context.put(Authentication.class.getName().concat(".PRINCIPAL"), new TestingAuthenticationToken(username, ""));
+            }).build();
+
+            val mockedUser = new UserModel(username, "", true, "", LocalDate.now(), wahlbezirkID, "", null, "", Collections.emptySet(), "");
+
+            Mockito.when(userService.getUser(username)).thenReturn(Optional.of(mockedUser));
+
+            unitUnderTest.customize(jwtContext);
+
+            jwtContext.getClaims().claims(claims -> Assertions.assertThat(claims).contains(Assertions.entry("wahlbezirkID", wahlbezirkID)));
         }
 
         @Test


### PR DESCRIPTION
# Beschreibung:

- wahlbezirkID und wahlbezirkIDWahlnummer werden vom dem User aus der Datenbank in den entsprechenden Claim geschrieben

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [X] Doku aktualisiert - kein Update notwendig
- [X] Swagger-API vollständig - keine Änderung an API
- [X] Unit-Tests gepflegt
- [X] Integrationstests gepflegt - keine Änderung im Verhalten zwischen Komponenten
- [X] Beispiel-Requests gepflegt - keine Änderung an API

# Referenzen[^1]:

Verwandt mit Issue #

Closes #935

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced authentication tokens now include additional user-specific identifiers for improved information delivery.

- **Refactor**
  - Streamlined naming conventions in the token customization components for greater consistency.

- **Tests**
  - Expanded test coverage to validate that the updated tokens correctly incorporate the new user information. 

These changes aim to improve the clarity and reliability of the authentication process without altering the end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->