### PR TITLE
1159 offsetdatetime wird nicht korrekt übermittelt

### DIFF
--- a/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/ClientConfiguration.java
+++ b/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/ClientConfiguration.java
@@ -3,24 +3,24 @@ package de.muenchen.oss.wahllokalsystem.adminservice.configuration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.errorhandler.WlsResponseErrorHandler;
 import de.muenchen.oss.wahllokalsystem.wls.common.security.OAuth2TokenInterceptor;
-import lombok.val;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class ClientConfiguration {
 
     @Bean
-    public RestTemplate restTemplate(final WlsResponseErrorHandler wlsResponseErrorHandler, final OAuth2TokenInterceptor oAuth2TokenInterceptor) {
-        val restTemplate = new RestTemplate();
+    public RestTemplate restTemplate(RestTemplateBuilder builder, final WlsResponseErrorHandler wlsResponseErrorHandler,
+            final OAuth2TokenInterceptor oAuth2TokenInterceptor, final ObjectMapper objectMapper) {
 
-        /* definieren des Errorhandlers für Antworten vom externen Service */
-        restTemplate.setErrorHandler(wlsResponseErrorHandler);
-        /* Ergänzen eines Interceptors um den Bearer-Token an den nächsten Service weiter zu geben */
-        restTemplate.getInterceptors().add(oAuth2TokenInterceptor);
-
-        return restTemplate;
+        return builder
+                .additionalMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .errorHandler(wlsResponseErrorHandler)
+                .additionalInterceptors(oAuth2TokenInterceptor)
+                .build();
     }
 
     @Bean

--- a/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/ClientConfiguration.java
+++ b/wls-admin-service/src/main/java/de/muenchen/oss/wahllokalsystem/adminservice/configuration/ClientConfiguration.java
@@ -13,7 +13,7 @@ import org.springframework.web.client.RestTemplate;
 public class ClientConfiguration {
 
     @Bean
-    public RestTemplate restTemplate(RestTemplateBuilder builder, final WlsResponseErrorHandler wlsResponseErrorHandler,
+    public RestTemplate restTemplate(final RestTemplateBuilder builder, final WlsResponseErrorHandler wlsResponseErrorHandler,
             final OAuth2TokenInterceptor oAuth2TokenInterceptor, final ObjectMapper objectMapper) {
 
         return builder

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/ClientConfiguration.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/ClientConfiguration.java
@@ -3,24 +3,24 @@ package de.muenchen.oss.wahllokalsystem.authservice.configuration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.errorhandler.WlsResponseErrorHandler;
 import de.muenchen.oss.wahllokalsystem.wls.common.security.OAuth2TokenInterceptor;
-import lombok.val;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class ClientConfiguration {
 
     @Bean
-    public RestTemplate restTemplate(final WlsResponseErrorHandler wlsResponseErrorHandler, final OAuth2TokenInterceptor oAuth2TokenInterceptor) {
-        val restTemplate = new RestTemplate();
+    public RestTemplate restTemplate(RestTemplateBuilder builder, final WlsResponseErrorHandler wlsResponseErrorHandler,
+            final OAuth2TokenInterceptor oAuth2TokenInterceptor, final ObjectMapper objectMapper) {
 
-        /* definieren des Errorhandlers für Antworten vom externen Service */
-        restTemplate.setErrorHandler(wlsResponseErrorHandler);
-        /* Ergänzen eines Interceptors um den Bearer-Token an den nächsten Service weiter zu geben */
-        restTemplate.getInterceptors().add(oAuth2TokenInterceptor);
-
-        return restTemplate;
+        return builder
+                .additionalMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .errorHandler(wlsResponseErrorHandler)
+                .additionalInterceptors(oAuth2TokenInterceptor)
+                .build();
     }
 
     @Bean

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/ClientConfiguration.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/ClientConfiguration.java
@@ -13,7 +13,7 @@ import org.springframework.web.client.RestTemplate;
 public class ClientConfiguration {
 
     @Bean
-    public RestTemplate restTemplate(RestTemplateBuilder builder, final WlsResponseErrorHandler wlsResponseErrorHandler,
+    public RestTemplate restTemplate(final RestTemplateBuilder builder, final WlsResponseErrorHandler wlsResponseErrorHandler,
             final OAuth2TokenInterceptor oAuth2TokenInterceptor, final ObjectMapper objectMapper) {
 
         return builder

--- a/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/configuration/ClientConfiguration.java
+++ b/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/configuration/ClientConfiguration.java
@@ -13,7 +13,7 @@ import org.springframework.web.client.RestTemplate;
 public class ClientConfiguration {
 
     @Bean
-    public RestTemplate restTemplate(RestTemplateBuilder builder, final WlsResponseErrorHandler wlsResponseErrorHandler,
+    public RestTemplate restTemplate(final RestTemplateBuilder builder, final WlsResponseErrorHandler wlsResponseErrorHandler,
             final OAuth2TokenInterceptor oAuth2TokenInterceptor, final ObjectMapper objectMapper) {
 
         return builder

--- a/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/configuration/ClientConfiguration.java
+++ b/wls-basisdaten-service/src/main/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/configuration/ClientConfiguration.java
@@ -3,24 +3,24 @@ package de.muenchen.oss.wahllokalsystem.basisdatenservice.configuration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.errorhandler.WlsResponseErrorHandler;
 import de.muenchen.oss.wahllokalsystem.wls.common.security.OAuth2TokenInterceptor;
-import lombok.val;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class ClientConfiguration {
 
     @Bean
-    public RestTemplate restTemplate(final WlsResponseErrorHandler wlsResponseErrorHandler, final OAuth2TokenInterceptor oAuth2TokenInterceptor) {
-        val restTemplate = new RestTemplate();
+    public RestTemplate restTemplate(RestTemplateBuilder builder, final WlsResponseErrorHandler wlsResponseErrorHandler,
+            final OAuth2TokenInterceptor oAuth2TokenInterceptor, final ObjectMapper objectMapper) {
 
-        /* definieren des Errorhandlers für Antworten vom externen Service */
-        restTemplate.setErrorHandler(wlsResponseErrorHandler);
-        /* Ergänzen eines Interceptors um den Bearer-Token an den nächsten Service weiter zu geben */
-        restTemplate.getInterceptors().add(oAuth2TokenInterceptor);
-
-        return restTemplate;
+        return builder
+                .additionalMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .errorHandler(wlsResponseErrorHandler)
+                .additionalInterceptors(oAuth2TokenInterceptor)
+                .build();
     }
 
     @Bean

--- a/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/rest/wahltermindaten/WahltermindatenControllerIntegrationTest.java
+++ b/wls-basisdaten-service/src/test/java/de/muenchen/oss/wahllokalsystem/basisdatenservice/rest/wahltermindaten/WahltermindatenControllerIntegrationTest.java
@@ -62,6 +62,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -71,6 +72,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @AutoConfigureMockMvc
 @AutoConfigureWireMock
 @ActiveProfiles(profiles = { SPRING_TEST_PROFILE, SPRING_NO_SECURITY_PROFILE })
+@DirtiesContext
 public class WahltermindatenControllerIntegrationTest {
 
     @Autowired

--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/configuration/ClientConfiguration.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/configuration/ClientConfiguration.java
@@ -3,24 +3,24 @@ package de.muenchen.oss.wahllokalsystem.ergebnismeldungservice.configuration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.errorhandler.WlsResponseErrorHandler;
 import de.muenchen.oss.wahllokalsystem.wls.common.security.OAuth2TokenInterceptor;
-import lombok.val;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class ClientConfiguration {
 
     @Bean
-    public RestTemplate restTemplate(final WlsResponseErrorHandler wlsResponseErrorHandler, final OAuth2TokenInterceptor oAuth2TokenInterceptor) {
-        val restTemplate = new RestTemplate();
+    public RestTemplate restTemplate(RestTemplateBuilder builder, final WlsResponseErrorHandler wlsResponseErrorHandler,
+            final OAuth2TokenInterceptor oAuth2TokenInterceptor, final ObjectMapper objectMapper) {
 
-        /* definieren des Errorhandlers für Antworten vom externen Service */
-        restTemplate.setErrorHandler(wlsResponseErrorHandler);
-        /* Ergänzen eines Interceptors um den Bearer-Token an den nächsten Service weiter zu geben */
-        restTemplate.getInterceptors().add(oAuth2TokenInterceptor);
-
-        return restTemplate;
+        return builder
+                .additionalMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .errorHandler(wlsResponseErrorHandler)
+                .additionalInterceptors(oAuth2TokenInterceptor)
+                .build();
     }
 
     @Bean

--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/configuration/ClientConfiguration.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/configuration/ClientConfiguration.java
@@ -13,7 +13,7 @@ import org.springframework.web.client.RestTemplate;
 public class ClientConfiguration {
 
     @Bean
-    public RestTemplate restTemplate(RestTemplateBuilder builder, final WlsResponseErrorHandler wlsResponseErrorHandler,
+    public RestTemplate restTemplate(final RestTemplateBuilder builder, final WlsResponseErrorHandler wlsResponseErrorHandler,
             final OAuth2TokenInterceptor oAuth2TokenInterceptor, final ObjectMapper objectMapper) {
 
         return builder

--- a/wls-monitoring-service/src/main/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/ClientConfiguration.java
+++ b/wls-monitoring-service/src/main/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/ClientConfiguration.java
@@ -3,24 +3,24 @@ package de.muenchen.oss.wahllokalsystem.monitoringservice.configuration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.errorhandler.WlsResponseErrorHandler;
 import de.muenchen.oss.wahllokalsystem.wls.common.security.OAuth2TokenInterceptor;
-import lombok.val;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class ClientConfiguration {
 
     @Bean
-    public RestTemplate restTemplate(final WlsResponseErrorHandler wlsResponseErrorHandler, final OAuth2TokenInterceptor oAuth2TokenInterceptor) {
-        val restTemplate = new RestTemplate();
+    public RestTemplate restTemplate(RestTemplateBuilder builder, final WlsResponseErrorHandler wlsResponseErrorHandler,
+            final OAuth2TokenInterceptor oAuth2TokenInterceptor, final ObjectMapper objectMapper) {
 
-        /* definieren des Errorhandlers für Antworten vom externen Service */
-        restTemplate.setErrorHandler(wlsResponseErrorHandler);
-        /* Ergänzen eines Interceptors um den Bearer-Token an den nächsten Service weiter zu geben */
-        restTemplate.getInterceptors().add(oAuth2TokenInterceptor);
-
-        return restTemplate;
+        return builder
+                .additionalMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .errorHandler(wlsResponseErrorHandler)
+                .additionalInterceptors(oAuth2TokenInterceptor)
+                .build();
     }
 
     @Bean

--- a/wls-monitoring-service/src/main/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/ClientConfiguration.java
+++ b/wls-monitoring-service/src/main/java/de/muenchen/oss/wahllokalsystem/monitoringservice/configuration/ClientConfiguration.java
@@ -13,7 +13,7 @@ import org.springframework.web.client.RestTemplate;
 public class ClientConfiguration {
 
     @Bean
-    public RestTemplate restTemplate(RestTemplateBuilder builder, final WlsResponseErrorHandler wlsResponseErrorHandler,
+    public RestTemplate restTemplate(final RestTemplateBuilder builder, final WlsResponseErrorHandler wlsResponseErrorHandler,
             final OAuth2TokenInterceptor oAuth2TokenInterceptor, final ObjectMapper objectMapper) {
 
         return builder

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/rest/wahllokalzustand/WahllokalZustandControllerIntegrationTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/rest/wahllokalzustand/WahllokalZustandControllerIntegrationTest.java
@@ -1,9 +1,12 @@
 package de.muenchen.oss.wahllokalsystem.monitoringservice.rest.wahllokalzustand;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static de.muenchen.oss.wahllokalsystem.monitoringservice.TestConstants.SPRING_NO_SECURITY_PROFILE;
 import static de.muenchen.oss.wahllokalsystem.monitoringservice.TestConstants.SPRING_TEST_PROFILE;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import de.muenchen.oss.wahllokalsystem.monitoringservice.MicroServiceApplication;
@@ -12,6 +15,7 @@ import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExcept
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExceptionDTO;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.util.ExceptionKonstanten;
 import de.muenchen.oss.wahllokalsystem.wls.common.security.domain.BezirkUndWahlID;
+import java.time.LocalDateTime;
 import lombok.val;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -211,6 +215,39 @@ class WahllokalZustandControllerIntegrationTest {
 
             Assertions.assertThat(responseBodyAsWlsExceptionDTO_wahlbezirkID_empty).usingRecursiveComparison().ignoringFields("message")
                     .isEqualTo(expectedWlsExceptionDTO);
+        }
+
+        @Test
+        void should_notThrowAnyException_when_requestParamValidAndLocalDateTimeGotTimezone() throws Exception {
+            val request_valid_param = MockMvcRequestBuilders.post("/businessActions/niederschriftDruckuhrzeit").with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                            {
+                              "druckuhrzeit": "2024-10-21T23:59:12.123Z",
+                              "bezirkUndWahlID": {
+                                "wahlID": "wahlID",
+                                "wahlbezirkID": "wahlbezirkID"
+                              }
+                            }""");
+            Assertions.assertThatNoException().isThrownBy(() -> mockMvc.perform(request_valid_param));
+        }
+
+        @Test
+        void should_convertTimeToJsonFormat_when_restCallWithTimestamp() throws Exception {
+            val validDruckDatenDTO = DruckdatenDTO.builder()
+                    .druckuhrzeit(LocalDateTime.parse("2024-10-21T23:59:12.123"))
+                    .bezirkUndWahlID(new BezirkUndWahlID("wahlID", "wahlbezirkID")).build();
+            val request_wahlbezirkID_empty = MockMvcRequestBuilders.post("/businessActions/niederschriftDruckuhrzeit").with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON).content(
+                            objectMapper.writeValueAsString(validDruckDatenDTO));
+
+            mockMvc.perform(request_wahlbezirkID_empty);
+
+            WireMock.verify(WireMock.postRequestedFor(WireMock.urlEqualTo("/wahllokalzustand"))
+                    .withHeader("Content-Type", equalTo("application/json"))
+                    .withRequestBody(matchingJsonPath("$.wahlbezirkID", equalTo("wahlbezirkID")))
+                    .withRequestBody(matchingJsonPath("$.druckzustaende[0].wahlID", equalTo("wahlID")))
+                    .withRequestBody(matchingJsonPath("$.druckzustaende[0].niederschriftDruckUhrzeit", equalTo("2024-10-21T23:59:12.123Z"))));
         }
 
     }

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/service/wahllokalzustand/WahllokalZustandServiceSecurityTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/service/wahllokalzustand/WahllokalZustandServiceSecurityTest.java
@@ -11,10 +11,10 @@ import de.muenchen.oss.wahllokalsystem.monitoringservice.eai.aou.model.Wahllokal
 import de.muenchen.oss.wahllokalsystem.monitoringservice.utils.Authorities;
 import de.muenchen.oss.wahllokalsystem.wls.common.security.domain.BezirkUndWahlID;
 import de.muenchen.oss.wahllokalsystem.wls.common.testing.SecurityUtils;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.Set;
 import lombok.val;
-import java.time.LocalDateTime;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -24,11 +24,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(classes = MicroServiceApplication.class)
 @ActiveProfiles({ TestConstants.SPRING_TEST_PROFILE })
 @AutoConfigureWireMock
+@DirtiesContext
 public class WahllokalZustandServiceSecurityTest {
 
     @Autowired

--- a/wls-wahlvorstand-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/configuration/ClientConfiguration.java
+++ b/wls-wahlvorstand-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/configuration/ClientConfiguration.java
@@ -13,7 +13,7 @@ import org.springframework.web.client.RestTemplate;
 public class ClientConfiguration {
 
     @Bean
-    public RestTemplate restTemplate(RestTemplateBuilder builder, final WlsResponseErrorHandler wlsResponseErrorHandler,
+    public RestTemplate restTemplate(final RestTemplateBuilder builder, final WlsResponseErrorHandler wlsResponseErrorHandler,
             final OAuth2TokenInterceptor oAuth2TokenInterceptor, final ObjectMapper objectMapper) {
 
         return builder

--- a/wls-wahlvorstand-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/configuration/ClientConfiguration.java
+++ b/wls-wahlvorstand-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorstandservice/configuration/ClientConfiguration.java
@@ -3,24 +3,24 @@ package de.muenchen.oss.wahllokalsystem.wahlvorstandservice.configuration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.errorhandler.WlsResponseErrorHandler;
 import de.muenchen.oss.wahllokalsystem.wls.common.security.OAuth2TokenInterceptor;
-import lombok.val;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class ClientConfiguration {
 
     @Bean
-    public RestTemplate restTemplate(final WlsResponseErrorHandler wlsResponseErrorHandler, final OAuth2TokenInterceptor oAuth2TokenInterceptor) {
-        val restTemplate = new RestTemplate();
+    public RestTemplate restTemplate(RestTemplateBuilder builder, final WlsResponseErrorHandler wlsResponseErrorHandler,
+            final OAuth2TokenInterceptor oAuth2TokenInterceptor, final ObjectMapper objectMapper) {
 
-        /* definieren des Errorhandlers für Antworten vom externen Service */
-        restTemplate.setErrorHandler(wlsResponseErrorHandler);
-        /* Ergänzen eines Interceptors um den Bearer-Token an den nächsten Service weiter zu geben */
-        restTemplate.getInterceptors().add(oAuth2TokenInterceptor);
-
-        return restTemplate;
+        return builder
+                .additionalMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .errorHandler(wlsResponseErrorHandler)
+                .additionalInterceptors(oAuth2TokenInterceptor)
+                .build();
     }
 
     @Bean


### PR DESCRIPTION
# Beschreibung:
- Rest-Template configs erweitert, damit sie mit LocalDateTime umgehen können
- int tests erweitert

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [xIntegrationstests gepflegt


# Referenzen[^1]:

Verwandt mit Issue #

Closes #1159 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the configuration of HTTP clients across multiple services for more streamlined API communication and improved reliability.

- **Tests**
  - Added integration tests to verify robust timestamp formatting and ensure that requests with date/time fields are processed as expected.
  - Introduced `@DirtiesContext` annotation to improve test isolation in the `WahltermindatenControllerIntegrationTest`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->