### PR TITLE
🎨 Refactor auf Selfclosingtags und Entfernung von leeren scoped styles in wls-gui und admin-gui

### DIFF
--- a/wls-gui-admintool/src/components/common/BaseAutocompleteWahltag.vue
+++ b/wls-gui-admintool/src/components/common/BaseAutocompleteWahltag.vue
@@ -8,7 +8,7 @@
     return-object
     data-test="autocompleteWahltage"
     no-data-text="Keine Wahltage gefunden"
-  ></v-autocomplete>
+  />
 </template>
 
 <script setup lang="ts">

--- a/wls-gui-admintool/src/components/common/BaseIconButtonRefresh.vue
+++ b/wls-gui-admintool/src/components/common/BaseIconButtonRefresh.vue
@@ -2,7 +2,7 @@
   <v-btn
     icon="$refresh"
     data-test="refreshButton"
-  ></v-btn>
+  />
 </template>
 <script setup lang="ts">
 import { VBtn } from "vuetify/components";

--- a/wls-gui-admintool/src/components/wahltag/BaseInitProgress.vue
+++ b/wls-gui-admintool/src/components/wahltag/BaseInitProgress.vue
@@ -38,5 +38,3 @@ defineProps({
   },
 });
 </script>
-
-<style scoped></style>

--- a/wls-gui-admintool/src/components/wahltag/TheWahltagInitProgressDiv.vue
+++ b/wls-gui-admintool/src/components/wahltag/TheWahltagInitProgressDiv.vue
@@ -81,5 +81,3 @@ function stopProgressPollInterval() {
   }
 }
 </script>
-
-<style scoped></style>

--- a/wls-gui-wahllokalsystem/src/App.vue
+++ b/wls-gui-wahllokalsystem/src/App.vue
@@ -38,8 +38,7 @@
                   density="comfortable"
                   size="x-large"
                   color="white"
-                >
-                </v-btn>
+                />
               </router-link>
             </template>
           </v-tooltip>
@@ -58,8 +57,7 @@
                   density="comfortable"
                   size="x-large"
                   color="white"
-                >
-                </v-btn>
+                />
               </router-link>
             </template>
           </v-tooltip>
@@ -78,8 +76,7 @@
                   density="comfortable"
                   size="x-large"
                   color="white"
-                >
-                </v-btn>
+                />
               </router-link>
             </template>
           </v-tooltip>
@@ -98,8 +95,7 @@
                   density="comfortable"
                   size="x-large"
                   color="white"
-                >
-                </v-btn>
+                />
               </router-link>
             </template>
           </v-tooltip>

--- a/wls-gui-wahllokalsystem/src/App.vue
+++ b/wls-gui-wahllokalsystem/src/App.vue
@@ -16,13 +16,13 @@
         <v-col
           cols="6"
           class="d-flex align-center justify-center"
-        ></v-col>
+        />
         <v-col
           cols="3"
           class="d-flex align-center justify-end"
         >
           <!-- heartbeat uses v-model for two-way-binding -->
-          <wls-heartbeat v-model:is-offline="isOffline"></wls-heartbeat>
+          <wls-heartbeat v-model:is-offline="isOffline" />
           <v-tooltip
             location="bottom"
             text="Routing Examples"
@@ -117,7 +117,7 @@
             <v-list-item
               v-bind="props"
               title="Wahlvorbereitung"
-            ></v-list-item>
+            />
           </template>
           <v-list-item
             title="Wahlschliessung"
@@ -139,7 +139,7 @@
         </router-view>
       </v-container>
     </v-main>
-    <the-broadcast-read-confirmation-dialog></the-broadcast-read-confirmation-dialog>
+    <the-broadcast-read-confirmation-dialog />
   </v-app>
 </template>
 

--- a/wls-gui-wahllokalsystem/src/components/broadcast/TheBroadcastReadConfirmationDialog.vue
+++ b/wls-gui-wahllokalsystem/src/components/broadcast/TheBroadcastReadConfirmationDialog.vue
@@ -10,7 +10,7 @@
         <v-icon
           icon="$information"
           size="x-small"
-        ></v-icon>
+        />
         <span class="ml-2">Nachricht vom Wahlamt</span>
       </v-card-title>
       <v-card-text class="pb-0">
@@ -20,7 +20,7 @@
           label="Nachricht gelesen"
           hide-details
           data-test="checkbox-mark-as-read"
-        ></v-checkbox>
+        />
       </v-card-text>
       <v-card-actions>
         <div class="ml-2 mb-2">

--- a/wls-gui-wahllokalsystem/src/components/common/icons/BaseIconWahlbezirksart.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/icons/BaseIconWahlbezirksart.vue
@@ -2,7 +2,7 @@
   <v-icon
     :icon="wahlartIcon"
     size="large"
-  ></v-icon>
+  />
 </template>
 
 <script setup lang="ts">

--- a/wls-gui-wahllokalsystem/src/components/common/inputs/BaseNumberInput.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/inputs/BaseNumberInput.vue
@@ -8,8 +8,7 @@
     :rules="props.rules"
     type="number"
     hide-spin-buttons
-  >
-  </v-text-field>
+  />
 </template>
 
 <script setup lang="ts">

--- a/wls-gui-wahllokalsystem/src/components/common/inputs/BaseTimeInput.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/inputs/BaseTimeInput.vue
@@ -6,7 +6,7 @@
     type="time"
     clearable
     @update:model-value="onTimeChanged"
-  ></v-text-field>
+  />
 </template>
 
 <script setup lang="ts">

--- a/wls-gui-wahllokalsystem/src/components/vorfaelleundvorkommnisse/TheEreignisseRow.vue
+++ b/wls-gui-wahllokalsystem/src/components/vorfaelleundvorkommnisse/TheEreignisseRow.vue
@@ -10,7 +10,7 @@
         >{{ index + 1 }}</v-col
       >
       <v-col cols="2">
-        <base-time-input v-model="ereignis.uhrzeit"></base-time-input>
+        <base-time-input v-model="ereignis.uhrzeit" />
       </v-col>
       <v-col>
         <v-textarea
@@ -21,7 +21,7 @@
           auto-grow
           clearable
           autofokus
-        ></v-textarea>
+        />
       </v-col>
       <v-col
         cols="1"
@@ -32,8 +32,7 @@
           icon="$delete"
           title="Löschen"
           @click="onDeleteIconClicked(index)"
-        >
-        </v-icon>
+        />
       </v-col>
     </v-row>
     <yes-no-dialog
@@ -42,7 +41,7 @@
       dialogtext="Möchten Sie dieses Ereignis wirklich löschen?"
       @no="onYesNoDialogNoClicked"
       @yes="onYesNoDialogYesClicked"
-    ></yes-no-dialog>
+    />
   </div>
 </template>
 

--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/OfflineSyncer.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/OfflineSyncer.vue
@@ -25,7 +25,7 @@
       <v-card
         title="Synchronizing"
         :text="statusText"
-      ></v-card>
+      />
     </v-dialog>
   </div>
 </template>
@@ -38,8 +38,6 @@ import { mergeProps, ref } from "vue";
 import { VBtn, VCard, VDialog, VTooltip } from "vuetify/components";
 
 import { basicPostConfig } from "@/api/axios-utils";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { useInterval } from "@/composables/useInterval";
 
 const dialog = ref(false);
 const statusText = ref("");

--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/OfflineSyncer.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/OfflineSyncer.vue
@@ -16,8 +16,7 @@
               size="x-small"
               color="primary"
               @click="synchronizeOfflineData"
-            >
-            </v-btn>
+            />
           </template>
         </v-tooltip>
       </template>

--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/OfflineSyncer.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/OfflineSyncer.vue
@@ -37,6 +37,8 @@ import { mergeProps, ref } from "vue";
 import { VBtn, VCard, VDialog, VTooltip } from "vuetify/components";
 
 import { basicPostConfig } from "@/api/axios-utils";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { useInterval } from "@/composables/useInterval";
 
 const dialog = ref(false);
 const statusText = ref("");

--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/WlsHeartbeat.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/WlsHeartbeat.vue
@@ -8,7 +8,7 @@
         density="comfortable"
         size="x-large"
         :color="getColor(isOffline)"
-      ></v-btn>
+      />
     </template>
     <v-card
       width="250"
@@ -38,7 +38,7 @@
         <v-divider
           thickness="2"
           color="black"
-        ></v-divider>
+        />
         <v-list-item> {{ getText(isOffline) }}</v-list-item>
       </v-list>
     </v-card>
@@ -61,8 +61,8 @@ import {
 
 import { basicPostConfig } from "@/api/axios-utils";
 import OfflineSyncer from "@/components/wlsComponents/OfflineSyncer.vue";
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { useInterval } from "@/composables/useInterval";
 
 // todo: checking status activated via click. uncomment to activate periodically
 /*

--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/WlsHeartbeat.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/WlsHeartbeat.vue
@@ -61,8 +61,8 @@ import {
 
 import { basicPostConfig } from "@/api/axios-utils";
 import OfflineSyncer from "@/components/wlsComponents/OfflineSyncer.vue";
-
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { useInterval } from "@/composables/useInterval";
 
 // todo: checking status activated via click. uncomment to activate periodically
 /*

--- a/wls-gui-wahllokalsystem/src/views/ExampleNewRouteView.vue
+++ b/wls-gui-wahllokalsystem/src/views/ExampleNewRouteView.vue
@@ -51,7 +51,7 @@
             v-model="textinput"
             clearable
             label="ID"
-          ></v-text-field>
+          />
           <p>
             Dynamic Route
             <router-link

--- a/wls-gui-wahllokalsystem/src/views/ExamplePrintView.vue
+++ b/wls-gui-wahllokalsystem/src/views/ExamplePrintView.vue
@@ -32,27 +32,26 @@
           label="Dein Lieblingskuchen"
           placeholder="Himbeertorte"
           width="500"
-        ></v-text-field>
+        />
         <base-number-input
           v-model="cakeNumber"
           label="Maximale Kuchenstücke die du verdrücken kannst"
           width="500"
-        ></base-number-input>
+        />
         <v-autocomplete
           v-model="toppings"
           label="Deine Lieblingstoppings"
           width="500"
           :items="['Streusel', 'Schokoglasur', 'Früchte']"
           multiple
-        ></v-autocomplete>
+        />
         <v-range-slider
           v-model="hungerIndex"
           label="Dein Hunger jetzt gerade"
           thumb-label
           thumb-size="14"
           width="500"
-        >
-        </v-range-slider>
+        />
       </v-col>
     </v-row>
 

--- a/wls-gui-wahllokalsystem/src/views/ExampleToastView.vue
+++ b/wls-gui-wahllokalsystem/src/views/ExampleToastView.vue
@@ -55,4 +55,3 @@ function toastError(): void {
   );
 }
 </script>
-<style scoped></style>

--- a/wls-gui-wahllokalsystem/src/views/ExampleValidation.vue
+++ b/wls-gui-wahllokalsystem/src/views/ExampleValidation.vue
@@ -20,12 +20,12 @@
               label="Input required"
               clearable
               :rules="[REQUIRED]"
-            ></v-text-field>
+            />
             <v-text-field
               min-width="400"
               label="Input has to be between 2 and 10"
               :rules="[MIN_LENGTH(2), MAX_LENGTH(10)]"
-            ></v-text-field>
+            />
           </v-container>
         </v-tabs-window-item>
         <v-tabs-window-item value="1">
@@ -45,17 +45,17 @@
                 clearable
                 label="Input required"
                 min-width="400"
-              ></v-text-field>
+              />
               <v-text-field
                 :rules="[MAX_LENGTH(20)]"
                 label="Input cant be longer than 20"
                 min-width="400"
-              ></v-text-field>
+              />
               <v-text-field
                 :rules="[MIN_LENGTH(5)]"
                 label="Input cant be shorter than 5"
                 min-width="400"
-              ></v-text-field>
+              />
               <v-btn
                 primary
                 class="mt-2"
@@ -63,7 +63,7 @@
                 type="submit"
                 :disabled="!firstFormIsValid"
                 block
-              ></v-btn>
+              />
             </v-form>
           </v-container>
         </v-tabs-window-item>
@@ -85,23 +85,23 @@
                 clearable
                 label="Input required"
                 min-width="400"
-              ></v-text-field>
+              />
               <v-text-field
                 :rules="[MAX_LENGTH(20)]"
                 label="Input cant be longer than 20"
                 min-width="400"
-              ></v-text-field>
+              />
               <v-text-field
                 :rules="[MIN_LENGTH(5)]"
                 label="Input cant be shorter than 5"
                 min-width="400"
-              ></v-text-field>
+              />
               <v-btn
                 primary
                 class="mt-2"
                 text="Submit"
                 type="submit"
-              ></v-btn>
+              />
             </v-form>
           </v-container>
         </v-tabs-window-item>

--- a/wls-gui-wahllokalsystem/src/views/HomeView.vue
+++ b/wls-gui-wahllokalsystem/src/views/HomeView.vue
@@ -8,7 +8,7 @@
         <v-icon
           icon="$home"
           size="large"
-        ></v-icon>
+        />
         <p>
           Das API-Gateway ist:
           <span :class="status">{{ status }}</span>

--- a/wls-gui-wahllokalsystem/src/views/WahlschliessungView.vue
+++ b/wls-gui-wahllokalsystem/src/views/WahlschliessungView.vue
@@ -1,5 +1,5 @@
 <template>
-  <base-wahlschliessung-card></base-wahlschliessung-card>
+  <base-wahlschliessung-card />
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
# Beschreibung:

- aus `></` ` />` (mit Leerzeichen vor dem Ende) gemacht
- Ich habe nach `></` gesucht. Auf manuellem Wege habe ich einige Stelle gefunden wo das End-Element auf der nächsten Zeile stand, danach habe ich aber nicht konsequent gesucht.
- `<style scoped></style>` entfernt

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet - nicht relevant
- [X] Doku aktualisiert - nicht relevant
- [X] Unit-Tests gepflegt - nicht relevant
- [X] Komponententests gepflegt - nicht relevant

# Referenzen[^1]:

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated Vue component templates to use self-closing tag syntax for improved code consistency and readability.
  - Removed an unused empty style block from one component.
  - Commented out or removed unused import statements in select components.

No changes to application functionality or behavior were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->