### PR TITLE
Default font without italic for wls-clock

### DIFF
--- a/wls-gui-wahllokalsystem/src/App.vue
+++ b/wls-gui-wahllokalsystem/src/App.vue
@@ -28,6 +28,8 @@ import { useMonitoringStore } from "@/stores/monitoringStore.ts";
 import { useTaskManagerStore } from "@/stores/taskManagerStore.ts";
 import { useUserStore } from "@/stores/userStore.ts";
 
+import "@fontsource/roboto/400.css";
+
 const { loadEreignisse } = useEreignisStore();
 const { loadUser } = useUserStore();
 const { initTasks } = useTaskManagerStore();

--- a/wls-gui-wahllokalsystem/src/App.vue
+++ b/wls-gui-wahllokalsystem/src/App.vue
@@ -28,8 +28,6 @@ import { useMonitoringStore } from "@/stores/monitoringStore.ts";
 import { useTaskManagerStore } from "@/stores/taskManagerStore.ts";
 import { useUserStore } from "@/stores/userStore.ts";
 
-import "@fontsource/roboto/400.css";
-
 const { loadEreignisse } = useEreignisStore();
 const { loadUser } = useUserStore();
 const { initTasks } = useTaskManagerStore();
@@ -66,6 +64,8 @@ onUnmounted(() => {
 </script>
 
 <style>
+@import "@fontsource/roboto/400.css";
+
 .main {
   background-color: white;
 }

--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/TheWlsAppBar.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/TheWlsAppBar.vue
@@ -20,7 +20,7 @@
         cols="3"
         class="d-flex align-center justify-end"
       >
-        <wls-clock class="mx-2 pt-1" />
+        <wls-clock class="mx-2" />
         <wls-heartbeat v-model:is-offline="isOffline" />
         <the-info-help-icon />
       </v-col>

--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/WlsClock.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/WlsClock.vue
@@ -18,8 +18,6 @@ const { currentTime } = useCurrentTime();
 <style scoped>
 .time {
   font-size: 24px;
-  font-family: "Rationale", monospace;
-  font-style: italic;
   letter-spacing: 0.08em;
 }
 </style>


### PR DESCRIPTION
# Beschreibung:

- Default Schriftart ohne kursive schreibweise für Uhrzeit im Header
- Import des Roboto-Fonts in der obersten Komponente `App.vue` Fixes #1409 

## Definition of Done (DoD):

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Doku aktualisiert
- [x] Unit-Tests gepflegt
- [x] Komponententests gepflegt
- [x] Texte auf Rechtschreibung und Grammatik geprüft

# Referenzen[^1]:

Verwandt mit Issue #

Closes #1421 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the application to use the Roboto font for a more consistent appearance.
  * Simplified the clock component's styling by removing custom font family and italic style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->