### PR TITLE
Release backend services sprint 24

### DIFF
--- a/wls-auth-service/pom.xml
+++ b/wls-auth-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-auth-service</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0</version>
     <name>wls_auth_service</name>
 
     <properties>
@@ -331,7 +331,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-auth-service/0.5.0</tag>
     </scm>
 
 

--- a/wls-auth-service/pom.xml
+++ b/wls-auth-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-auth-service</artifactId>
-    <version>0.5.0</version>
+    <version>0.6.0-SNAPSHOT</version>
     <name>wls_auth_service</name>
 
     <properties>
@@ -331,7 +331,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-auth-service/0.5.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
 


### PR DESCRIPTION
# Beschreibung:

releases gebaut
- auth-service
  - [release notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-auth-service%2F0.5.0)
  - [image](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-auth-service)

- wahlvorstand-service
  - [release notes]()
  - [image]()