### PR TITLE
add testwahltage for kommunahlwahl 2026

### DIFF
--- a/wls-eai-service/src/main/resources/db/dummydata/h2/V6_0__addWahltageForKommunahlwahl2026.sql
+++ b/wls-eai-service/src/main/resources/db/dummydata/h2/V6_0__addWahltageForKommunahlwahl2026.sql
@@ -1,9 +1,6 @@
 INSERT INTO wahltag (id, tag, beschreibung, nummer)
-values ('00000000-2026-0003-0008-000000000000', to_timestamp('2026-03-08', 'YYYY-MM-DD'),
-        'OB-Wahl', '0');
+values ('00000000-2026-0003-0008-000000000000', '2026-03-08', 'OB-Wahl', '0');
 INSERT INTO wahltag (id, tag, beschreibung, nummer)
-values ('00000000-2026-0003-0008-000000000001', to_timestamp('2026-03-08', 'YYYY-MM-DD'),
-        'Stadtratswahl-Wahl', '1');
+values ('00000000-2026-0003-0008-000000000001', '2026-03-08', 'Stadtratswahl-Wahl', '1');
 INSERT INTO wahltag (id, tag, beschreibung, nummer)
-values ('00000000-2026-0003-0008-000000000002', to_timestamp('2026-03-08', 'YYYY-MM-DD'),
-        'Bezirksausschuss-Wahl', '2');
+values ('00000000-2026-0003-0008-000000000002', '2026-03-08', 'Bezirksausschuss-Wahl', '2');

--- a/wls-eai-service/src/main/resources/db/dummydata/h2/V6_0__addWahltageForKommunahlwahl2026.sql
+++ b/wls-eai-service/src/main/resources/db/dummydata/h2/V6_0__addWahltageForKommunahlwahl2026.sql
@@ -1,0 +1,9 @@
+INSERT INTO wahltag (id, tag, beschreibung, nummer)
+values ('00000000-2026-0003-0008-000000000000', to_timestamp('2026-03-08', 'YYYY-MM-DD'),
+        'OB-Wahl', '0');
+INSERT INTO wahltag (id, tag, beschreibung, nummer)
+values ('00000000-2026-0003-0008-000000000001', to_timestamp('2026-03-08', 'YYYY-MM-DD'),
+        'Stadtratswahl-Wahl', '1');
+INSERT INTO wahltag (id, tag, beschreibung, nummer)
+values ('00000000-2026-0003-0008-000000000002', to_timestamp('2026-03-08', 'YYYY-MM-DD'),
+        'Bezirksausschuss-Wahl', '2');

--- a/wls-eai-service/src/main/resources/db/dummydata/oracle/V6_0__addWahltageForKommunahlwahl2026.sql
+++ b/wls-eai-service/src/main/resources/db/dummydata/oracle/V6_0__addWahltageForKommunahlwahl2026.sql
@@ -1,0 +1,9 @@
+INSERT INTO wahltag (id, tag, beschreibung, nummer)
+values ('00000000-2026-0003-0008-000000000000', to_timestamp('2026-03-08', 'YYYY-MM-DD'),
+        'OB-Wahl', '0');
+INSERT INTO wahltag (id, tag, beschreibung, nummer)
+values ('00000000-2026-0003-0008-000000000001', to_timestamp('2026-03-08', 'YYYY-MM-DD'),
+        'Stadtratswahl-Wahl', '1');
+INSERT INTO wahltag (id, tag, beschreibung, nummer)
+values ('00000000-2026-0003-0008-000000000002', to_timestamp('2026-03-08', 'YYYY-MM-DD'),
+        'Bezirksausschuss-Wahl', '2');


### PR DESCRIPTION
# Beschreibung:

- 3 Wahltage ergänzt wie sie für die kommende Kommunahlwahl sein werden
 - es ist nicht ein 1 Wahltag mit 3 Wahlen, sondern 3 Wahltage mit je einer Wahl

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [X] [Naming Conventions][naming-conventions-link] beachtet - keine Relevanz, da nur Dummydaten geändert werden
- [X] Doku aktualisiert - keine Relevanz, da nur Dummydaten geändert werden
- [X] Swagger-API vollständig - keine Relevanz, da nur Dummydaten geändert werden
- [X] Unit-Tests gepflegt - keine Relevanz, da nur Dummydaten geändert werden
- [X] Integrationstests gepflegt - keine Relevanz, da nur Dummydaten geändert werden
- [X] Beispiel-Requests gepflegt - keine Relevanz, da nur Dummydaten geändert werden
- [X] Oracle-Skripte verifiziert auf mit einer leeren DB

# Referenzen[^1]:

Verwandt mit Issue #1074 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added updated election schedule data for March 8, 2026, featuring three distinct election types: OB-Wahl, Stadtratswahl-Wahl, and Bezirksausschuss-Wahl.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->