### PR TITLE
update wahlvorbereitung service to match nested testsuite convention

### DIFF
--- a/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/rest/briefwahlvorbereitung/BriefwahlvorbereitungControllerTest.java
+++ b/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/rest/briefwahlvorbereitung/BriefwahlvorbereitungControllerTest.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.Optional;
 import lombok.val;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -28,44 +29,52 @@ public class BriefwahlvorbereitungControllerTest {
     @InjectMocks
     BriefwahlvorbereitungController unitUnderTest;
 
-    @Test
-    void should_returnBriefwahlvorbereitungData_when_dataFound() {
-        val wahlbezirkID = "wahlbezirkID";
+    @Nested
+    class GetBriefwahlvorbereitung {
 
-        val mockedServiceOptionalBody = new BriefwahlvorbereitungModel(wahlbezirkID, Collections.emptyList());
-        val mockedMappedServiceResponseAsDTO = new BriefwahlvorbereitungDTO(wahlbezirkID, Collections.emptyList());
+        @Test
+        void should_returnBriefwahlvorbereitungData_when_dataFound() {
+            val wahlbezirkID = "wahlbezirkID";
 
-        Mockito.when(briefwahlvorbereitungService.getBriefwahlvorbereitung(wahlbezirkID)).thenReturn(Optional.of(mockedServiceOptionalBody));
-        Mockito.when(briefwahlvorbereitungDTOMapper.toDTO(mockedServiceOptionalBody)).thenReturn(mockedMappedServiceResponseAsDTO);
+            val mockedServiceOptionalBody = new BriefwahlvorbereitungModel(wahlbezirkID, Collections.emptyList());
+            val mockedMappedServiceResponseAsDTO = new BriefwahlvorbereitungDTO(wahlbezirkID, Collections.emptyList());
 
-        val result = unitUnderTest.getBriefwahlvorbereitung(wahlbezirkID);
+            Mockito.when(briefwahlvorbereitungService.getBriefwahlvorbereitung(wahlbezirkID)).thenReturn(Optional.of(mockedServiceOptionalBody));
+            Mockito.when(briefwahlvorbereitungDTOMapper.toDTO(mockedServiceOptionalBody)).thenReturn(mockedMappedServiceResponseAsDTO);
 
-        Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-        Assertions.assertThat(result.getBody()).isEqualTo(mockedMappedServiceResponseAsDTO);
+            val result = unitUnderTest.getBriefwahlvorbereitung(wahlbezirkID);
+
+            Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+            Assertions.assertThat(result.getBody()).isEqualTo(mockedMappedServiceResponseAsDTO);
+        }
+
+        @Test
+        void should_returnNoContent_when_noDataFound() {
+            val wahlbezirkID = "wahlbezirkID";
+
+            Mockito.when(briefwahlvorbereitungService.getBriefwahlvorbereitung(wahlbezirkID)).thenReturn(Optional.empty());
+
+            val result = unitUnderTest.getBriefwahlvorbereitung(wahlbezirkID);
+
+            Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+            Assertions.assertThat(result.getBody()).isNull();
+        }
     }
 
-    @Test
-    void should_returnNoContent_when_noDataFound() {
-        val wahlbezirkID = "wahlbezirkID";
+    @Nested
+    class PostBriefwahlvorbereitung {
 
-        Mockito.when(briefwahlvorbereitungService.getBriefwahlvorbereitung(wahlbezirkID)).thenReturn(Optional.empty());
+        @Test
+        void should_postBriefwahlvorbereitungData_when_calledAndMappedCorrectly() {
+            val wahlbezirkID = "wahlbezirkID";
+            val requestBody = new BriefwahlvorbereitungWriteDTO(Collections.emptyList());
 
-        val result = unitUnderTest.getBriefwahlvorbereitung(wahlbezirkID);
+            val mockedMappedRequest = new BriefwahlvorbereitungModel(wahlbezirkID, Collections.emptyList());
 
-        Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-        Assertions.assertThat(result.getBody()).isNull();
-    }
+            Mockito.when(briefwahlvorbereitungDTOMapper.toModel(eq(wahlbezirkID), eq(requestBody))).thenReturn(mockedMappedRequest);
 
-    @Test
-    void should_postBriefwahlvorbereitungData_when_calledAndMappedCorrectly() {
-        val wahlbezirkID = "wahlbezirkID";
-        val requestBody = new BriefwahlvorbereitungWriteDTO(Collections.emptyList());
-
-        val mockedMappedRequest = new BriefwahlvorbereitungModel(wahlbezirkID, Collections.emptyList());
-
-        Mockito.when(briefwahlvorbereitungDTOMapper.toModel(eq(wahlbezirkID), eq(requestBody))).thenReturn(mockedMappedRequest);
-
-        Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.postBriefwahlvorbereitung(wahlbezirkID, requestBody));
-        Mockito.verify(briefwahlvorbereitungService).setBriefwahlvorbereitung(mockedMappedRequest);
+            Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.postBriefwahlvorbereitung(wahlbezirkID, requestBody));
+            Mockito.verify(briefwahlvorbereitungService).setBriefwahlvorbereitung(mockedMappedRequest);
+        }
     }
 }

--- a/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/rest/eroeffnungsuhrzeit/EroeffnungsUhrzeitControllerTest.java
+++ b/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/rest/eroeffnungsuhrzeit/EroeffnungsUhrzeitControllerTest.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.val;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -28,46 +29,54 @@ public class EroeffnungsUhrzeitControllerTest {
     @InjectMocks
     EroeffnungsUhrzeitController unitUnderTest;
 
-    @Test
-    void should_returnEroeffnungsuhrzeit_when_dataFound() {
-        val wahlbezirkID = "wahlbezirkID";
-        val eroeffnungsUhrzeit = LocalDateTime.now();
+    @Nested
+    class GetEroeffnungsuhrzeit {
 
-        val mockedServiceOptionalBody = new EroeffnungsUhrzeitModel(wahlbezirkID, eroeffnungsUhrzeit);
-        val mockedMappedServiceResponseAsDTO = new EroeffnungsUhrzeitDTO(wahlbezirkID, eroeffnungsUhrzeit);
+        @Test
+        void should_returnEroeffnungsuhrzeit_when_dataFound() {
+            val wahlbezirkID = "wahlbezirkID";
+            val eroeffnungsUhrzeit = LocalDateTime.now();
 
-        Mockito.when(eroeffnungsUhrzeitService.getEroeffnungsUhrzeit(wahlbezirkID)).thenReturn(Optional.of(mockedServiceOptionalBody));
-        Mockito.when(eroeffnungsUhrzeitDTOMapper.toDTO(mockedServiceOptionalBody)).thenReturn(mockedMappedServiceResponseAsDTO);
+            val mockedServiceOptionalBody = new EroeffnungsUhrzeitModel(wahlbezirkID, eroeffnungsUhrzeit);
+            val mockedMappedServiceResponseAsDTO = new EroeffnungsUhrzeitDTO(wahlbezirkID, eroeffnungsUhrzeit);
 
-        val result = unitUnderTest.getEroeffnungsuhrzeit(wahlbezirkID);
+            Mockito.when(eroeffnungsUhrzeitService.getEroeffnungsUhrzeit(wahlbezirkID)).thenReturn(Optional.of(mockedServiceOptionalBody));
+            Mockito.when(eroeffnungsUhrzeitDTOMapper.toDTO(mockedServiceOptionalBody)).thenReturn(mockedMappedServiceResponseAsDTO);
 
-        Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-        Assertions.assertThat(result.getBody()).isEqualTo(mockedMappedServiceResponseAsDTO);
+            val result = unitUnderTest.getEroeffnungsuhrzeit(wahlbezirkID);
+
+            Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+            Assertions.assertThat(result.getBody()).isEqualTo(mockedMappedServiceResponseAsDTO);
+        }
+
+        @Test
+        void should_returnNoContent_when_noDataFound() {
+            val wahlbezirkID = "wahlbezirkID";
+
+            Mockito.when(eroeffnungsUhrzeitService.getEroeffnungsUhrzeit(wahlbezirkID)).thenReturn(Optional.empty());
+
+            val result = unitUnderTest.getEroeffnungsuhrzeit(wahlbezirkID);
+
+            Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+            Assertions.assertThat(result.getBody()).isNull();
+        }
     }
 
-    @Test
-    void should_returnNoContent_when_noDataFound() {
-        val wahlbezirkID = "wahlbezirkID";
+    @Nested
+    class PostEroeffnungsuhrzeit {
 
-        Mockito.when(eroeffnungsUhrzeitService.getEroeffnungsUhrzeit(wahlbezirkID)).thenReturn(Optional.empty());
+        @Test
+        void should_postEroeffnungsuhrzeit_when_calledAndMappedCorrectly() {
+            val wahlbezirkID = "wahlbezirkID";
+            val eroeffnungsUhrzeit = LocalDateTime.now();
+            val requestBody = new EroeffnungsUhrzeitWriteDTO(eroeffnungsUhrzeit);
 
-        val result = unitUnderTest.getEroeffnungsuhrzeit(wahlbezirkID);
+            val mockedMappedRequest = new EroeffnungsUhrzeitModel(wahlbezirkID, eroeffnungsUhrzeit);
 
-        Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-        Assertions.assertThat(result.getBody()).isNull();
-    }
+            Mockito.when(eroeffnungsUhrzeitDTOMapper.toModel(eq(wahlbezirkID), eq(requestBody))).thenReturn(mockedMappedRequest);
 
-    @Test
-    void should_postEroeffnungsuhrzeit_when_calledAndMappedCorrectly() {
-        val wahlbezirkID = "wahlbezirkID";
-        val eroeffnungsUhrzeit = LocalDateTime.now();
-        val requestBody = new EroeffnungsUhrzeitWriteDTO(eroeffnungsUhrzeit);
-
-        val mockedMappedRequest = new EroeffnungsUhrzeitModel(wahlbezirkID, eroeffnungsUhrzeit);
-
-        Mockito.when(eroeffnungsUhrzeitDTOMapper.toModel(eq(wahlbezirkID), eq(requestBody))).thenReturn(mockedMappedRequest);
-
-        Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.postEroeffnungsuhrzeit(wahlbezirkID, requestBody));
-        Mockito.verify(eroeffnungsUhrzeitService).setEroeffnungsUhrzeit(mockedMappedRequest);
+            Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.postEroeffnungsuhrzeit(wahlbezirkID, requestBody));
+            Mockito.verify(eroeffnungsUhrzeitService).setEroeffnungsUhrzeit(mockedMappedRequest);
+        }
     }
 }

--- a/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/rest/fortsetzungsuhrzeit/FortsetzungsUhrzeitControllerTest.java
+++ b/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/rest/fortsetzungsuhrzeit/FortsetzungsUhrzeitControllerTest.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.val;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -28,46 +29,54 @@ public class FortsetzungsUhrzeitControllerTest {
     @InjectMocks
     FortsetzungsUhrzeitController unitUnderTest;
 
-    @Test
-    void should_returnFortsetzungsuhrzeit_when_dataFound() {
-        val wahlbezirkID = "wahlbezirkID";
-        val fortsetzungsUhrzeit = LocalDateTime.now();
+    @Nested
+    class GetFortsetzungsUhrzeit {
 
-        val mockedServiceOptionalBody = new FortsetzungsUhrzeitModel(wahlbezirkID, fortsetzungsUhrzeit);
-        val mockedMappedServiceResponseAsDTO = new FortsetzungsUhrzeitDTO(wahlbezirkID, fortsetzungsUhrzeit);
+        @Test
+        void should_returnFortsetzungsuhrzeit_when_dataFound() {
+            val wahlbezirkID = "wahlbezirkID";
+            val fortsetzungsUhrzeit = LocalDateTime.now();
 
-        Mockito.when(fortsetzungsUhrzeitService.getFortsetzungsUhrzeit(wahlbezirkID)).thenReturn(Optional.of(mockedServiceOptionalBody));
-        Mockito.when(fortsetzungsUhrzeitDTOMapper.toDTO(mockedServiceOptionalBody)).thenReturn(mockedMappedServiceResponseAsDTO);
+            val mockedServiceOptionalBody = new FortsetzungsUhrzeitModel(wahlbezirkID, fortsetzungsUhrzeit);
+            val mockedMappedServiceResponseAsDTO = new FortsetzungsUhrzeitDTO(wahlbezirkID, fortsetzungsUhrzeit);
 
-        val result = unitUnderTest.getFortsetzungsUhrzeit(wahlbezirkID);
+            Mockito.when(fortsetzungsUhrzeitService.getFortsetzungsUhrzeit(wahlbezirkID)).thenReturn(Optional.of(mockedServiceOptionalBody));
+            Mockito.when(fortsetzungsUhrzeitDTOMapper.toDTO(mockedServiceOptionalBody)).thenReturn(mockedMappedServiceResponseAsDTO);
 
-        Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-        Assertions.assertThat(result.getBody()).isEqualTo(mockedMappedServiceResponseAsDTO);
+            val result = unitUnderTest.getFortsetzungsUhrzeit(wahlbezirkID);
+
+            Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+            Assertions.assertThat(result.getBody()).isEqualTo(mockedMappedServiceResponseAsDTO);
+        }
+
+        @Test
+        void should_returnNoContent_when_noDataFound() {
+            val wahlbezirkID = "wahlbezirkID";
+
+            Mockito.when(fortsetzungsUhrzeitService.getFortsetzungsUhrzeit(wahlbezirkID)).thenReturn(Optional.empty());
+
+            val result = unitUnderTest.getFortsetzungsUhrzeit(wahlbezirkID);
+
+            Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+            Assertions.assertThat(result.getBody()).isNull();
+        }
     }
 
-    @Test
-    void should_returnNoContent_when_noDataFound() {
-        val wahlbezirkID = "wahlbezirkID";
+    @Nested
+    class PostFortsetzungsUhrzeit {
 
-        Mockito.when(fortsetzungsUhrzeitService.getFortsetzungsUhrzeit(wahlbezirkID)).thenReturn(Optional.empty());
+        @Test
+        void should_postFortsetzungsuhrzeit_when_calledAndMappedCorrectly() {
+            val wahlbezirkID = "wahlbezirkID";
+            val fortsetzungsUhrzeit = LocalDateTime.now();
+            val requestBody = new FortsetzungsUhrzeitWriteDTO(fortsetzungsUhrzeit);
 
-        val result = unitUnderTest.getFortsetzungsUhrzeit(wahlbezirkID);
+            val mockedMappedRequest = new FortsetzungsUhrzeitModel(wahlbezirkID, fortsetzungsUhrzeit);
 
-        Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-        Assertions.assertThat(result.getBody()).isNull();
-    }
+            Mockito.when(fortsetzungsUhrzeitDTOMapper.toModel(eq(wahlbezirkID), eq(requestBody))).thenReturn(mockedMappedRequest);
 
-    @Test
-    void should_postFortsetzungsuhrzeit_when_calledAndMappedCorrectly() {
-        val wahlbezirkID = "wahlbezirkID";
-        val fortsetzungsUhrzeit = LocalDateTime.now();
-        val requestBody = new FortsetzungsUhrzeitWriteDTO(fortsetzungsUhrzeit);
-
-        val mockedMappedRequest = new FortsetzungsUhrzeitModel(wahlbezirkID, fortsetzungsUhrzeit);
-
-        Mockito.when(fortsetzungsUhrzeitDTOMapper.toModel(eq(wahlbezirkID), eq(requestBody))).thenReturn(mockedMappedRequest);
-
-        Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.postFortsetzungsUhrzeit(wahlbezirkID, requestBody));
-        Mockito.verify(fortsetzungsUhrzeitService).setFortsetzungsUhrzeit(mockedMappedRequest);
+            Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.postFortsetzungsUhrzeit(wahlbezirkID, requestBody));
+            Mockito.verify(fortsetzungsUhrzeitService).setFortsetzungsUhrzeit(mockedMappedRequest);
+        }
     }
 }

--- a/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/rest/unterbrechungsuhrzeit/UnterbrechungsUhrzeitControllerTest.java
+++ b/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/rest/unterbrechungsuhrzeit/UnterbrechungsUhrzeitControllerTest.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.val;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -28,46 +29,54 @@ public class UnterbrechungsUhrzeitControllerTest {
     @InjectMocks
     UnterbrechungsUhrzeitController unitUnderTest;
 
-    @Test
-    void should_returnUnterbrechungsuhrzeit_when_dataFound() {
-        val wahlbezirkID = "wahlbezirkID";
-        val unterbrechungsUhrzeit = LocalDateTime.now();
+    @Nested
+    class GetUnterbrechungsuhrzeit {
 
-        val mockedServiceOptionalBody = new UnterbrechungsUhrzeitModel(wahlbezirkID, unterbrechungsUhrzeit);
-        val mockedMappedServiceResponseAsDTO = new UnterbrechungsUhrzeitDTO(wahlbezirkID, unterbrechungsUhrzeit);
+        @Test
+        void should_returnUnterbrechungsuhrzeit_when_dataFound() {
+            val wahlbezirkID = "wahlbezirkID";
+            val unterbrechungsUhrzeit = LocalDateTime.now();
 
-        Mockito.when(unterbrechungsUhrzeitService.getUnterbrechungsUhrzeit(wahlbezirkID)).thenReturn(Optional.of(mockedServiceOptionalBody));
-        Mockito.when(unterbrechungsUhrzeitDTOMapper.toDTO(mockedServiceOptionalBody)).thenReturn(mockedMappedServiceResponseAsDTO);
+            val mockedServiceOptionalBody = new UnterbrechungsUhrzeitModel(wahlbezirkID, unterbrechungsUhrzeit);
+            val mockedMappedServiceResponseAsDTO = new UnterbrechungsUhrzeitDTO(wahlbezirkID, unterbrechungsUhrzeit);
 
-        val result = unitUnderTest.getUnterbrechungsuhrzeit(wahlbezirkID);
+            Mockito.when(unterbrechungsUhrzeitService.getUnterbrechungsUhrzeit(wahlbezirkID)).thenReturn(Optional.of(mockedServiceOptionalBody));
+            Mockito.when(unterbrechungsUhrzeitDTOMapper.toDTO(mockedServiceOptionalBody)).thenReturn(mockedMappedServiceResponseAsDTO);
 
-        Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-        Assertions.assertThat(result.getBody()).isEqualTo(mockedMappedServiceResponseAsDTO);
+            val result = unitUnderTest.getUnterbrechungsuhrzeit(wahlbezirkID);
+
+            Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+            Assertions.assertThat(result.getBody()).isEqualTo(mockedMappedServiceResponseAsDTO);
+        }
+
+        @Test
+        void should_returnNoContent_when_noDataFound() {
+            val wahlbezirkID = "wahlbezirkID";
+
+            Mockito.when(unterbrechungsUhrzeitService.getUnterbrechungsUhrzeit(wahlbezirkID)).thenReturn(Optional.empty());
+
+            val result = unitUnderTest.getUnterbrechungsuhrzeit(wahlbezirkID);
+
+            Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+            Assertions.assertThat(result.getBody()).isNull();
+        }
     }
 
-    @Test
-    void should_returnNoContent_when_noDataFound() {
-        val wahlbezirkID = "wahlbezirkID";
+    @Nested
+    class PostUnterbrechungsuhrzeit {
 
-        Mockito.when(unterbrechungsUhrzeitService.getUnterbrechungsUhrzeit(wahlbezirkID)).thenReturn(Optional.empty());
+        @Test
+        void should_postUnterbrechungsuhrzeit_when_calledAndMappedCorrectly() {
+            val wahlbezirkID = "wahlbezirkID";
+            val unterbrechungsUhrzeit = LocalDateTime.now();
+            val requestBody = new UnterbrechungsUhrzeitWriteDTO(unterbrechungsUhrzeit);
 
-        val result = unitUnderTest.getUnterbrechungsuhrzeit(wahlbezirkID);
+            val mockedMappedRequest = new UnterbrechungsUhrzeitModel(wahlbezirkID, unterbrechungsUhrzeit);
 
-        Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-        Assertions.assertThat(result.getBody()).isNull();
-    }
+            Mockito.when(unterbrechungsUhrzeitDTOMapper.toModel(eq(wahlbezirkID), eq(requestBody))).thenReturn(mockedMappedRequest);
 
-    @Test
-    void should_postUnterbrechungsuhrzeit_when_calledAndMappedCorrectly() {
-        val wahlbezirkID = "wahlbezirkID";
-        val unterbrechungsUhrzeit = LocalDateTime.now();
-        val requestBody = new UnterbrechungsUhrzeitWriteDTO(unterbrechungsUhrzeit);
-
-        val mockedMappedRequest = new UnterbrechungsUhrzeitModel(wahlbezirkID, unterbrechungsUhrzeit);
-
-        Mockito.when(unterbrechungsUhrzeitDTOMapper.toModel(eq(wahlbezirkID), eq(requestBody))).thenReturn(mockedMappedRequest);
-
-        Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.postUnterbrechungsuhrzeit(wahlbezirkID, requestBody));
-        Mockito.verify(unterbrechungsUhrzeitService).setUnterbrechungsUhrzeit(mockedMappedRequest);
+            Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.postUnterbrechungsuhrzeit(wahlbezirkID, requestBody));
+            Mockito.verify(unterbrechungsUhrzeitService).setUnterbrechungsUhrzeit(mockedMappedRequest);
+        }
     }
 }

--- a/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/rest/urnenwahlschliessungsuhrzeit/UrnenwahlSchliessungsUhrzeitControllerTest.java
+++ b/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/rest/urnenwahlschliessungsuhrzeit/UrnenwahlSchliessungsUhrzeitControllerTest.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.val;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -28,46 +29,54 @@ public class UrnenwahlSchliessungsUhrzeitControllerTest {
     @InjectMocks
     UrnenwahlSchliessungsUhrzeitController unitUnderTest;
 
-    @Test
-    void should_returnUrnenwahlSchliessungsuhrzeit_when_dataFound() {
-        val wahlbezirkID = "wahlbezirkID";
-        val urnenwahlSchliessungsUhrzeit = LocalDateTime.now();
+    @Nested
+    class GetUrnenwahlSchliessungsUhrzeit {
 
-        val mockedServiceOptionalBody = new UrnenwahlSchliessungsUhrzeitModel(wahlbezirkID, urnenwahlSchliessungsUhrzeit);
-        val mockedMappedServiceResponseAsDTO = new UrnenwahlSchliessungsUhrzeitDTO(wahlbezirkID, urnenwahlSchliessungsUhrzeit);
+        @Test
+        void should_returnUrnenwahlSchliessungsuhrzeit_when_dataFound() {
+            val wahlbezirkID = "wahlbezirkID";
+            val urnenwahlSchliessungsUhrzeit = LocalDateTime.now();
 
-        Mockito.when(urnenwahlSchliessungsUhrzeitService.getUrnenwahlSchliessungsUhrzeit(wahlbezirkID)).thenReturn(Optional.of(mockedServiceOptionalBody));
-        Mockito.when(urnenwahlSchliessungsUhrzeitDTOMapper.toDTO(mockedServiceOptionalBody)).thenReturn(mockedMappedServiceResponseAsDTO);
+            val mockedServiceOptionalBody = new UrnenwahlSchliessungsUhrzeitModel(wahlbezirkID, urnenwahlSchliessungsUhrzeit);
+            val mockedMappedServiceResponseAsDTO = new UrnenwahlSchliessungsUhrzeitDTO(wahlbezirkID, urnenwahlSchliessungsUhrzeit);
 
-        val result = unitUnderTest.getUrnenwahlSchliessungsUhrzeit(wahlbezirkID);
+            Mockito.when(urnenwahlSchliessungsUhrzeitService.getUrnenwahlSchliessungsUhrzeit(wahlbezirkID)).thenReturn(Optional.of(mockedServiceOptionalBody));
+            Mockito.when(urnenwahlSchliessungsUhrzeitDTOMapper.toDTO(mockedServiceOptionalBody)).thenReturn(mockedMappedServiceResponseAsDTO);
 
-        Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-        Assertions.assertThat(result.getBody()).isEqualTo(mockedMappedServiceResponseAsDTO);
+            val result = unitUnderTest.getUrnenwahlSchliessungsUhrzeit(wahlbezirkID);
+
+            Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+            Assertions.assertThat(result.getBody()).isEqualTo(mockedMappedServiceResponseAsDTO);
+        }
+
+        @Test
+        void should_returnNoContent_when_noDataFound() {
+            val wahlbezirkID = "wahlbezirkID";
+
+            Mockito.when(urnenwahlSchliessungsUhrzeitService.getUrnenwahlSchliessungsUhrzeit(wahlbezirkID)).thenReturn(Optional.empty());
+
+            val result = unitUnderTest.getUrnenwahlSchliessungsUhrzeit(wahlbezirkID);
+
+            Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+            Assertions.assertThat(result.getBody()).isNull();
+        }
     }
 
-    @Test
-    void should_returnNoContent_when_noDataFound() {
-        val wahlbezirkID = "wahlbezirkID";
+    @Nested
+    class PostUrnenwahlSchliessungsUhrzeit {
 
-        Mockito.when(urnenwahlSchliessungsUhrzeitService.getUrnenwahlSchliessungsUhrzeit(wahlbezirkID)).thenReturn(Optional.empty());
+        @Test
+        void should_postUrnenwahlSchliessungsuhrzeit_when_calledAndMappedCorrectly() {
+            val wahlbezirkID = "wahlbezirkID";
+            val urnenwahlSchliessungsUhrzeit = LocalDateTime.now();
+            val requestBody = new UrnenwahlSchliessungsUhrzeitWriteDTO(urnenwahlSchliessungsUhrzeit);
 
-        val result = unitUnderTest.getUrnenwahlSchliessungsUhrzeit(wahlbezirkID);
+            val mockedMappedRequest = new UrnenwahlSchliessungsUhrzeitModel(wahlbezirkID, urnenwahlSchliessungsUhrzeit);
 
-        Assertions.assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-        Assertions.assertThat(result.getBody()).isNull();
-    }
+            Mockito.when(urnenwahlSchliessungsUhrzeitDTOMapper.toModel(eq(wahlbezirkID), eq(requestBody))).thenReturn(mockedMappedRequest);
 
-    @Test
-    void should_postUrnenwahlSchliessungsuhrzeit_when_calledAndMappedCorrectly() {
-        val wahlbezirkID = "wahlbezirkID";
-        val urnenwahlSchliessungsUhrzeit = LocalDateTime.now();
-        val requestBody = new UrnenwahlSchliessungsUhrzeitWriteDTO(urnenwahlSchliessungsUhrzeit);
-
-        val mockedMappedRequest = new UrnenwahlSchliessungsUhrzeitModel(wahlbezirkID, urnenwahlSchliessungsUhrzeit);
-
-        Mockito.when(urnenwahlSchliessungsUhrzeitDTOMapper.toModel(eq(wahlbezirkID), eq(requestBody))).thenReturn(mockedMappedRequest);
-
-        Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.postUrnenwahlSchliessungsUhrzeit(wahlbezirkID, requestBody));
-        Mockito.verify(urnenwahlSchliessungsUhrzeitService).setUrnenwahlSchliessungsUhrzeit(mockedMappedRequest);
+            Assertions.assertThatNoException().isThrownBy(() -> unitUnderTest.postUrnenwahlSchliessungsUhrzeit(wahlbezirkID, requestBody));
+            Mockito.verify(urnenwahlSchliessungsUhrzeitService).setUrnenwahlSchliessungsUhrzeit(mockedMappedRequest);
+        }
     }
 }

--- a/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/service/briefwahlvorbereitung/BriefwahlvorbereitungServiceTest.java
+++ b/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/service/briefwahlvorbereitung/BriefwahlvorbereitungServiceTest.java
@@ -38,7 +38,7 @@ class BriefwahlvorbereitungServiceTest {
     BriefwahlvorbereitungService unitUnderTest;
 
     @Nested
-    class getBriefwahlvorbereitung {
+    class GetBriefwahlvorbereitung {
 
         @Test
         void should_returnBriefwahlvorbereitung_when_givenValidWahlbezirkID() {

--- a/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/service/eroeffnungsuhrzeit/EroeffnungsUhrzeitServiceTest.java
+++ b/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/service/eroeffnungsuhrzeit/EroeffnungsUhrzeitServiceTest.java
@@ -38,7 +38,7 @@ class EroeffnungsUhrzeitServiceTest {
     EroeffnungsUhrzeitService unitUnderTest;
 
     @Nested
-    class getEroeffnungsUhrzeit {
+    class GetEroeffnungsUhrzeit {
 
         @Test
         void should_returnEroeffnungsuhrzeit_when_givenValidWahlbezirkID() {

--- a/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/service/fortsetzungsuhrzeit/FortsetzungsUhrzeitServiceTest.java
+++ b/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/service/fortsetzungsuhrzeit/FortsetzungsUhrzeitServiceTest.java
@@ -38,7 +38,7 @@ class FortsetzungsUhrzeitServiceTest {
     FortsetzungsUhrzeitService unitUnderTest;
 
     @Nested
-    class getFortsetzungsUhrzeit {
+    class GetFortsetzungsUhrzeit {
 
         @Test
         void should_returnFortsetzungsuhrzeit_when_givenValidWahlbezirkID() {

--- a/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/service/unterbrechungsuhrzeit/UnterbrechungsUhrzeitServiceTest.java
+++ b/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/service/unterbrechungsuhrzeit/UnterbrechungsUhrzeitServiceTest.java
@@ -38,7 +38,7 @@ class UnterbrechungsUhrzeitServiceTest {
     UnterbrechungsUhrzeitService unitUnderTest;
 
     @Nested
-    class getUnterbrechungsUhrzeit {
+    class GetUnterbrechungsUhrzeit {
 
         @Test
         void should_returnUnterbrechungsuhrzeit_when_givenValidWahlbezirkID() {

--- a/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/service/urnenwahlvorbereitung/UrnenwahlvorbereitungServiceTest.java
+++ b/wls-wahlvorbereitung-service/src/test/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/service/urnenwahlvorbereitung/UrnenwahlvorbereitungServiceTest.java
@@ -38,7 +38,7 @@ class UrnenwahlvorbereitungServiceTest {
     UrnenwahlvorbereitungService unitUnderTest;
 
     @Nested
-    class getUrnenwahlvorbereitung {
+    class GetUrnenwahlvorbereitung {
 
         @Test
         void should_returnUrnenwahlvorbereitung_when_givenValidWahlbezirkID() {


### PR DESCRIPTION
# Beschreibung:

im `BriefwahlvorbereitungControllerTest` waren die tests nicht entsprechend der Convention in Nested Blöcke verschachtelt.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Unit-Tests gepflegt

# Referenzen[^1]:

Verwandt mit Issue #769 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved internal test organization by grouping related test cases for data retrieval and submission, enhancing the maintainability of our test suite while keeping user-facing functionality intact.
  - Renamed nested classes in various service tests to align with Java naming conventions, ensuring consistency without affecting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->