### PR TITLE
Inhaltsbreite auf Seite ohne Seitenavigation auf 100% erweitert

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,4 +1,4 @@
-/*Changes fo default settings to use full width of page.
+/*Changes default settings to use full width of page.
 We have large images that require more space. #1266 #1277*/
 :root {
   --vp-code-copy-copied-text-content: "In Zwischenablage kopiert!";

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -6,3 +6,15 @@
 .VPDoc.has-aside .content-container {
   max-width: 100% !important;
 }
+
+.VPDoc.has-aside .content {
+  max-width: 100% !important;
+}
+
+.VPDoc:not(has-sidebar) .content-container {
+  max-width: 100% !important;
+}
+
+.VPDoc .container {
+  max-width: 100% !important;
+}

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,3 +1,5 @@
+/*Changes fo default settings to use full width of page.
+We have large images that require more space. #1266 #1277*/
 :root {
   --vp-code-copy-copied-text-content: "In Zwischenablage kopiert!";
   --vp-layout-max-width: 100%;


### PR DESCRIPTION
# Beschreibung:

- Betrifft aktuell nur die `About`-Seite, die anderen Seite sind unverändert
- ist notwendig auf Grund der Anpassungen durch #1276

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

# Referenzen[^1]:

Verwandt mit Issue #846

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout by ensuring content areas consistently use the full available width across documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->