### PR TITLE
Sessionrestriktionen und -migration deaktiviert

### DIFF
--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/SecurityConfiguration.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/SecurityConfiguration.java
@@ -103,22 +103,22 @@ public class SecurityConfiguration {
     public SecurityFilterChain filterChain(HttpSecurity http, SessionRegistry sessionRegistry) throws Exception {
         http
                 .authorizeHttpRequests((requests) -> requests.requestMatchers(
-                                // allow access to /actuator/info
-                                AntPathRequestMatcher.antMatcher("/actuator/info"),
-                                // allow access to /actuator/health for OpenShift Health Check
-                                AntPathRequestMatcher.antMatcher("/actuator/health"),
-                                // allow access to /actuator/health/liveness for OpenShift Liveness Check
-                                AntPathRequestMatcher.antMatcher("/actuator/health/liveness"),
-                                // allow access to /actuator/health/readiness for OpenShift Readiness Check
-                                AntPathRequestMatcher.antMatcher("/actuator/health/readiness"),
-                                // allow access to /actuator/metrics for Prometheus monitoring in OpenShift
-                                AntPathRequestMatcher.antMatcher("/actuator/metrics"),
-                                AntPathRequestMatcher.antMatcher("/v3/api-docs/**"),
-                                AntPathRequestMatcher.antMatcher("/swagger-ui/**"),
-                                AntPathRequestMatcher.antMatcher("/"),
-                                AntPathRequestMatcher.antMatcher("/home"),
-                                AntPathRequestMatcher.antMatcher("/css/*"),
-                                AntPathRequestMatcher.antMatcher("/js/*"))
+                        // allow access to /actuator/info
+                        AntPathRequestMatcher.antMatcher("/actuator/info"),
+                        // allow access to /actuator/health for OpenShift Health Check
+                        AntPathRequestMatcher.antMatcher("/actuator/health"),
+                        // allow access to /actuator/health/liveness for OpenShift Liveness Check
+                        AntPathRequestMatcher.antMatcher("/actuator/health/liveness"),
+                        // allow access to /actuator/health/readiness for OpenShift Readiness Check
+                        AntPathRequestMatcher.antMatcher("/actuator/health/readiness"),
+                        // allow access to /actuator/metrics for Prometheus monitoring in OpenShift
+                        AntPathRequestMatcher.antMatcher("/actuator/metrics"),
+                        AntPathRequestMatcher.antMatcher("/v3/api-docs/**"),
+                        AntPathRequestMatcher.antMatcher("/swagger-ui/**"),
+                        AntPathRequestMatcher.antMatcher("/"),
+                        AntPathRequestMatcher.antMatcher("/home"),
+                        AntPathRequestMatcher.antMatcher("/css/*"),
+                        AntPathRequestMatcher.antMatcher("/js/*"))
                         .permitAll()
                         .anyRequest().authenticated())
                 .oauth2ResourceServer(httpSecurityOAuth2ResourceServerConfigurer -> httpSecurityOAuth2ResourceServerConfigurer

--- a/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/SecurityConfiguration.java
+++ b/wls-auth-service/src/main/java/de/muenchen/oss/wahllokalsystem/authservice/configuration/SecurityConfiguration.java
@@ -103,22 +103,22 @@ public class SecurityConfiguration {
     public SecurityFilterChain filterChain(HttpSecurity http, SessionRegistry sessionRegistry) throws Exception {
         http
                 .authorizeHttpRequests((requests) -> requests.requestMatchers(
-                        // allow access to /actuator/info
-                        AntPathRequestMatcher.antMatcher("/actuator/info"),
-                        // allow access to /actuator/health for OpenShift Health Check
-                        AntPathRequestMatcher.antMatcher("/actuator/health"),
-                        // allow access to /actuator/health/liveness for OpenShift Liveness Check
-                        AntPathRequestMatcher.antMatcher("/actuator/health/liveness"),
-                        // allow access to /actuator/health/readiness for OpenShift Readiness Check
-                        AntPathRequestMatcher.antMatcher("/actuator/health/readiness"),
-                        // allow access to /actuator/metrics for Prometheus monitoring in OpenShift
-                        AntPathRequestMatcher.antMatcher("/actuator/metrics"),
-                        AntPathRequestMatcher.antMatcher("/v3/api-docs/**"),
-                        AntPathRequestMatcher.antMatcher("/swagger-ui/**"),
-                        AntPathRequestMatcher.antMatcher("/"),
-                        AntPathRequestMatcher.antMatcher("/home"),
-                        AntPathRequestMatcher.antMatcher("/css/*"),
-                        AntPathRequestMatcher.antMatcher("/js/*"))
+                                // allow access to /actuator/info
+                                AntPathRequestMatcher.antMatcher("/actuator/info"),
+                                // allow access to /actuator/health for OpenShift Health Check
+                                AntPathRequestMatcher.antMatcher("/actuator/health"),
+                                // allow access to /actuator/health/liveness for OpenShift Liveness Check
+                                AntPathRequestMatcher.antMatcher("/actuator/health/liveness"),
+                                // allow access to /actuator/health/readiness for OpenShift Readiness Check
+                                AntPathRequestMatcher.antMatcher("/actuator/health/readiness"),
+                                // allow access to /actuator/metrics for Prometheus monitoring in OpenShift
+                                AntPathRequestMatcher.antMatcher("/actuator/metrics"),
+                                AntPathRequestMatcher.antMatcher("/v3/api-docs/**"),
+                                AntPathRequestMatcher.antMatcher("/swagger-ui/**"),
+                                AntPathRequestMatcher.antMatcher("/"),
+                                AntPathRequestMatcher.antMatcher("/home"),
+                                AntPathRequestMatcher.antMatcher("/css/*"),
+                                AntPathRequestMatcher.antMatcher("/js/*"))
                         .permitAll()
                         .anyRequest().authenticated())
                 .oauth2ResourceServer(httpSecurityOAuth2ResourceServerConfigurer -> httpSecurityOAuth2ResourceServerConfigurer
@@ -126,12 +126,6 @@ public class SecurityConfiguration {
                 .formLogin((form) -> form
                         .loginPage(LOGIN_PATH)
                         .permitAll())
-                .sessionManagement(customizer -> customizer
-                        .sessionFixation().migrateSession()
-                        .maximumSessions(1)
-                        .expiredUrl(LOGIN_PATH)
-                        .maxSessionsPreventsLogin(false)
-                        .sessionRegistry(sessionRegistry))
                 .logout(LogoutConfigurer::permitAll)
                 .securityContext(securityContext -> securityContext.requireExplicitSave(false))
                 .addFilterBefore(customUsernamePasswordAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
# Beschreibung:

- ist aktuell die Ursache für das Problem in #786 
- ausgebaut damit es noch einmal Grundlegend angegangen werden kann
  - die Anforderung, dass sich ein Benutzer nur einmal einloggen darf, in #863 aufgenommen
  - die aktuellen Einstellungen sind fehlerhaft und führen zu Problemen, u.a. durch Verwirrung, bei der Entwicklung

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [X] [Naming Conventions][naming-conventions-link] beachtet - kein Update
- [X] Doku aktualisiert - kein Update
- [X] Swagger-API vollständig - kein Update
- [X] Unit-Tests gepflegt - kein Update
- [x] Integrationstests gepflegt - kein Update
- [X] Beispiel-Requests gepflegt - kein Update

# Referenzen[^1]:

Verwandt mit Issue
- #786
- #863

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined security settings by removing session management configuration; core service endpoints remain accessible to all users for a consistent experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->