### PR TITLE
1422 anpassung titel im navigationsmenü zu "wahlhandlung"

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/TheWlsAppBar.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/TheWlsAppBar.vue
@@ -48,7 +48,7 @@
           :to="ROUTE_BEGINN_STIMMABGABE"
         />
         <v-list-item
-          title="Wahlschliessung"
+          title="Wahlhandlung"
           :to="ROUTE_WAHLSCHLIESSUNG"
         />
       </v-list-group>


### PR DESCRIPTION
## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] text angepasst

# Referenzen[^1]:

Closes #1422

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the navigation drawer item label from "Wahlschliessung" to "Wahlhandlung" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->