### PR TITLE
Broadcast-Service - Einhaltung der Abhängigkeiten 

### DIFF
--- a/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/archunit/ArchUnitTest.java
+++ b/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/archunit/ArchUnitTest.java
@@ -8,6 +8,7 @@ import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.ArchRule;
 import de.muenchen.oss.wahllokalsystem.broadcastservice.MicroServiceApplication;
 import de.muenchen.oss.wahllokalsystem.wls.common.testing.archunit.condition.NestedTestsuitesHaveMatchingMethodCondition;
+import de.muenchen.oss.wahllokalsystem.wls.common.testing.archunit.rule.ClassRules;
 import de.muenchen.oss.wahllokalsystem.wls.common.testing.archunit.rule.MethodRules;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -22,6 +23,7 @@ public class ArchUnitTest {
 
     private static JavaClasses allTestClasses;
     private static JavaClasses allClasses;
+    private static JavaClasses allClassesWithoutTests;
 
     @BeforeAll
     static void init() {
@@ -30,6 +32,10 @@ public class ArchUnitTest {
                 .importPackages(MicroServiceApplication.class.getPackage().getName());
 
         allClasses = new ClassFileImporter()
+                .importPackages(MicroServiceApplication.class.getPackage().getName());
+
+        allClassesWithoutTests = new ClassFileImporter()
+                .withImportOption(new ImportOption.DoNotIncludeTests())
                 .importPackages(MicroServiceApplication.class.getPackage().getName());
     }
 
@@ -43,6 +49,12 @@ public class ArchUnitTest {
     @MethodSource("allClassesRulesToVerify")
     void should_verifyArchUnitRuleForAllClasses_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allClasses);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("allClassesWithoutTestsRulesToVerify")
+    void should_verifyArchUnitRuleForAllClassesWithoutTests_when_running(final ArgumentsAccessor arguments) {
+        arguments.get(1, ArchRule.class).check(allClassesWithoutTests);
     }
 
     public static Stream<Arguments> allTestClassesRulesToVerify() {
@@ -66,4 +78,25 @@ public class ArchUnitTest {
     private static final ArchRule RULE_NESTED_TESTSUITE_HAS_CORRESPONDING_PUBLIC_METHOD_CONVENTION_MATCHED = classes()
             .that().areAnnotatedWith(Nested.class).should(new NestedTestsuitesHaveMatchingMethodCondition(Set.of(
                     "BroadcastControllerIntegrationTest", "BroadcastServiceSecurityTest", "ArchUnitTest", "MessageValidationTest")));
+
+    private static Stream<Arguments> allClassesWithoutTestsRulesToVerify() {
+        return Stream.of(
+                //--- rest rules
+                Arguments.of("DATAMODEL_IN_REST_ENDS_WITH_DTO_CONVENTION_MATCHED",
+                        ClassRules.RULE_DATAMODEL_IN_REST_ENDS_WITH_DTO_CONVENTION_MATCHED),
+                Arguments.of("RULE_NO_DTOS_OR_CONTROLLERS_OUTSIDE_OF_REST_PACKAGE_CONVENTION_MATCHED",
+                        ClassRules.RULE_NO_DTOS_OR_CONTROLLERS_OUTSIDE_OF_REST_PACKAGE_CONVENTION_MATCHED),
+                Arguments.of("RULE_NO_DATAMODEL_CROSS_DEPENDENCIES_INSIDE_REST_CONVENTION_MATCHED",
+                        ClassRules.RULE_NO_DATAMODEL_CROSS_DEPENDENCIES_INSIDE_REST_CONVENTION_MATCHED),
+                //--- service rules
+                Arguments.of("RULE_NO_MODELS_OR_SERVICES_OUTSIDE_OF_SERVICE_PACKAGE_CONVENTION_MATCHED",
+                        ClassRules.RULE_NO_MODELS_OR_SERVICES_OUTSIDE_OF_SERVICE_PACKAGE_CONVENTION_MATCHED),
+                //--- domain rules
+                Arguments.of("RULE_DATAMODEL_IN_DOMAIN_HAS_NO_ENDING_CONVENTION_MATCHED",
+                        ClassRules.RULE_DATAMODEL_IN_DOMAIN_HAS_NO_ENDING_CONVENTION_MATCHED),
+                Arguments.of("RULE_NO_ENTITIES_OR_REPOS_OUTSIDE_OF_DOMAIN_PACKAGE_CONVENTION_MATCHED",
+                        ClassRules.RULE_NO_ENTITIES_OR_REPOS_OUTSIDE_OF_DOMAIN_PACKAGE_CONVENTION_MATCHED),
+                Arguments.of("RULE_NO_CROSS_DEPENDENCIES_INSIDE_DOMAIN_CONVENTION_MATCHED",
+                        ClassRules.RULE_NO_CROSS_DEPENDENCIES_INSIDE_DOMAIN_CONVENTION_MATCHED));
+    }
 }


### PR DESCRIPTION
# Beschreibung:

- arch unit rules eingefügt
- die rules `RULE_NO_DATAMODEL_CROSS_DEPENDENCIES_INSIDE_SERVICE_CONVENTION_MATCHED` und `RULE_DATAMODEL_IN_SERVICE_ENDS_WITH_MODEL_CONVENTION_MATCHED` wurden weggelassen, weil es keine Datenmodelle im `service`-package gibt
- die rules `RULE_NO_CROSS_DEPENDENCIES_INSIDE_REST_CONVENTION_MATCHED` und `RULE_NO_CROSS_DEPENDENCIES_INSIDE_SERVICE_CONVENTION_MATCHED` wurden weggelassen, weil die abhängigkeiten durch das [shared Datenmodell](https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr002-controller-service-datamodels.html) so gewollt sind

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Unit-Tests gepflegt

# Referenzen[^1]:

Closes #1005

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Introduced a new parameterized test to verify architectural rules for classes without associated tests.
  - Added a static variable to streamline the import of relevant classes while excluding test classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->