### PR TITLE
#1348 remove disabled prop

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/wahlvorstand/TheNachbesetzungDruckenButton.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlvorstand/TheNachbesetzungDruckenButton.vue
@@ -2,7 +2,6 @@
   <v-btn
     v-if="currentUserWahlbezirksArt === 'BWB'"
     prepend-icon="$printer"
-    :disabled="!!schliessungsUhrzeitSent"
     @click="onNachbesetzungDruckenClicked"
   >
     Nachbesetzung drucken
@@ -18,7 +17,6 @@ import { VBtn } from "vuetify/components";
 import { useDateTimeFormatter } from "@/composables/common/dateTimeFormatter.ts";
 import { useWahlvorstandNachbesetzungsDruck } from "@/composables/wahlvorstand/wahlvorstandNachbesetzungsDruck.ts";
 import { useUserStore } from "@/stores/userStore.ts";
-import { useWahlbezirkStore } from "@/stores/wahlbezirkStore.ts";
 import { useWahlvorstandStore } from "@/stores/wahlvorstandStore.ts";
 
 const { forceLoadWahlvorstand, sendWahlvorstand } = useWahlvorstandStore();
@@ -28,7 +26,6 @@ const { toHhMm } = useDateTimeFormatter();
 const { currentUserWahlbezirkNummer, currentUserWahlbezirksArt } =
   storeToRefs(useUserStore());
 const { wahlvorstand } = storeToRefs(useWahlvorstandStore());
-const { schliessungsUhrzeitSent } = storeToRefs(useWahlbezirkStore());
 
 function onNachbesetzungDruckenClicked() {
   sendWahlvorstand();


### PR DESCRIPTION
# Beschreibung:

- disabled prop vom nachbesetzung drucken button entfernt

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] bug gefixed

# Referenzen[^1]:

Closes #1348

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The "Nachbesetzung Drucken" button is now always enabled, allowing users to print at any time.
- **Refactor**
  - Simplified the button component by removing unnecessary dependencies and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->