### PR TITLE
remove unused code

### DIFF
--- a/wls-gui-admintool/src/constants.ts
+++ b/wls-gui-admintool/src/constants.ts
@@ -4,8 +4,6 @@ export const ROUTES_INIT_WAHLTAG = "initWahltag";
 
 export const APPSWITCHER_URL = import.meta.env.VITE_APPSWITCHER_URL;
 
-export const SNACKBAR_DEFAULT_TIMEOUT = 5000;
-
 export const enum STATUS_INDICATORS {
   SUCCESS = "success",
   INFO = "info",

--- a/wls-gui-wahllokalsystem/src/constants.ts
+++ b/wls-gui-wahllokalsystem/src/constants.ts
@@ -10,15 +10,6 @@ export const ROUTE_WAHLSCHLIESSUNG = "wahlschliessung";
 export const TOAST = "toast";
 export const PRINT_EXAMPLE = "print-example";
 
-export const SNACKBAR_DEFAULT_TIMEOUT = 5000;
-
-export const enum STATUS_INDICATORS {
-  SUCCESS = "success",
-  INFO = "info",
-  WARNING = "warning",
-  ERROR = "error",
-}
-
 const WLS_SERVICE_API_URL = "/api/";
 
 export const BROADCAST_SERVICE_API_URL =


### PR DESCRIPTION
# Beschreibung:

- im `constants.ts` file waren noch die constanten `SNACKBAR_DEFAULT_TIMEOUT` und `STATUS_INDICATORS` von `TheSnackbar.vue` übrig, welche bei uns nicht mehr existiert
  - im admintool `SNACKBAR_DEFAULT_TIMEOUT` entfernt 
  - in der wls-gui `SNACKBAR_DEFAULT_TIMEOUT` und `STATUS_INDICATORS` entfernt

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] unused code entfernt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed unused status indicator options and default timeout settings for notifications. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->