### PR TITLE
increase content width on larger displays

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,23 +1,6 @@
 :root {
   --vp-code-copy-copied-text-content: "In Zwischenablage kopiert!";
-}
-
-@media (min-width: 1440px) {
-  :root {
-    --vp-layout-max-width: 1440px;
-  }
-}
-
-@media (min-width: 1920px) {
-  :root {
-    --vp-layout-max-width: 1920px;
-  }
-}
-
-@media (min-width: 2560px) {
-  :root {
-    --vp-layout-max-width: 2560px;
-  }
+  --vp-layout-max-width: 100%;
 }
 
 .VPDoc.has-aside .content-container {

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,3 +1,26 @@
 :root {
-  --vp-code-copy-copied-text-content: "In Zwischenablage kopiert!";
+    --vp-code-copy-copied-text-content: "In Zwischenablage kopiert!";
 }
+
+@media (min-width: 1440px) {
+    :root {
+        --vp-layout-max-width: 1440px;
+    }
+}
+
+@media (min-width: 1920px) {
+    :root {
+        --vp-layout-max-width: 1920px;
+    }
+}
+
+@media (min-width: 2560px) {
+    :root {
+        --vp-layout-max-width: 2560px;
+    }
+}
+
+.VPDoc.has-aside .content-container {
+    max-width: 100% !important;
+}
+

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,26 +1,25 @@
 :root {
-    --vp-code-copy-copied-text-content: "In Zwischenablage kopiert!";
+  --vp-code-copy-copied-text-content: "In Zwischenablage kopiert!";
 }
 
 @media (min-width: 1440px) {
-    :root {
-        --vp-layout-max-width: 1440px;
-    }
+  :root {
+    --vp-layout-max-width: 1440px;
+  }
 }
 
 @media (min-width: 1920px) {
-    :root {
-        --vp-layout-max-width: 1920px;
-    }
+  :root {
+    --vp-layout-max-width: 1920px;
+  }
 }
 
 @media (min-width: 2560px) {
-    :root {
-        --vp-layout-max-width: 2560px;
-    }
+  :root {
+    --vp-layout-max-width: 2560px;
+  }
 }
 
 .VPDoc.has-aside .content-container {
-    max-width: 100% !important;
+  max-width: 100% !important;
 }
-


### PR DESCRIPTION
# Beschreibung:

Auf Grund von mermaid-Grafiken wäre es gut wenn der Content-Bereich breiter wäre.

Die Doku nutzt immer 100% der Breite

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Dokumentation -->
### Dokumentation
- [x] Links geprüft - keine Links eingefügt, gelöscht oder verändert
# Referenzen[^1]:

Verwandt mit Issue #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the documentation layout to ensure the content container uses the full available width when a sidebar is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->