### PR TITLE
992 - Verwendung Standardports für Zugriff auf andere Services

### DIFF
--- a/wls-auth-service/src/main/resources/application.yml
+++ b/wls-auth-service/src/main/resources/application.yml
@@ -68,7 +68,7 @@ service:
     maxLoginAttempts: 5
     clients:
       infomanagement:
-        basepath: http://localhost:39146
+        basepath: http://localhost:8201
         configkey:
           welcomeMessage: WILLKOMMENSTEXT
           fruehesterLogin: FRUEHESTE_LOGIN_UHRZEIT

--- a/wls-basisdaten-service/src/main/resources/application.yml
+++ b/wls-basisdaten-service/src/main/resources/application.yml
@@ -71,6 +71,6 @@ service:
       threadNamePrefix: "taskExecutor-"
     clients:
       eai:
-        basePath: http://localhost:39149
+        basePath: http://localhost:8300
       infomanagement:
-        basePath: http://localhost:39148
+        basePath: http://localhost:8201

--- a/wls-monitoring-service/src/main/resources/application.yml
+++ b/wls-monitoring-service/src/main/resources/application.yml
@@ -64,4 +64,4 @@ info.application.version: @project.version@
 app:
   clients:
     eai:
-      basePath: http://localhost:39149
+      basePath: http://localhost:8300

--- a/wls-wahlvorstand-service/src/main/resources/application.yml
+++ b/wls-wahlvorstand-service/src/main/resources/application.yml
@@ -64,8 +64,8 @@ info.application.version: @project.version@
 app:
   clients:
     eai:
-      basePath: http://localhost:39149
+      basePath: http://localhost:8300
     infomanagement:
-      basePath: http://localhost:39148
+      basePath: http://localhost:8201
     basisdaten:
-      basePath: http://localhost:39151
+      basePath: http://localhost:8205


### PR DESCRIPTION
# Beschreibung:

In den BasePaths wurden die Ports eingetragen die [Doku](https://it-at-m.github.io/Wahllokalsystem/technik/get_started/#services-und-ports) hinterlegt sind. Somit ist im Standardverhalten (local und Stack) keine separate Konfiguration notwendig.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

- [x] Testing: Ports doppelt mit Doku abgeglichen dass es die korrekten Ports sind

# Referenzen[^1]:

Verwandt mit Issue #

Closes #992 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal service connectivity configurations to use new communication endpoints, ensuring improved consistency and stability across system components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->