### PR TITLE
Test naming convention wls common

### DIFF
--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/archunit/ArchUnitTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/archunit/ArchUnitTest.java
@@ -31,6 +31,8 @@ public class ArchUnitTest {
     }
 
     public static Stream<Arguments> allTestClassesRulesToVerify() {
-        return Stream.of(Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
+        return Stream.of(
+                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED),
+                Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
     }
 }

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/DTOMapperTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/DTOMapperTest.java
@@ -41,7 +41,7 @@ class DTOMapperTest {
     @ParameterizedTest(name = "expected: {0} input: {1}")
     @MethodSource
     void should_returnWlsExceptionCategory_when_restDTOCategoryIsGiven(final WlsExceptionCategory expectedResult,
-                                                                       final de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory categoryToMap) {
+            final de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory categoryToMap) {
         Assertions.assertThat(unitUnderTest.toDTOCategory(categoryToMap)).isEqualTo(expectedResult);
     }
 

--- a/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/DTOMapperTest.java
+++ b/wls-common/exception/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/exception/rest/model/DTOMapperTest.java
@@ -24,7 +24,7 @@ class DTOMapperTest {
         }
 
         @Test
-        void should_returnDTO_whenExceptionIsGiven() {
+        void should_returnDTO_when_exceptionIsGiven() {
             val code = "089";
             val serviceName = "dto mapper test";
             val message = "lets check the mapping";
@@ -41,7 +41,7 @@ class DTOMapperTest {
     @ParameterizedTest(name = "expected: {0} input: {1}")
     @MethodSource
     void should_returnWlsExceptionCategory_when_restDTOCategoryIsGiven(final WlsExceptionCategory expectedResult,
-            final de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory categoryToMap) {
+                                                                       final de.muenchen.oss.wahllokalsystem.wls.common.exception.model.WlsExceptionCategory categoryToMap) {
         Assertions.assertThat(unitUnderTest.toDTOCategory(categoryToMap)).isEqualTo(expectedResult);
     }
 

--- a/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/archunit/ArchUnitTest.java
+++ b/wls-common/security/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/security/archunit/ArchUnitTest.java
@@ -31,6 +31,8 @@ public class ArchUnitTest {
     }
 
     public static Stream<Arguments> allTestClassesRulesToVerify() {
-        return Stream.of(Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
+        return Stream.of(
+                Arguments.of("TEST_NAMING_CONVENTION_RULE", MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED),
+                Arguments.of("RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED", MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED));
     }
 }

--- a/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/SecurityUtilsTest.java
+++ b/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/SecurityUtilsTest.java
@@ -112,7 +112,7 @@ class SecurityUtilsTest {
     class BuildArgumentsForMissingAuthoritiesVariations {
 
         @Test
-        void should_createStreamWithCombinationsOfAuthoritiesWithOneAuthorityMissingInEachCombination_when_AuthoritiesAreGiven() {
+        void should_createStreamWithCombinationsOfAuthoritiesWithOneAuthorityMissingInEachCombination_when_authoritiesAreGiven() {
             val authority1 = "authority1";
             val authority2 = "authority2";
             val authority3 = "authority3";

--- a/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/archunit/ArchUnitTest.java
+++ b/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/archunit/ArchUnitTest.java
@@ -1,0 +1,57 @@
+package de.muenchen.oss.wahllokalsystem.wls.common.testing.archunit;
+
+import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import de.muenchen.oss.wahllokalsystem.wls.common.testing.SecurityUtils;
+import de.muenchen.oss.wahllokalsystem.wls.common.testing.archunit.rule.MethodRules;
+import de.muenchen.oss.wahllokalsystem.wls.common.testing.archunit.utilityClasses.NamingConventionExamplesTest;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class ArchUnitTest {
+
+    private static JavaClasses allTestClassesNamingConvention;
+    private static JavaClasses allTestClassesBeforeEachConvention;
+
+    @BeforeAll
+    static void init() {
+        allTestClassesNamingConvention = new ClassFileImporter()
+                .withImportOption(new ImportOption.OnlyIncludeTests())
+                .importPackages(SecurityUtils.class.getPackage().getName())
+                // excluding intended negative examples from actual test
+                .that(not(equivalentTo(NamingConventionExamplesTest.ExampleTestNamesViolatingNamingConventionRule.class)));
+
+        allTestClassesBeforeEachConvention = new ClassFileImporter()
+                .withImportOption(new ImportOption.OnlyIncludeTests())
+                .importPackages(SecurityUtils.class.getPackage().getName())
+                // excluding intended negative examples from actual test
+                .that(not(equivalentTo(NamingConventionExamplesTest.ExampleBeforeEachMethodNamesViolatingNamingConventionRule.class)));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("allTestClassesRulesToVerify")
+    void should_verifyArchUnitRuleForAllTestClassesOfService_when_running(final ArgumentsAccessor arguments) {
+        arguments.get(1, ArchRule.class).check(arguments.get(2, JavaClasses.class));
+    }
+
+    public static Stream<Arguments> allTestClassesRulesToVerify() {
+        return Stream.of(
+                Arguments.of(
+                        "TEST_NAMING_CONVENTION_RULE",
+                        MethodRules.RULE_TEST_NAMING_CONVENTION_SHOULD_WHEN_MATCHED,
+                        allTestClassesNamingConvention),
+                Arguments.of(
+                        "RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED",
+                        MethodRules.RULE_BEFORE_EACH_NAMING_CONVENTION_MATCHED,
+                        allTestClassesBeforeEachConvention));
+    }
+}

--- a/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/archunit/condition/RequestMappingMethodParameterAnnotationConditionTest.java
+++ b/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/archunit/condition/RequestMappingMethodParameterAnnotationConditionTest.java
@@ -30,19 +30,19 @@ class RequestMappingMethodParameterAnnotationConditionTest {
         }
 
         @Test
-        void should_throwNoException_when_RequestParamAnnotationIsGiven() {
+        void should_throwNoException_when_requestParamAnnotationIsGiven() {
             ruleWithConditionUnderTest.check(
                     new ClassFileImporter(List.of(new ImportOption.OnlyIncludeTests())).importClasses(RequestParamAnnotationIsGivenOnParameter.class));
         }
 
         @Test
-        void should_throwNoException_when_RequestBodyAnnotationIsGiven() {
+        void should_throwNoException_when_requestBodyAnnotationIsGiven() {
             ruleWithConditionUnderTest.check(
                     new ClassFileImporter(List.of(new ImportOption.OnlyIncludeTests())).importClasses(RequestBodyAnnotationIsGivenOnParameter.class));
         }
 
         @Test
-        void should_throwNoException_when_RequestHeaderAnnotationIsGiven() {
+        void should_throwNoException_when_requestHeaderAnnotationIsGiven() {
             ruleWithConditionUnderTest.check(
                     new ClassFileImporter(List.of(new ImportOption.OnlyIncludeTests())).importClasses(RequestHeaderAnnotationIsGivenOnParameter.class));
         }

--- a/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/archunit/utilityClasses/ModifiersExampleTest.java
+++ b/wls-common/testing/src/test/java/de/muenchen/oss/wahllokalsystem/wls/common/testing/archunit/utilityClasses/ModifiersExampleTest.java
@@ -11,12 +11,12 @@ public class ModifiersExampleTest {
     public class CorrectModifierExamples {
 
         @Test
-        void test123() {
+        void should_test123_when_test456() {
         }
 
         @ParameterizedTest
         @NullSource
-        void test456(String input) {
+        void should_execute_when_running(String input) {
         }
     }
 
@@ -24,16 +24,16 @@ public class ModifiersExampleTest {
     public class WrongModifierExamples {
 
         @Test
-        public void test123() {
+        public void should_abc_when_def() {
         }
 
         @Test
-        protected void test456() {
+        protected void should_a123_when_b456() {
         }
 
         @ParameterizedTest
         @NullSource
-        private void test789(String input) {
+        private void should_a_when_b(String input) {
         }
     }
 }


### PR DESCRIPTION
# Beschreibung:

- test naming convention rule zu wls-common packages hinzugefügt, in denen es tests gibt.
- nachtrag zu pr #833 

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Unit-Tests gepflegt

# Referenzen[^1]:

Verwandt mit Issue #767 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Tests**
	- Expanded internal validations to boost overall quality assurance and architectural compliance.
	- Added checks that verify adherence to naming standards across the test suite.
	- Introduced a new test class for enforcing architectural rules on test classes.
- **Style**
	- Standardized test method naming for improved clarity and consistency.

These enhancements reinforce the robustness and maintainability of our application without impacting its user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->