### PR TITLE
add wls-gui-admintool as option

### DIFF
--- a/.github/workflows/dispatch-create-github-container-image-frontend.yml
+++ b/.github/workflows/dispatch-create-github-container-image-frontend.yml
@@ -9,6 +9,7 @@ on:
         description: frontend-service/directory to build (wls-gui-wahllokalsystem, ...)
         options:
           - wls-gui-wahllokalsystem
+          - wls-gui-admintool
       tag:
         required: false
         description: 'optional: gittag'


### PR DESCRIPTION
# Beschreibung:

- Erweiterung der Auswahl für welchen Service der Build erfolgen soll um Admintool
- Ist Voraussetzung damit Images für bestimmte Tags/Branches des Admintools gebaut werden können

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

# Referenzen[^1]:

Verwandt mit Issue #906

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a new selectable option, `wls-gui-admintool`, to the service choices in the GitHub Actions workflow for container image creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->