### PR TITLE
Neue Runconfigurations ohne dummy-clients und mit db-oracle

### DIFF
--- a/stack/run_configurations/AdminService - local,db-oracle.run.xml
+++ b/stack/run_configurations/AdminService - local,db-oracle.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="AdminService - local,db-oracle" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" folderName="local,integrated,oracle,sec">
+    <option name="ACTIVE_PROFILES" value="local,db-oracle" />
+    <module name="wls-admin-service" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="de.muenchen.oss.wahllokalsystem.adminservice.MicroServiceApplication" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/stack/run_configurations/AuthService - local,db-h2,dummy.ldap,db-dummydata.run.xml
+++ b/stack/run_configurations/AuthService - local,db-h2,dummy.ldap,db-dummydata.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="AuthService - local,db-h2,dummy.ldap,db-dummydata" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" folderName="local,integrated,sec">
+    <option name="ACTIVE_PROFILES" value="local,db-h2,dummy.ldap,db-dummydata" />
+    <module name="wls-auth-service" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="de.muenchen.oss.wahllokalsystem.authservice.MicroServiceApplication" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/stack/run_configurations/AuthService - local,db-oracle,dummy.ldap,db-dummydata.run.xml
+++ b/stack/run_configurations/AuthService - local,db-oracle,dummy.ldap,db-dummydata.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="AuthService - local,db-oracle,dummy.ldap,db-dummydata" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" folderName="local,integrated,sec">
+  <configuration default="false" name="AuthService - local,db-oracle,dummy.ldap,db-dummydata" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" folderName="local,integrated,oracle,sec">
     <option name="ACTIVE_PROFILES" value="local,db-oracle,dummy.ldap,db-dummydata" />
     <module name="wls-auth-service" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="de.muenchen.oss.wahllokalsystem.authservice.MicroServiceApplication" />

--- a/stack/run_configurations/BasisdatenService - local,db-oracle.run.xml
+++ b/stack/run_configurations/BasisdatenService - local,db-oracle.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="BasisdatenService - local,db-oracle" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" folderName="local,integrated,oracle,sec">
+    <option name="ACTIVE_PROFILES" value="local,db-oracle" />
+    <module name="wls-basisdaten-service" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="de.muenchen.oss.wahllokalsystem.basisdatenservice.MicroServiceApplication" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/stack/run_configurations/BriefwahlService - local,db-oracle.run.xml
+++ b/stack/run_configurations/BriefwahlService - local,db-oracle.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="BriefwahlService - local,db-oracle" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" folderName="local,integrated,oracle,sec">
+    <option name="ACTIVE_PROFILES" value="local,db-oracle" />
+    <module name="wls-briefwahl-service" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="de.muenchen.oss.wahllokalsystem.briefwahlservice.MicroServiceApplication" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/stack/run_configurations/BroadcastService - local,db-oracle.run.xml
+++ b/stack/run_configurations/BroadcastService - local,db-oracle.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="BroadcastService - local,db-oracle" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" folderName="local,integrated,oracle,sec">
+    <option name="ACTIVE_PROFILES" value="local,db-oracle" />
+    <module name="wls-broadcast-service" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="de.muenchen.oss.wahllokalsystem.broadcastservice.MicroServiceApplication" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/stack/run_configurations/EAIService - local,db-oracle,db-dummydata.run.xml
+++ b/stack/run_configurations/EAIService - local,db-oracle,db-dummydata.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="EAIService - local,db-oracle,db-dummydata" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" folderName="local,integrated,oracle,sec">
+    <option name="ACTIVE_PROFILES" value="local,db-oracle,db-dummydata" />
+    <module name="wls-eai-service" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="de.muenchen.oss.wahllokalsystem.eaiservice.MicroServiceApplication" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/stack/run_configurations/ErgebnismeldungService - local,db-oracle.run.xml
+++ b/stack/run_configurations/ErgebnismeldungService - local,db-oracle.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="ErgebnismeldungService - local,db-oracle" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" folderName="local,integrated,oracle,sec">
+    <option name="ACTIVE_PROFILES" value="local,db-oracle" />
+    <module name="wls-ergebnismeldung-service" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="de.muenchen.oss.wahllokalsystem.ergebnismeldungservice.MicroServiceApplication" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/stack/run_configurations/InfomanagementService - local,db-oracle.run.xml
+++ b/stack/run_configurations/InfomanagementService - local,db-oracle.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="InfomanagementService - local,db-oracle" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" folderName="local,integrated,oracle,sec">
+    <option name="ACTIVE_PROFILES" value="local,db-oracle" />
+    <module name="wls-infomanagement-service" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="de.muenchen.oss.wahllokalsystem.infomanagementservice.MicroServiceApplication" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/stack/run_configurations/MonitoringService - local,db-oracle.run.xml
+++ b/stack/run_configurations/MonitoringService - local,db-oracle.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="MonitoringService - local,db-oracle" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" folderName="local,integrated,oracle,sec">
+    <option name="ACTIVE_PROFILES" value="local,db-oracle" />
+    <module name="wls-monitoring-service" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="de.muenchen.oss.wahllokalsystem.monitoringservice.MicroServiceApplication" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/stack/run_configurations/VorfälleService - local,db-oracle.run.xml
+++ b/stack/run_configurations/VorfälleService - local,db-oracle.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="VorfälleService - local,db-oracle" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" folderName="local,integrated,oracle,sec">
+    <option name="ACTIVE_PROFILES" value="local,db-oracle" />
+    <module name="wls-vorfaelleundvorkommnisse-service" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="de.muenchen.oss.wahllokalsystem.vorfaelleundvorkommnisseservice.MicroServiceApplication" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/stack/run_configurations/WahlvorbereitungService - local,db-oracle.run.xml
+++ b/stack/run_configurations/WahlvorbereitungService - local,db-oracle.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="WahlvorbereitungService - local,db-oracle" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" folderName="local,integrated,oracle,sec">
+    <option name="ACTIVE_PROFILES" value="local,db-oracle" />
+    <module name="wls-wahlvorbereitung-service" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="de.muenchen.oss.wahllokalsystem.wahlvorbereitungservice.MicroServiceApplication" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/stack/run_configurations/WahlvorstandService - local,db-oracle.run.xml
+++ b/stack/run_configurations/WahlvorstandService - local,db-oracle.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="WahlvorstandService - local,db-oracle" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" folderName="local,integrated,oracle,sec">
+    <option name="ACTIVE_PROFILES" value="local,db-oracle" />
+    <module name="wls-wahlvorstand-service" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="de.muenchen.oss.wahllokalsystem.wahlvorstandservice.MicroServiceApplication" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
# Beschreibung:

Bisher hatten wir bei den Runconfigurations ohne dummy-clients nur h2 als DB dran. Bei der Entwicklung im Frontend musste ich an die Daten ran, was bei aktiver Security bei uns nicht mit h2 funktioniert. Daher habe ich zusätzliche Runconfigurations erstellt.

Für den auth-Service war die Config bereits auf oracle eingestellt daher habe ich zur Vollständigkeit eine h2-Version erstellt.

Die neuen Runconfigurations sind in einer neuen Gruppe `local,integrated,oracle,sec`.

‼‼ Bekannter Fehler: der AuthService started nicht weil Parameter für die rsa-Konfig fehlen. Das passe ich in einem separatem PR an.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

- [x] - gestest: h2 und oracle version gestartet. Alle Erfolgreich, ausgenommen dem Authservice (siehe bekannter Fehler)

# Referenzen[^1]:

Verwandt mit Issue #1074

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new run configurations for multiple services, including Admin, Auth, Basisdaten, Briefwahl, Broadcast, EAI, Ergebnismeldung, Infomanagement, Monitoring, Vorfälle, Wahlvorbereitung, and Wahlvorstand, to support local deployments with enhanced flexibility.

- **Configuration Improvements**
	- Updated the organizational grouping for one AuthService configuration to align with the latest deployment setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->