### PR TITLE
fix: set forceUpdate true

### DIFF
--- a/wls-gui-wahllokalsystem/src/stores/wahlvorstandStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/wahlvorstandStore.ts
@@ -62,7 +62,7 @@ export const useWahlvorstandStore = defineStore(storeID, () => {
     try {
       const wahlbezirkID = currentUserWahlbezirkID.value;
       if (wahlbezirkID) {
-        wahlvorstand.value = await getWahlvorstand(wahlbezirkID);
+        wahlvorstand.value = await getWahlvorstand(wahlbezirkID, true);
         lastLoading.value = new Date();
       }
     } finally {

--- a/wls-gui-wahllokalsystem/tests/stores/wahlvorstandStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/wahlvorstandStore.spec.ts
@@ -393,7 +393,7 @@ describe("wahlvorstandStore.ts", () => {
 
       expect(unitUnderTest.wahlvorstand).toStrictEqual(mockedGetWahlvorstand);
       expect(mockDefinitions.getWahlvorstand.mock.calls).toStrictEqual([
-        [wahlbezirkID],
+        [wahlbezirkID, true],
       ]);
     });
 


### PR DESCRIPTION
# Beschreibung:

header `forceUpdate` war `false`, muss aber bei der Aktion `true` sein

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet - kein Update
- [x] Doku aktualisiert - kein Update
- [X] Unit-Tests gepflegt
- [X] Komponententests gepflegt - kein Update

# Referenzen[^1]:

Verwandt mit Issue #

Closes #1318

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated tests to verify that data retrieval now includes an additional parameter during loading.

No visible changes to the user interface or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->