### PR TITLE
Dokumentation des Broadcast-Services in vitepress

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -190,6 +190,10 @@ export default withMermaid({
               link: `${PATH_SERVICES_BACKEND}briefwahl-service/`,
             },
             {
+              text: "Broadcast-Service",
+              link: `${PATH_SERVICES_BACKEND}broadcast-service/`,
+            },
+            {
               text: "EAI-Service",
               link: `${PATH_SERVICES_BACKEND}eai-service/`,
             },

--- a/docs/src/services/backend-services/broadcast-service/index.md
+++ b/docs/src/services/backend-services/broadcast-service/index.md
@@ -1,0 +1,32 @@
+# Broadcast-Service
+
+Dieser Service ermöglicht den Benutzern des Admin-Tools, eine Broadcast-Nachricht über die POST-Methode `broadcast()` an alle Wahllokale zu senden. 
+Im [Frontend des Wahllokalsystems](/services/frontend-services/wahllokalsystem/) prüft jedes Wahllokal in regelmäßigen Abständen mit der `getMessage()`-Methode, ob es neue, noch ungelesene Broadcast-Nachrichten gibt, die ihm zugewiesen wurden.
+Wenn dies der Fall ist, wird die Nachricht an das Wahllokal übermittelt. Nach der Empfangsbestätigung wird die entsprechende Nachricht für das betroffene Wahllokal über die POST-Methode `deleteMessage()` gelöscht.
+
+## Abhängigkeiten
+
+Der Service hat keine Abhängigkeiten zu anderen Services.
+
+## Daten und Funktionen
+
+### BroadcastMessageDTO
+
+Enthält die Nachricht und die IDs aller zu benachrichtigenden Wahllokalen.
+
+### MessageDTO
+
+Enthält die Nachricht eines einzelnen Wahllokals.
+
+### Post-Methode broadcast(BroadcastMessageDTO broadcastMessageDTO)
+
+Mit dem Objekt `broadcastMessageDTO` erhält der Controller sowohl eine Textnachricht als auch eine ID-Liste aller adressierten Wahllokale.
+Das führt zur Speicherung der Text-Nachricht für jedes einzelne Wahllokal aus der Liste.
+
+### Get-Methode getMessage(String wahlbezirkID)
+
+Sucht nach der ältesten Nachricht für die gegebene Wahlbezirk-Id und gibt diese zurück.
+
+### Post-Methode deleteMessage(String nachrichtID)
+
+Löscht die Nachricht mit der gegebenen ID, nachdem sie gelesen wurde. Es wird nur der dem entsprechenden Wahllokal zugewiesene Datenbankeintrag gelöscht.

--- a/docs/src/services/backend-services/broadcast-service/index.md
+++ b/docs/src/services/backend-services/broadcast-service/index.md
@@ -1,6 +1,6 @@
 # Broadcast-Service
 
-Dieser Service ermöglicht den Benutzern des Admin-Tools, eine Broadcast-Nachricht über die POST-Methode `broadcast()` an alle Wahllokale zu senden. 
+Dieser Service ermöglicht den Benutzern des Admin-Tools, eine Broadcast-Nachricht über die POST-Methode `broadcast()` an alle Wahllokale zu senden.
 Im [Frontend des Wahllokalsystems](/services/frontend-services/wahllokalsystem/) prüft jedes Wahllokal in regelmäßigen Abständen mit der `getMessage()`-Methode, ob es neue, noch ungelesene Broadcast-Nachrichten gibt, die ihm zugewiesen wurden.
 Wenn dies der Fall ist, wird die Nachricht an das Wahllokal übermittelt. Nach der Empfangsbestätigung wird die entsprechende Nachricht für das betroffene Wahllokal über die POST-Methode `deleteMessage()` gelöscht.
 

--- a/docs/src/technik/get_started/index.md
+++ b/docs/src/technik/get_started/index.md
@@ -48,12 +48,12 @@ flowchart LR
 > Beachten Sie, dass somit nur eine Instanz eines Services gleichzeitig laufen kann.
 
 | Service                                                                                   | Port |
-| ----------------------------------------------------------------------------------------- | ---- |
+|-------------------------------------------------------------------------------------------| ---- |
 | [Admin](/services/backend-services/admin-service/)                                        | 8209 |
 | [Auth](/services/backend-services/auth-service/)                                          | 8100 |
 | [Basisdaten](/services/backend-services/basisdaten-service/)                              | 8205 |
 | [Briefwahl](/services/backend-services/briefwahl-service/)                                | 8202 |
-| Broadcast                                                                                 | 8200 |
+| [Broadcast](/services/backend-services/broadcast-service/)                                | 8200 |
 | [EAI](/services/backend-services/eai-service/)                                            | 8300 |
 | [Ergebnismeldung](/services/backend-services/ergebnismeldung-service/)                    | 8208 |
 | [Infomanagement](/services/backend-services/infomanagement-service/)                      | 8201 |


### PR DESCRIPTION
### Dokumentation des Broadcast-Services in vitepress

- Verlinkung zu services und getStarted
- Beschreibung in index.md

## Definition of Done (DoD):

- Broadcast-Service in die Doku aufgenommen;
- Verlinkung zu services und getStarted;
- Beschreibung in index.md;

<!-- Dokumentation -->
### Dokumentation
- [X] Links geprüft

Closes #544 

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "Broadcast-Service" navigation entry under backend services, offering users direct access to the broadcast messaging functionality.

- **Documentation**
  - Introduced comprehensive documentation for the Broadcast Service, detailing how administrators can send alerts to polling stations.
  - Enhanced the "Get Started" guide with a direct link to the Broadcast Service documentation, improving overall navigation and user accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->