### PR TITLE
update vuetify defaults

### DIFF
--- a/wls-gui-wahllokalsystem/src/plugins/vuetify.ts
+++ b/wls-gui-wahllokalsystem/src/plugins/vuetify.ts
@@ -58,4 +58,10 @@ export default createVuetify({
       },
     },
   },
+  defaults: {
+    VCardTitle: {
+      style: "background-color: #eeeeee; border-bottom: 1px solid #bcbcbc;",
+      class: "mb-2",
+    },
+  },
 });

--- a/wls-gui-wahllokalsystem/src/plugins/vuetify.ts
+++ b/wls-gui-wahllokalsystem/src/plugins/vuetify.ts
@@ -60,8 +60,7 @@ export default createVuetify({
   },
   defaults: {
     VCardTitle: {
-      style: "background-color: #eeeeee; border-bottom: 1px solid #bcbcbc;",
-      class: "mb-2",
+      class: "bg-grey-lighten-3 border-b border-grey-lighten-1 mb-2",
     },
   },
 });


### PR DESCRIPTION
# Beschreibung:

Die Titelzeile von VCards sieht aktuell so aus:
![grafik](https://github.com/user-attachments/assets/5502fd57-4400-4c06-a09d-d625d698e706)
![grafik](https://github.com/user-attachments/assets/bc7a2fe4-0000-4f40-8ace-90ae98ac40a4)
___
das styling wurde in diesem pr wie folgt angepasst, um dem aussehen vom altsystem zu entsprechen:
![grafik](https://github.com/user-attachments/assets/af40e540-08dd-4be3-977e-3f8bd67e6efd)
![grafik](https://github.com/user-attachments/assets/6ca9e0aa-b0f8-404b-bccd-2e9f090f2406)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the default appearance of card titles with a light gray background, a subtle bottom border, and added bottom margin for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->