### PR TITLE
905 admintool über das gateway im stack erreichbar machen

### DIFF
--- a/stack/gateway_config/application-routes.yml
+++ b/stack/gateway_config/application-routes.yml
@@ -84,7 +84,11 @@ spring:
             - Path=/api/wahlvorstand-service/**
           filters:
             - RewritePath=/api/wahlvorstand-service/(?<urlsegments>.*), /$\{urlsegments}
-          # frontend has to be the last route to be sure it does not override other routes with path=/**
+        - id: admintool
+          uri: http://kubernetes.docker.internal:8401/
+          predicates:
+            - Path=/admintool/**
+        # frontend has to be the last route to be sure it does not override other routes with path=/**
         - id: frontend
           uri: http://kubernetes.docker.internal:8400/
           predicates:

--- a/wls-gui-admintool/src/plugins/router.ts
+++ b/wls-gui-admintool/src/plugins/router.ts
@@ -21,7 +21,7 @@ const routes = [
 ];
 
 const router = createRouter({
-  history: createWebHashHistory(),
+  history: createWebHashHistory('/admintool/'),
   routes,
   scrollBehavior() {
     return {

--- a/wls-gui-admintool/src/plugins/router.ts
+++ b/wls-gui-admintool/src/plugins/router.ts
@@ -21,7 +21,7 @@ const routes = [
 ];
 
 const router = createRouter({
-  history: createWebHashHistory('/admintool/'),
+  history: createWebHashHistory("/admintool/"),
   routes,
   scrollBehavior() {
     return {

--- a/wls-gui-admintool/vite.config.ts
+++ b/wls-gui-admintool/vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig(({ mode }) => {
         "/api": "http://localhost:8083",
         "/actuator": "http://localhost:8083",
       },
-      allowedHosts: ["host.docker.internal"], // required to use frontend behind proxy (e.g. API Gateway)
+      allowedHosts: ["host.docker.internal", "kubernetes.docker.internal"], // required to use frontend behind proxy (e.g. API Gateway)
       headers: {
         "x-frame-options": "SAMEORIGIN", // required to use devtools behind proxy (e.g. API Gateway)
       },

--- a/wls-gui-admintool/vite.config.ts
+++ b/wls-gui-admintool/vite.config.ts
@@ -34,6 +34,7 @@ export default defineConfig(({ mode }) => {
       }),
       vueDevTools(),
     ],
+    base: '/admintool/',
     server: {
       host: true,
       port: 8401,

--- a/wls-gui-admintool/vite.config.ts
+++ b/wls-gui-admintool/vite.config.ts
@@ -34,7 +34,7 @@ export default defineConfig(({ mode }) => {
       }),
       vueDevTools(),
     ],
-    base: '/admintool/',
+    base: "/admintool/",
     server: {
       host: true,
       port: 8401,


### PR DESCRIPTION
# Beschreibung:

- admintool erreichbar via `gateway/admintool/`

# Referenzen[^1]:

Verwandt mit Issue #

Closes #905

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a dedicated admin tool interface accessible via a new route.
	- Updated application routing to prepend the base path for the admin tool.
	- Enhanced server configuration to allow additional hosts for better proxy support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->