### PR TITLE
:recycle: refactor userStore

### DIFF
--- a/wls-gui-wahllokalsystem/src/App.vue
+++ b/wls-gui-wahllokalsystem/src/App.vue
@@ -182,7 +182,7 @@ import {
   ROUTE_WAHLVORSTAND,
   TOAST,
 } from "@/constants";
-import { useUserStore } from "@/stores/user";
+import { useUserStore } from "@/stores/userStore.ts";
 import { useWahlvorstandStore } from "@/stores/wahlvorstandStore";
 import { User, UserLocalDevelopment } from "@/types/User";
 

--- a/wls-gui-wahllokalsystem/src/components/common/icons/BaseIconWahlbezirksart.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/icons/BaseIconWahlbezirksart.vue
@@ -9,7 +9,7 @@
 import { computed } from "vue";
 import { VIcon } from "vuetify/components";
 
-import { useUserStore } from "@/stores/user";
+import { useUserStore } from "@/stores/userStore.ts";
 
 const userStore = useUserStore();
 

--- a/wls-gui-wahllokalsystem/src/stores/ereignisStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/ereignisStore.ts
@@ -9,13 +9,13 @@ import { useUserStore } from "@/stores/userStore.ts";
 import { WahlbezirkEreignisseBuilder } from "@/types/vorfaelleundvorkommnisse/WahlbezirkEreignisse.ts";
 
 const ereignisService = useEreignisService();
-const { currentUserWahlbezirkID } = useUserStore();
 
 export const storeID = "vorfaelleundvorkommnisse";
 
 export const useEreignisStore = defineStore(storeID, () => {
   const error = ref<string | null>(null);
 
+  const { currentUserWahlbezirkID } = useUserStore();
   const wahlbezirkEreignisse = ref<WahlbezirkEreignisse>(
     WahlbezirkEreignisseBuilder.createEmptyWahlbezirkEreignisse()
   );

--- a/wls-gui-wahllokalsystem/src/stores/ereignisStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/ereignisStore.ts
@@ -1,7 +1,7 @@
 import type { Ereignis } from "@/types/vorfaelleundvorkommnisse/Ereignis.ts";
 import type { WahlbezirkEreignisse } from "@/types/vorfaelleundvorkommnisse/WahlbezirkEreignisse.ts";
 
-import { defineStore } from "pinia";
+import { defineStore, storeToRefs } from "pinia";
 import { ref } from "vue";
 
 import { useEreignisService } from "@/composables/vorfaelleundvorkommnisse/ereignisService.ts";
@@ -15,7 +15,7 @@ export const storeID = "vorfaelleundvorkommnisse";
 export const useEreignisStore = defineStore(storeID, () => {
   const error = ref<string | null>(null);
 
-  const { currentUserWahlbezirkID } = useUserStore();
+  const { currentUserWahlbezirkID } = storeToRefs(useUserStore());
   const wahlbezirkEreignisse = ref<WahlbezirkEreignisse>(
     WahlbezirkEreignisseBuilder.createEmptyWahlbezirkEreignisse()
   );
@@ -29,7 +29,7 @@ export const useEreignisStore = defineStore(storeID, () => {
   }
 
   async function loadEreignisse() {
-    const wahlbezirkID = currentUserWahlbezirkID();
+    const wahlbezirkID = currentUserWahlbezirkID.value;
     if (wahlbezirkID) {
       error.value = null;
       try {
@@ -44,7 +44,7 @@ export const useEreignisStore = defineStore(storeID, () => {
   }
 
   async function sendEreignisse() {
-    const wahlbezirkID = currentUserWahlbezirkID();
+    const wahlbezirkID = currentUserWahlbezirkID.value;
     if (wahlbezirkID) {
       error.value = null;
       try {

--- a/wls-gui-wahllokalsystem/src/stores/ereignisStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/ereignisStore.ts
@@ -5,10 +5,11 @@ import { defineStore } from "pinia";
 import { ref } from "vue";
 
 import { useEreignisService } from "@/composables/vorfaelleundvorkommnisse/ereignisService.ts";
-import { useUserStore } from "@/stores/user";
+import { useUserStore } from "@/stores/userStore.ts";
 import { WahlbezirkEreignisseBuilder } from "@/types/vorfaelleundvorkommnisse/WahlbezirkEreignisse.ts";
 
 const ereignisService = useEreignisService();
+const { currentUserWahlbezirkID } = useUserStore();
 
 export const storeID = "vorfaelleundvorkommnisse";
 
@@ -28,13 +29,12 @@ export const useEreignisStore = defineStore(storeID, () => {
   }
 
   async function loadEreignisse() {
-    const currentUserWahlbezirkID = getUsersWahlbezirkID();
-    if (currentUserWahlbezirkID) {
+    const wahlbezirkID = currentUserWahlbezirkID();
+    if (wahlbezirkID) {
       error.value = null;
       try {
-        wahlbezirkEreignisse.value = await ereignisService.getEreignisse(
-          currentUserWahlbezirkID
-        );
+        wahlbezirkEreignisse.value =
+          await ereignisService.getEreignisse(wahlbezirkID);
         sortEreignisse(wahlbezirkEreignisse.value.ereigniseintraege);
       } catch (e) {
         error.value = "Fehler beim Laden der Ereignisse";
@@ -44,13 +44,13 @@ export const useEreignisStore = defineStore(storeID, () => {
   }
 
   async function sendEreignisse() {
-    const currentUserWahlbezirkID = getUsersWahlbezirkID();
-    if (currentUserWahlbezirkID) {
+    const wahlbezirkID = currentUserWahlbezirkID();
+    if (wahlbezirkID) {
       error.value = null;
       try {
         sortEreignisse(wahlbezirkEreignisse.value.ereigniseintraege);
         await ereignisService.saveEreignisse(
-          currentUserWahlbezirkID,
+          wahlbezirkID,
           wahlbezirkEreignisse.value
         );
       } catch (e) {
@@ -77,10 +77,4 @@ function sortEreignisse(ereigniseintraege: Ereignis[] | undefined) {
 
     return timeA - timeB;
   });
-}
-
-// Funktion zum Abrufen der Wahlbezirk-ID des Benutzers
-function getUsersWahlbezirkID(): string | undefined {
-  const userStore = useUserStore();
-  return userStore.getUser?.wahlbezirkID;
 }

--- a/wls-gui-wahllokalsystem/src/stores/userStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/userStore.ts
@@ -10,16 +10,16 @@ export interface UserState {
 export const useUserStore = defineStore("user", () => {
   const user = ref<User | null>(null);
 
+  const currentUserWahlbezirkID = computed((): string | undefined => {
+    return user.value?.wahlbezirkID;
+  });
+
   const getUser = computed((): User | null => {
     return user.value;
   });
 
   function setUser(payload: User | null): void {
     user.value = payload;
-  }
-
-  function currentUserWahlbezirkID(): string | undefined {
-    return user.value?.wahlbezirkID;
   }
 
   return { getUser, setUser, currentUserWahlbezirkID };

--- a/wls-gui-wahllokalsystem/src/stores/userStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/userStore.ts
@@ -17,5 +17,10 @@ export const useUserStore = defineStore("user", () => {
   function setUser(payload: User | null): void {
     user.value = payload;
   }
-  return { getUser, setUser };
+
+  function currentUserWahlbezirkID(): string | undefined {
+    return user.value?.wahlbezirkID;
+  }
+
+  return { getUser, setUser, currentUserWahlbezirkID };
 });

--- a/wls-gui-wahllokalsystem/src/stores/wahlvorstandStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/wahlvorstandStore.ts
@@ -1,6 +1,6 @@
 import type { Wahlvorstand } from "@/types/wahlvorstand/Wahlvorstand";
 
-import { defineStore } from "pinia";
+import { defineStore, storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 
 import { useWahlvorstandService } from "@/composables/wahlvorstand/wahlvorstandService";
@@ -16,7 +16,7 @@ const { getWahlvorstand, saveWahlvorstand } = useWahlvorstandService();
 export const storeID = "wahlvorstand";
 
 export const useWahlvorstandStore = defineStore(storeID, () => {
-  const { currentUserWahlbezirkID } = useUserStore();
+  const { currentUserWahlbezirkID } = storeToRefs(useUserStore());
   const wahlvorstand = ref<Wahlvorstand>(
     WahlvorstandBuilder.createEmptyWahlvorstand()
   );
@@ -38,7 +38,7 @@ export const useWahlvorstandStore = defineStore(storeID, () => {
   );
 
   async function loadWahlvorstand() {
-    const wahlbezirkID = currentUserWahlbezirkID();
+    const wahlbezirkID = currentUserWahlbezirkID.value;
     if (wahlbezirkID) {
       wahlvorstand.value = await getWahlvorstand(wahlbezirkID);
       lastLoading.value = new Date();
@@ -46,7 +46,7 @@ export const useWahlvorstandStore = defineStore(storeID, () => {
   }
 
   async function sendWahlvorstand() {
-    const wahlbezirkID = currentUserWahlbezirkID();
+    const wahlbezirkID = currentUserWahlbezirkID.value;
     if (wahlbezirkID) {
       const { updateDatetime } = await saveWahlvorstand(
         wahlbezirkID,

--- a/wls-gui-wahllokalsystem/src/stores/wahlvorstandStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/wahlvorstandStore.ts
@@ -4,7 +4,7 @@ import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 
 import { useWahlvorstandService } from "@/composables/wahlvorstand/wahlvorstandService";
-import { useUserStore } from "@/stores/user";
+import { useUserStore } from "@/stores/userStore.ts";
 import { WahlvorstandBuilder } from "@/types/wahlvorstand/Wahlvorstand";
 import {
   isSchriftfuehrer,
@@ -12,12 +12,11 @@ import {
 } from "@/types/wahlvorstand/WahlvorstandsmitgliedFunktion";
 
 const { getWahlvorstand, saveWahlvorstand } = useWahlvorstandService();
+const { currentUserWahlbezirkID } = useUserStore();
 
 export const storeID = "wahlvorstand";
 
 export const useWahlvorstandStore = defineStore(storeID, () => {
-  const userStore = useUserStore();
-
   const wahlvorstand = ref<Wahlvorstand>(
     WahlvorstandBuilder.createEmptyWahlvorstand()
   );
@@ -39,18 +38,18 @@ export const useWahlvorstandStore = defineStore(storeID, () => {
   );
 
   async function loadWahlvorstand() {
-    const currentUserWahlbezirkID = getUsersWahlbezirkID();
-    if (currentUserWahlbezirkID) {
-      wahlvorstand.value = await getWahlvorstand(currentUserWahlbezirkID);
+    const wahlbezirkID = currentUserWahlbezirkID();
+    if (wahlbezirkID) {
+      wahlvorstand.value = await getWahlvorstand(wahlbezirkID);
       lastLoading.value = new Date();
     }
   }
 
   async function sendWahlvorstand() {
-    const currentUserWahlbezirkID = getUsersWahlbezirkID();
-    if (currentUserWahlbezirkID) {
+    const wahlbezirkID = currentUserWahlbezirkID();
+    if (wahlbezirkID) {
       const { updateDatetime } = await saveWahlvorstand(
-        currentUserWahlbezirkID,
+        wahlbezirkID,
         wahlvorstand.value
       );
       lastSending.value = updateDatetime;
@@ -66,10 +65,6 @@ export const useWahlvorstandStore = defineStore(storeID, () => {
     if (wahlvorstandsMitgliedToUpdate) {
       wahlvorstandsMitgliedToUpdate.anwesend = newValue;
     }
-  }
-
-  function getUsersWahlbezirkID(): string | undefined {
-    return userStore.getUser?.wahlbezirkID;
   }
 
   return {

--- a/wls-gui-wahllokalsystem/src/stores/wahlvorstandStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/wahlvorstandStore.ts
@@ -12,11 +12,11 @@ import {
 } from "@/types/wahlvorstand/WahlvorstandsmitgliedFunktion";
 
 const { getWahlvorstand, saveWahlvorstand } = useWahlvorstandService();
-const { currentUserWahlbezirkID } = useUserStore();
 
 export const storeID = "wahlvorstand";
 
 export const useWahlvorstandStore = defineStore(storeID, () => {
+  const { currentUserWahlbezirkID } = useUserStore();
   const wahlvorstand = ref<Wahlvorstand>(
     WahlvorstandBuilder.createEmptyWahlvorstand()
   );

--- a/wls-gui-wahllokalsystem/stories/components/common/icons/BaseIconWahlbezirksart.stories.ts
+++ b/wls-gui-wahllokalsystem/stories/components/common/icons/BaseIconWahlbezirksart.stories.ts
@@ -4,7 +4,7 @@ import { createPinia, setActivePinia } from "pinia";
 
 import BaseIconWahlbezirksart from "@/components/common/icons/BaseIconWahlbezirksart.vue";
 import pinia from "@/plugins/pinia";
-import { useUserStore } from "@/stores/user.ts";
+import { useUserStore } from "@/stores/userStore.ts";
 import { User } from "@/types/User.ts";
 
 const meta = {

--- a/wls-gui-wahllokalsystem/tests/components/common/icons/BaseIconWahlbezirksart.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/components/common/icons/BaseIconWahlbezirksart.spec.ts
@@ -15,7 +15,7 @@ import { nextTick } from "vue";
 
 import BaseIconWahlbezirksart from "@/components/common/icons/BaseIconWahlbezirksart.vue";
 import vuetify from "@/plugins/vuetify.ts";
-import { useUserStore } from "@/stores/user";
+import { useUserStore } from "@/stores/userStore.ts";
 import { User } from "@/types/User.ts";
 
 describe("BaseIconWahlbezirksart.vue", () => {

--- a/wls-gui-wahllokalsystem/tests/stores/ereignisStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/ereignisStore.spec.ts
@@ -2,7 +2,7 @@ import { createPinia, setActivePinia } from "pinia";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useEreignisStore } from "@/stores/ereignisStore.ts";
-import { useUserStore } from "@/stores/user";
+import { useUserStore } from "@/stores/userStore.ts";
 import { User } from "@/types/User";
 import { WahlbezirkEreignisseBuilder } from "@/types/vorfaelleundvorkommnisse/WahlbezirkEreignisse.ts";
 

--- a/wls-gui-wahllokalsystem/tests/stores/wahlvorstandStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/wahlvorstandStore.spec.ts
@@ -2,7 +2,7 @@ import { createTestingPinia } from "@pinia/testing";
 import { createPinia, setActivePinia } from "pinia";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useUserStore } from "@/stores/user";
+import { useUserStore } from "@/stores/userStore.ts";
 import { useWahlvorstandStore } from "@/stores/wahlvorstandStore";
 import { User } from "@/types/User";
 import { WahlvorstandBuilder } from "@/types/wahlvorstand/Wahlvorstand";


### PR DESCRIPTION
# Beschreibung:

Die funktion 
```ts
function getUsersWahlbezirkID(): string | undefined {
  return userStore.getUser?.wahlbezirkID;
}
```

wurde aus zwei stores ausgelagert und in den userStore verschoben, weil sie noch öfter gebraucht wird.
Außerdem wurde der user store von `user` zu `userStore` umbenannt.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [ ] [Naming Conventions][naming-conventions-link] beachtet
- [ ] Doku aktualisiert
- [ ] Unit-Tests gepflegt
- [ ] Komponententests gepflegt

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a function to retrieve the current user's Wahlbezirk ID directly from the user store.

- **Refactor**
  - Updated internal usage to access the user's Wahlbezirk ID using the new function, streamlining related logic.

- **Tests**
  - Adjusted test imports to reflect changes in the user store module path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->