### PR TITLE
add handling wenn response status code is 204 on wahlbeteiligung

### DIFF
--- a/wls-gui-wahllokalsystem/src/composables/broadcast/broadcastService.ts
+++ b/wls-gui-wahllokalsystem/src/composables/broadcast/broadcastService.ts
@@ -5,11 +5,13 @@ import {
   Configuration,
 } from "@/api/wls-clients/generated-broadcast-api";
 import { useBroadcastMapper } from "@/composables/broadcast/broadcastMapper.ts";
+import { useCommonApiUtils } from "@/composables/common/commonApiUtils.ts";
 import { useUserNotificationService } from "@/composables/userNotification/userNotificationService.ts";
 import { BROADCAST_SERVICE_API_URL } from "@/constants.ts";
 
 const { dtoToModel } = useBroadcastMapper();
 const { addNotification } = useUserNotificationService();
+const { getNullOn204OrElseResponseData } = useCommonApiUtils();
 
 export function useBroadcastService() {
   const broadcastCA = new BroadcastControllerApi(
@@ -24,11 +26,8 @@ export function useBroadcastService() {
     try {
       const response = await broadcastCA.getMessage(wahlbezirkID);
 
-      if (response.status === 200) {
-        return dtoToModel(response.data);
-      } else {
-        return null;
-      }
+      const responseData = getNullOn204OrElseResponseData(response);
+      return responseData !== null ? dtoToModel(responseData) : null;
     } catch {
       addNotification(
         "Abrufen der Broadcastnachricht ist fehlgeschlagen",

--- a/wls-gui-wahllokalsystem/src/composables/broadcast/broadcastService.ts
+++ b/wls-gui-wahllokalsystem/src/composables/broadcast/broadcastService.ts
@@ -27,7 +27,7 @@ export function useBroadcastService() {
       const response = await broadcastCA.getMessage(wahlbezirkID);
 
       const responseData = getNullOn204OrElseResponseData(response);
-      return responseData !== null ? dtoToModel(responseData) : null;
+      return responseData ? dtoToModel(responseData) : null;
     } catch {
       addNotification(
         "Abrufen der Broadcastnachricht ist fehlgeschlagen",

--- a/wls-gui-wahllokalsystem/src/composables/common/commonApiUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/common/commonApiUtils.ts
@@ -1,9 +1,9 @@
 import type { AxiosResponse } from "axios";
 
 export function useCommonApiUtils() {
-  function getNullOn204OrElseResponseData<dataType>(
-    response: AxiosResponse<dataType>
-  ): dataType | null {
+  function getNullOn204OrElseResponseData<T>(
+    response: AxiosResponse<T>
+  ): T | null {
     return response.status === 204 ? null : response.data;
   }
 

--- a/wls-gui-wahllokalsystem/src/composables/common/commonApiUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/common/commonApiUtils.ts
@@ -1,0 +1,13 @@
+import type { AxiosResponse } from "axios";
+
+export function useCommonApiUtils() {
+  function getNullOn204OrElseResponseData<dataType>(
+    response: AxiosResponse<dataType>
+  ): dataType | null {
+    return response.status === 204 ? null : response.data;
+  }
+
+  return {
+    getNullOn204OrElseResponseData,
+  };
+}

--- a/wls-gui-wahllokalsystem/src/composables/monitoring/monitoringService.ts
+++ b/wls-gui-wahllokalsystem/src/composables/monitoring/monitoringService.ts
@@ -25,7 +25,7 @@ export function useMonitoringService() {
         wahlbezirkID
       );
       const responseData = getNullOn204OrElseResponseData(response);
-      return responseData !== null ? toModel(responseData) : undefined;
+      return responseData ? toModel(responseData) : undefined;
     } catch (e) {
       console.debug(e);
     }

--- a/wls-gui-wahllokalsystem/src/composables/monitoring/monitoringService.ts
+++ b/wls-gui-wahllokalsystem/src/composables/monitoring/monitoringService.ts
@@ -4,12 +4,14 @@ import {
   Configuration,
   WaehleranzahlControllerApi,
 } from "@/api/wls-clients/generated-monitoring-api";
+import { useCommonApiUtils } from "@/composables/common/commonApiUtils.ts";
 import { useDateTimeFormatter } from "@/composables/common/dateTimeFormatter.ts";
 import { useWahlbeteiligungMapper } from "@/composables/monitoring/wahlbeteiligungMapper.ts";
 import { MONITORING_SERVICE_API_URL } from "@/constants.ts";
 
 const { toDto, toModel } = useWahlbeteiligungMapper();
 const { applyLocalTimezoneOffset } = useDateTimeFormatter();
+const { getNullOn204OrElseResponseData } = useCommonApiUtils();
 
 export function useMonitoringService() {
   const waehlerAnzahlControllerApi = new WaehleranzahlControllerApi(
@@ -22,7 +24,8 @@ export function useMonitoringService() {
         wahlID,
         wahlbezirkID
       );
-      return toModel(response.data);
+      const responseData = getNullOn204OrElseResponseData(response);
+      return responseData !== null ? toModel(responseData) : undefined;
     } catch (e) {
       console.debug(e);
     }

--- a/wls-gui-wahllokalsystem/tests/composables/common/commonApiUtils.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/common/commonApiUtils.spec.ts
@@ -1,0 +1,40 @@
+import { useAxiosTestDataFactory } from "@tests/utils/common/AxiosTestDataFactory.ts";
+import { describe, expect, it } from "vitest";
+
+import { useCommonApiUtils } from "@/composables/common/commonApiUtils.ts";
+
+describe("commonApiUtils.ts", () => {
+  const { createAxiosResponse } = useAxiosTestDataFactory();
+  const { getNullOn204OrElseResponseData } = useCommonApiUtils();
+
+  describe("getNullOn204OrElseResponseData", () => {
+    it.each([205, 203])(
+      "should_returnResponseData_when_responseStatusIsNot204BecauseItIs%i",
+      (statusCode) => {
+        const responseData = "responseData";
+        const result = getNullOn204OrElseResponseData(
+          createAxiosResponse({ status: statusCode, data: responseData })
+        );
+
+        expect(result).toStrictEqual(responseData);
+      }
+    );
+
+    it.each([
+      { responseData: "text", descriptionSuffix: "AndDataIsText" },
+      { responseData: null, descriptionSuffix: "AndDataIsNull" },
+      { responseData: {}, descriptionSuffix: "AndDataIsEmptyObject" },
+      { responseData: undefined, descriptionSuffix: "AndDataIsUndefined" },
+    ])(
+      "should_returnNull_when_statusCodeIs204$descriptionSuffix",
+      (testCaseParameter) => {
+        const responseData = testCaseParameter.responseData;
+        const result = getNullOn204OrElseResponseData(
+          createAxiosResponse({ status: 204, data: responseData })
+        );
+
+        expect(result).toStrictEqual(null);
+      }
+    );
+  });
+});

--- a/wls-gui-wahllokalsystem/tests/composables/monitoring/monitoringService.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/monitoring/monitoringService.spec.ts
@@ -61,9 +61,10 @@ describe("monitoringService.ts", () => {
         uhrzeit: new Date("2025-05-05T12:00:00"),
       };
 
-      mockDefinitions.getWahlbeteiligung.mockResolvedValue(
-        mockedWaehleranzahlDTO
-      );
+      mockDefinitions.getWahlbeteiligung.mockResolvedValue({
+        status: 200,
+        data: mockedWaehleranzahlDTO,
+      });
       mockDefinitions.toModel.mockReturnValue(mockedWaehleranzahlModel);
 
       const result = await getWahlbeteiligung(wahlID, wahlbezirkID);
@@ -73,6 +74,9 @@ describe("monitoringService.ts", () => {
         wahlbezirkID
       );
       expect(result).toEqual(mockedWaehleranzahlModel);
+      expect(mockDefinitions.toModel.mock.calls).toStrictEqual([
+        [mockedWaehleranzahlDTO],
+      ]);
     });
 
     it.each([

--- a/wls-gui-wahllokalsystem/tests/composables/monitoring/monitoringService.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/monitoring/monitoringService.spec.ts
@@ -112,6 +112,24 @@ describe("monitoringService.ts", () => {
         expect(mockDefinitions.toModel).not.toHaveBeenCalled();
       }
     );
+
+    it("should_returnUndefined_when_apiCallReturnedResponseWithStatus204", async () => {
+      const wahlbezirkID = generateRandomString(10);
+      const wahlID = generateRandomString(10);
+
+      mockDefinitions.getWahlbeteiligung.mockResolvedValue(
+        Promise.resolve({ status: 204, data: null })
+      );
+
+      const result = await getWahlbeteiligung(wahlID, wahlbezirkID);
+
+      expect(result).toStrictEqual(undefined);
+      expect(mockDefinitions.getWahlbeteiligung).toHaveBeenCalledWith(
+        wahlID,
+        wahlbezirkID
+      );
+      expect(mockDefinitions.toModel).toHaveBeenCalledTimes(0);
+    });
   });
 
   describe("postWahlbeteiligung", () => {

--- a/wls-gui-wahllokalsystem/tests/utils/common/AxiosTestDataFactory.ts
+++ b/wls-gui-wahllokalsystem/tests/utils/common/AxiosTestDataFactory.ts
@@ -1,0 +1,24 @@
+import type { AxiosResponse } from "axios";
+
+import { AxiosHeaders } from "axios";
+
+export function useAxiosTestDataFactory() {
+  function createAxiosResponse(response: {
+    status: number;
+    data?: unknown;
+  }): AxiosResponse {
+    return {
+      config: {
+        headers: new AxiosHeaders(),
+      },
+      data: response.data,
+      headers: {},
+      statusText: "",
+      status: response.status,
+    };
+  }
+
+  return {
+    createAxiosResponse,
+  };
+}


### PR DESCRIPTION
# Beschreibung:

- Fix von fehlendem Handling von 204 bei GET wahlbeteiligung in monitoringService composable 
- ein composable erstellt für Hilfsfunktionen für API-Calls

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Unit-Tests gepflegt
- [X] Texte auf Rechtschreibung und Grammatik geprüft

# Referenzen[^1]:

Verwandt mit Issue #

Closes #1489

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of HTTP responses across the app to better manage cases where no content is returned.
  * Centralized response status handling for more consistent behavior.

* **New Features**
  * Added a utility for processing API responses, ensuring null is returned for empty responses.

* **Tests**
  * Introduced comprehensive tests for the new response utility and updated monitoring service tests to cover new scenarios.
  * Added utilities for creating mock API responses in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->