### PR TITLE
fix log message to match the methodname

### DIFF
--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/ergebnisse/ErgebnisseService.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/ergebnisse/ErgebnisseService.java
@@ -45,7 +45,7 @@ public class ErgebnisseService {
                 + " and @bezirkIdPermissionEvaluator.tokenUserBezirkIdMatches(#wahlbezirkID, authentication)"
     )
     public List<ErgebnisseModel> getAllErgebnisse(@NotNull final String wahlID, @P("wahlbezirkID") @NotNull final String wahlbezirkID) {
-        log.info("#getErgebnisse");
+        log.info("#getAllErgebnisse");
 
         ergebnisseValidator.validIDOrThrow(wahlID, wahlbezirkID,
                 exceptionFactory.createFachlicheWlsException(ExceptionConstants.GET_ERGEBNISSE_PARAMETER_UNVOLLSTAENDIG));


### PR DESCRIPTION
# Beschreibung:

- Logmessage geändert auf `getAllErgebnisse` da die Methode so heißt, statt `getErgebnisse`

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [X] [Naming Conventions][naming-conventions-link] beachtet - nicht zutreffend
- [X] Doku aktualisiert - nicht zutreffend
- [X] Swagger-API vollständig - nicht zutreffend
- [X] Unit-Tests gepflegt - nicht zutreffend
- [X] Integrationstests gepflegt - nicht zutreffend
- [X] Beispiel-Requests gepflegt - nicht zutreffend

# Referenzen[^1]:

Verwandt mit Issue #1104 

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated internal log messages for improved clarity in system operation tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->