### PR TITLE
Alias @tests für Dateien im Test-Ordner erstellt

### DIFF
--- a/wls-gui-wahllokalsystem/tests/components/common/inputs/BaseNumberInput.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/components/common/inputs/BaseNumberInput.spec.ts
@@ -1,3 +1,4 @@
+import { getSnapshotFilename } from "@tests/utils/testutils.ts";
 import { enableAutoUnmount, mount, VueWrapper } from "@vue/test-utils";
 import { createPinia } from "pinia";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -10,7 +11,6 @@ import * as directives from "vuetify/directives";
 import BaseNumberInput from "@/components/common/inputs/BaseNumberInput.vue";
 import pinia from "@/plugins/pinia";
 import { MAX_NUMBER, MIN_NUMBER, REQUIRED } from "@/util/rules.ts";
-import { getSnapshotFilename } from "../../../utils/testutils.ts";
 
 describe("BaseNumberInput.vue", () => {
   let vuetify: ReturnType<typeof createVuetify>;

--- a/wls-gui-wahllokalsystem/tests/components/wahlvorstand/TheWahlvorstandAnwesenheitRequirementCard.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/components/wahlvorstand/TheWahlvorstandAnwesenheitRequirementCard.spec.ts
@@ -1,4 +1,5 @@
 import { createTestingPinia } from "@pinia/testing";
+import { getSnapshotFilename } from "@tests/utils/testutils";
 import { enableAutoUnmount, mount, VueWrapper } from "@vue/test-utils";
 import { createPinia } from "pinia";
 import {
@@ -17,7 +18,6 @@ import * as directives from "vuetify/directives";
 
 import TheWahlvorstandAnwesenheitRequirementCard from "@/components/wahlvorstand/TheWahlvorstandAnwesenheitRequirementCard.vue";
 import { useWahlvorstandStore } from "@/stores/wahlvorstandStore";
-import { getSnapshotFilename } from "../../utils/testutils";
 
 describe("TheWahlvorstandAnwesenheitRequirementCard.vue", () => {
   let vuetify: ReturnType<typeof createVuetify>;

--- a/wls-gui-wahllokalsystem/tests/components/wahlvorstand/TheWahlvorstandMitgliederTable.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/components/wahlvorstand/TheWahlvorstandMitgliederTable.spec.ts
@@ -1,6 +1,7 @@
 import type { Wahlvorstandsmitglied } from "@/types/wahlvorstand/Wahlvorstandsmitglied";
 
 import { createTestingPinia } from "@pinia/testing";
+import { getSnapshotFilename } from "@tests/utils/testutils";
 import { enableAutoUnmount, mount, VueWrapper } from "@vue/test-utils";
 import { createPinia } from "pinia";
 import {
@@ -20,7 +21,6 @@ import * as directives from "vuetify/directives";
 import TheWahlvorstandMitgliederTable from "@/components/wahlvorstand/TheWahlvorstandMitgliederTable.vue";
 import { useWahlvorstandStore } from "@/stores/wahlvorstandStore";
 import { WahlvorstandsmitgliedBuilder } from "@/types/wahlvorstand/Wahlvorstandsmitglied";
-import { getSnapshotFilename } from "../../utils/testutils";
 
 describe("TheWahlvorstandMitgliederTable.vue", () => {
   let vuetify: ReturnType<typeof createVuetify>;

--- a/wls-gui-wahllokalsystem/tsconfig.app.json
+++ b/wls-gui-wahllokalsystem/tsconfig.app.json
@@ -12,7 +12,8 @@
     "composite": true,
     "tsBuildInfoFile": "./cache/tsconfig.app.tsbuildinfo",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@tests/*": ["./tests/*"]
     },
     "allowSyntheticDefaultImports": true
   }

--- a/wls-gui-wahllokalsystem/vite.config.ts
+++ b/wls-gui-wahllokalsystem/vite.config.ts
@@ -70,6 +70,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),
+      "@tests": fileURLToPath(new URL("./tests", import.meta.url)),
     },
   },
 });


### PR DESCRIPTION
# Beschreibung:

- Analog zu der Änderung mit #1163 im admin-gui
- die Import in spec.ts-Dateien mit `../` wurden ersetzt
- ‼‼‼‼ Damit keine Fehler im Code angezeigt werden ist ein Neustart der IDE erforderlich

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [X] Doku aktualisiert
- [X] Unit-Tests gepflegt
- [x] Komponententests gepflegt

# Referenzen[^1]:

Verwandt mit Issue #1163

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Standardized internal test references to ensure a more consistent testing experience.
- **Chores**
	- Enhanced project configuration by introducing a new alias for internal modules, streamlining dependency resolution across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->