### PR TITLE
EAI-Service - Einhaltung der Abhängigkeiten

### DIFF
--- a/wls-eai-service/src/test/java/de/muenchen/oss/wahllokalsystem/eaiservice/archunit/ArchUnitTest.java
+++ b/wls-eai-service/src/test/java/de/muenchen/oss/wahllokalsystem/eaiservice/archunit/ArchUnitTest.java
@@ -18,6 +18,8 @@ public class ArchUnitTest {
 
     private static JavaClasses allTestClasses;
     private static JavaClasses allClasses;
+    private static JavaClasses allClassesWithoutTests;
+    //private static final ImportOption ignoreGeneratedCode = location -> !location.contains("/eai");
 
     @BeforeAll
     static void init() {
@@ -26,6 +28,11 @@ public class ArchUnitTest {
                 .importPackages(MicroServiceApplication.class.getPackage().getName());
 
         allClasses = new ClassFileImporter()
+                .importPackages(MicroServiceApplication.class.getPackage().getName());
+
+        allClassesWithoutTests = new ClassFileImporter()
+                .withImportOption(new ImportOption.DoNotIncludeTests())
+                //.withImportOption(ignoreGeneratedCode)
                 .importPackages(MicroServiceApplication.class.getPackage().getName());
     }
 
@@ -39,6 +46,12 @@ public class ArchUnitTest {
     @MethodSource("allClassesRulesToVerify")
     void should_verifyArchUnitRuleForAllClasses_when_running(final ArgumentsAccessor arguments) {
         arguments.get(1, ArchRule.class).check(allClasses);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("allClassesWithoutTestsRulesToVerify")
+    void should_verifyArchUnitRuleForAllClassesWithoutTests_when_running(final ArgumentsAccessor arguments) {
+        arguments.get(1, ArchRule.class).check(allClassesWithoutTests);
     }
 
     public static Stream<Arguments> allTestClassesRulesToVerify() {
@@ -55,5 +68,26 @@ public class ArchUnitTest {
                         ClassRules.RULE_NESTED_TESTSUITE_HAS_CORRESPONDING_PUBLIC_METHOD_CONVENTION_MATCHED),
                 Arguments.of("RULE_TESTCLASSES_END_WITH_TEST_CONVENTION_MATCHED",
                         MethodRules.RULE_TESTCLASSES_END_WITH_TEST_CONVENTION_MATCHED));
+    }
+
+    private static Stream<Arguments> allClassesWithoutTestsRulesToVerify() {
+        return Stream.of(
+                //--- rest rules
+                Arguments.of("DATAMODEL_IN_REST_ENDS_WITH_DTO_CONVENTION_MATCHED",
+                        ClassRules.RULE_DATAMODEL_IN_REST_ENDS_WITH_DTO_CONVENTION_MATCHED),
+                Arguments.of("RULE_NO_DTOS_OR_CONTROLLERS_OUTSIDE_OF_REST_PACKAGE_CONVENTION_MATCHED",
+                        ClassRules.RULE_NO_DTOS_OR_CONTROLLERS_OUTSIDE_OF_REST_PACKAGE_CONVENTION_MATCHED),
+                Arguments.of("RULE_NO_DATAMODEL_CROSS_DEPENDENCIES_INSIDE_REST_CONVENTION_MATCHED",
+                        ClassRules.RULE_NO_DATAMODEL_CROSS_DEPENDENCIES_INSIDE_REST_CONVENTION_MATCHED),
+                //--- service rules
+                Arguments.of("RULE_NO_MODELS_OR_SERVICES_OUTSIDE_OF_SERVICE_PACKAGE_CONVENTION_MATCHED",
+                        ClassRules.RULE_NO_MODELS_OR_SERVICES_OUTSIDE_OF_SERVICE_PACKAGE_CONVENTION_MATCHED),
+                //--- domain rules
+                Arguments.of("RULE_DATAMODEL_IN_DOMAIN_HAS_NO_ENDING_CONVENTION_MATCHED",
+                        ClassRules.RULE_DATAMODEL_IN_DOMAIN_HAS_NO_ENDING_CONVENTION_MATCHED),
+                Arguments.of("RULE_NO_ENTITIES_OR_REPOS_OUTSIDE_OF_DOMAIN_PACKAGE_CONVENTION_MATCHED",
+                        ClassRules.RULE_NO_ENTITIES_OR_REPOS_OUTSIDE_OF_DOMAIN_PACKAGE_CONVENTION_MATCHED),
+                Arguments.of("RULE_NO_CROSS_DEPENDENCIES_INSIDE_DOMAIN_CONVENTION_MATCHED",
+                        ClassRules.RULE_NO_CROSS_DEPENDENCIES_INSIDE_DOMAIN_CONVENTION_MATCHED));
     }
 }

--- a/wls-eai-service/src/test/java/de/muenchen/oss/wahllokalsystem/eaiservice/archunit/ArchUnitTest.java
+++ b/wls-eai-service/src/test/java/de/muenchen/oss/wahllokalsystem/eaiservice/archunit/ArchUnitTest.java
@@ -19,7 +19,6 @@ public class ArchUnitTest {
     private static JavaClasses allTestClasses;
     private static JavaClasses allClasses;
     private static JavaClasses allClassesWithoutTests;
-    //private static final ImportOption ignoreGeneratedCode = location -> !location.contains("/eai");
 
     @BeforeAll
     static void init() {
@@ -32,7 +31,6 @@ public class ArchUnitTest {
 
         allClassesWithoutTests = new ClassFileImporter()
                 .withImportOption(new ImportOption.DoNotIncludeTests())
-                //.withImportOption(ignoreGeneratedCode)
                 .importPackages(MicroServiceApplication.class.getPackage().getName());
     }
 


### PR DESCRIPTION
# Beschreibung:

- arch unit rules eingefügt
- die rules `RULE_NO_DATAMODEL_CROSS_DEPENDENCIES_INSIDE_SERVICE_CONVENTION_MATCHED` und `RULE_DATAMODEL_IN_SERVICE_ENDS_WITH_MODEL_CONVENTION_MATCHED` wurden weggelassen, weil es keine Datenmodelle im `service`-package gibt
- die rules `RULE_NO_CROSS_DEPENDENCIES_INSIDE_REST_CONVENTION_MATCHED` und `RULE_NO_CROSS_DEPENDENCIES_INSIDE_SERVICE_CONVENTION_MATCHED` wurden weggelassen, weil die abhängigkeiten durch das [shared Datenmodell](https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr002-controller-service-datamodels.html) so gewollt sind

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Unit-Tests gepflegt

# Referenzen[^1]:

Closes #1006

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enhanced internal validation checks to ensure adherence to the application's architectural standards, bolstering system reliability and code quality.
  - Introduced a new test method to verify architectural rules specifically for classes without tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->