### PR TITLE
add user notification service

### DIFF
--- a/wls-gui-admintool/package-lock.json
+++ b/wls-gui-admintool/package-lock.json
@@ -14,6 +14,7 @@
         "pinia": "3.0.1",
         "vue": "3.5.13",
         "vue-router": "4.5.0",
+        "vue3-toastify": "0.2.8",
         "vuetify": "3.7.18"
       },
       "devDependencies": {
@@ -7968,6 +7969,23 @@
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/vue3-toastify": {
+      "version": "0.2.8",
+      "integrity": "sha512-8jDOqsJaBZEbGpCbhWDETJc11D1lZefvgFPq/IPdM+U7+qyXoVPDvK6uq/FIgyV7qV0NcNzvGBMEzjsLQqGROw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20",
+        "npm": ">=9.0.0"
+      },
+      "peerDependencies": {
+        "vue": ">=3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/vuetify": {

--- a/wls-gui-admintool/package.json
+++ b/wls-gui-admintool/package.json
@@ -28,6 +28,7 @@
     "pinia": "3.0.1",
     "vue": "3.5.13",
     "vue-router": "4.5.0",
+    "vue3-toastify": "0.2.8",
     "vuetify": "3.7.18"
   },
   "devDependencies": {

--- a/wls-gui-admintool/src/composables/userNotification/userNotificationService.ts
+++ b/wls-gui-admintool/src/composables/userNotification/userNotificationService.ts
@@ -1,0 +1,36 @@
+import { toast } from "vue3-toastify";
+
+import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
+
+export function useUserNotificationService() {
+  const toastPosition = toast.POSITION.BOTTOM_LEFT;
+  const autoCloseInMs = 5000;
+
+  function addNotification(
+    message: string,
+    category: UserNotificationCategoryEnum
+  ) {
+    switch (category) {
+      case UserNotificationCategoryEnum.SUCCESS:
+        toast.success(message, {
+          autoClose: autoCloseInMs,
+          position: toastPosition,
+        });
+        break;
+      case UserNotificationCategoryEnum.WARNING:
+        toast.warning(message, {
+          autoClose: autoCloseInMs,
+          position: toastPosition,
+        });
+        break;
+      case UserNotificationCategoryEnum.ERROR:
+        toast.error(message, {
+          autoClose: false,
+          position: toastPosition,
+        });
+        break;
+    }
+  }
+
+  return { addNotification };
+}

--- a/wls-gui-admintool/src/main.ts
+++ b/wls-gui-admintool/src/main.ts
@@ -4,6 +4,7 @@ import App from "@/App.vue";
 import { registerPlugins } from "@/plugins";
 
 import "unfonts.css";
+import "vue3-toastify/dist/index.css";
 
 const app = createApp(App);
 

--- a/wls-gui-admintool/src/types/userNotification/UserNotificationCategoryEnum.ts
+++ b/wls-gui-admintool/src/types/userNotification/UserNotificationCategoryEnum.ts
@@ -1,0 +1,8 @@
+export const UserNotificationCategoryEnum = {
+  SUCCESS: "Success",
+  WARNING: "Warning",
+  ERROR: "Error",
+} as const;
+
+export type UserNotificationCategoryEnum =
+  (typeof UserNotificationCategoryEnum)[keyof typeof UserNotificationCategoryEnum];

--- a/wls-gui-admintool/tests/composables/userNotification/userNotificationService.spec.ts
+++ b/wls-gui-admintool/tests/composables/userNotification/userNotificationService.spec.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { toast } from "vue3-toastify";
+
+import { useUserNotificationService } from "@/composables/userNotification/userNotificationService.ts";
+import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
+
+vi.mock("vue3-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    POSITION: {
+      BOTTOM_LEFT: "bottom-left",
+    },
+  },
+}));
+
+describe("useUserNotificationService.ts", () => {
+  const notificationService = useUserNotificationService();
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should_callToastSuccess_when_calledWithSuccessCategory", () => {
+    const message = "Success";
+    notificationService.addNotification(
+      message,
+      UserNotificationCategoryEnum.SUCCESS
+    );
+
+    expect(toast.success).toHaveBeenCalledWith(message, {
+      autoClose: 5000,
+      position: toast.POSITION.BOTTOM_LEFT,
+    });
+  });
+
+  it("should_callToastWarning_when_calledWithWarningCategory", () => {
+    const message = "Warning";
+    notificationService.addNotification(
+      message,
+      UserNotificationCategoryEnum.WARNING
+    );
+
+    expect(toast.warning).toHaveBeenCalledWith(message, {
+      autoClose: 5000,
+      position: toast.POSITION.BOTTOM_LEFT,
+    });
+  });
+
+  it("should_callToastError_when_calledWithErrorCategory", () => {
+    const message = "Error";
+    notificationService.addNotification(
+      message,
+      UserNotificationCategoryEnum.ERROR
+    );
+
+    expect(toast.error).toHaveBeenCalledWith(message, {
+      autoClose: false,
+      position: toast.POSITION.BOTTOM_LEFT,
+    });
+  });
+
+  it("should_notCallAnyToast_when_calledWithUnknownCategory", () => {
+    const message = "Unknown";
+    // @ts-expect-error pass unknown category to the service
+    notificationService.addNotification(message, "UNKNOWN_CATEGORY");
+
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.warning).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Beschreibung:

Übernahme des UserNotification-Services als der wls-gui in die admin-gui

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [X] [Naming Conventions][naming-conventions-link] beachtet
- [X] Doku aktualisiert - nicht notwendig
- [x] Unit-Tests gepflegt
- [X] Komponententests gepflegt - keine neue Komponente

# Referenzen[^1]:

Verwandt mit Issue #1074

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a toast notification service that delivers user notifications for success, warning, and error messages, with automatic dismissal for some types and manual for errors.
	- Enhanced the application’s styling by integrating toast notification styles and providing a structured categorization for notification types.
	- Added a new dependency for improved toast notification functionality.

- **Tests**
	- Added a comprehensive test suite to ensure the new notification behaviors function correctly across different scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->