### PR TITLE
refactored instant.now() to one variable

### DIFF
--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/domain/ausdruck/AusdruckRepositoryTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/domain/ausdruck/AusdruckRepositoryTest.java
@@ -39,15 +39,16 @@ class AusdruckRepositoryTest {
         @Test
         void should_returnData_when_idIsGiven() {
             val idToFind = new WahlUndBezirkIDUndMeldungsart("wahlbezirkID01", "wahlID01", Meldungsart.V1);
-            val ausdruckToFind = new Ausdruck(idToFind, "Testcontent", Instant.now());
+            val timeNow = Instant.now();
+            val ausdruckToFind = new Ausdruck(idToFind, "Testcontent", timeNow);
             val ausdruckeToSave = List.of(
                     ausdruckToFind,
                     new Ausdruck(new WahlUndBezirkIDUndMeldungsart("wahlbezirkID02", "wahlID01", Meldungsart.V1),
-                            "Testcontent", Instant.now()),
+                            "Testcontent", timeNow),
                     new Ausdruck(new WahlUndBezirkIDUndMeldungsart("wahlbezirkID03", "wahlID01", Meldungsart.V1),
-                            "Testcontent", Instant.now()),
+                            "Testcontent", timeNow),
                     new Ausdruck(new WahlUndBezirkIDUndMeldungsart("wahlbezirkID04", "wahlID01", Meldungsart.V1),
-                            "Testcontent", Instant.now()));
+                            "Testcontent", timeNow));
 
             repository.saveAll(ausdruckeToSave);
 
@@ -65,19 +66,20 @@ class AusdruckRepositoryTest {
         void should_returnAusdruck_when_wahlUndBezirkIDUndMeldungsartIsGiven() {
             val wahlIdToFind = "wahlId01";
             val wahlbezirkIdToFind = "wahlbezirkID01";
+            val timeNow = Instant.now();
             val ausdruckToFind1 = new Ausdruck(new WahlUndBezirkIDUndMeldungsart(wahlbezirkIdToFind, wahlIdToFind, Meldungsart.V1), "Testcontent",
-                    Instant.now());
+                    timeNow);
             val ausdruckToFind2 = new Ausdruck(new WahlUndBezirkIDUndMeldungsart(wahlbezirkIdToFind, wahlIdToFind, Meldungsart.V3), "Testcontent",
-                    Instant.now());
+                    timeNow);
             val ausdruckeToSave = List.of(
                     ausdruckToFind1,
                     ausdruckToFind2,
                     new Ausdruck(new WahlUndBezirkIDUndMeldungsart("wahlbezirkID02", "wahlID01", Meldungsart.V1),
-                            "Testcontent", Instant.now()),
+                            "Testcontent", timeNow),
                     new Ausdruck(new WahlUndBezirkIDUndMeldungsart("wahlbezirkID03", "wahlID01", Meldungsart.V1),
-                            "Testcontent", Instant.now()),
+                            "Testcontent", timeNow),
                     new Ausdruck(new WahlUndBezirkIDUndMeldungsart("wahlbezirkID04", "wahlID01", Meldungsart.V1),
-                            "Testcontent", Instant.now()));
+                            "Testcontent", timeNow));
 
             repository.saveAll(ausdruckeToSave);
 


### PR DESCRIPTION
# Beschreibung:

- `Instant.now()` in variable ausgelagert

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] Integrationstests gepflegt

# Referenzen[^1]:

Verwandt mit Issue #

Closes #1022 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Enhanced internal test reliability by standardizing timestamp assignment for consistent validation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->