### PR TITLE
Sprint 26 Releases

### DIFF
--- a/wls-admin-service/pom.xml
+++ b/wls-admin-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-admin-service</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.2-SNAPSHOT</version>
     <name>wls_admin_service</name>
 
     <properties>
@@ -317,7 +317,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-admin-service/0.4.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-admin-service/pom.xml
+++ b/wls-admin-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-admin-service</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.4.1</version>
     <name>wls_admin_service</name>
 
     <properties>
@@ -317,7 +317,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-admin-service/0.4.1</tag>
     </scm>
 
 

--- a/wls-basisdaten-service/pom.xml
+++ b/wls-basisdaten-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-basisdaten-service</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.2-SNAPSHOT</version>
     <name>wls_basisdaten_service</name>
 
     <properties>
@@ -309,7 +309,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-basisdaten-service/0.4.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-basisdaten-service/pom.xml
+++ b/wls-basisdaten-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-basisdaten-service</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.4.1</version>
     <name>wls_basisdaten_service</name>
 
     <properties>
@@ -309,7 +309,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-basisdaten-service/0.4.1</tag>
     </scm>
 
 

--- a/wls-ergebnismeldung-service/pom.xml
+++ b/wls-ergebnismeldung-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-ergebnismeldung-service</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.2-SNAPSHOT</version>
     <name>wls_ergebnismeldung_service</name>
 
     <properties>
@@ -312,7 +312,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-ergebnismeldung-service/0.4.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-ergebnismeldung-service/pom.xml
+++ b/wls-ergebnismeldung-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-ergebnismeldung-service</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.4.1</version>
     <name>wls_ergebnismeldung_service</name>
 
     <properties>
@@ -312,7 +312,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-ergebnismeldung-service/0.4.1</tag>
     </scm>
 
 

--- a/wls-infomanagement-service/pom.xml
+++ b/wls-infomanagement-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-infomanagement-service</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.4.2</version>
     <name>wls_infomanagement_service</name>
 
 
@@ -300,7 +300,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-infomanagement-service/0.4.2</tag>
     </scm>
 
 

--- a/wls-infomanagement-service/pom.xml
+++ b/wls-infomanagement-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-infomanagement-service</artifactId>
-    <version>0.4.2</version>
+    <version>0.4.3-SNAPSHOT</version>
     <name>wls_infomanagement_service</name>
 
 
@@ -300,7 +300,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-infomanagement-service/0.4.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-monitoring-service/pom.xml
+++ b/wls-monitoring-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-monitoring-service</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.2-SNAPSHOT</version>
     <name>wls_monitoring_service</name>
 
     <properties>
@@ -310,7 +310,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-monitoring-service/0.3.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-monitoring-service/pom.xml
+++ b/wls-monitoring-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-monitoring-service</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.3.1</version>
     <name>wls_monitoring_service</name>
 
     <properties>
@@ -310,7 +310,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-monitoring-service/0.3.1</tag>
     </scm>
 
 

--- a/wls-wahlvorstand-service/pom.xml
+++ b/wls-wahlvorstand-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-wahlvorstand-service</artifactId>
-    <version>0.6.0-SNAPSHOT</version>
+    <version>0.5.1</version>
     <name>wls_wahlvorstand_service</name>
 
     <properties>
@@ -311,7 +311,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-wahlvorstand-service/0.5.1</tag>
     </scm>
 
 

--- a/wls-wahlvorstand-service/pom.xml
+++ b/wls-wahlvorstand-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-wahlvorstand-service</artifactId>
-    <version>0.5.1</version>
+    <version>0.5.2-SNAPSHOT</version>
     <name>wls_wahlvorstand_service</name>
 
     <properties>
@@ -311,7 +311,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-wahlvorstand-service/0.5.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
 


### PR DESCRIPTION
# Beschreibung:

Bereitstellung der Testversionen für Sprint 26

## Admin-Service
- 0.4.1
  - [Releasenotes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-admin-service%2F0.4.1)
  - [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-admin-service/453249304?tag=0.4.1)

## Basisdaten-Service
- 0.4.1
  - [Releasenotes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-basisdaten-service%2F0.4.1)
  - [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-basisdaten-service/453252654?tag=0.4.1)

## Ergebnismeldungs-Service
- 0.4.1
  - [Releasenotes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-ergebnismeldung-service%2F0.4.1)
  - [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-ergebnismeldung-service/453246411?tag=0.4.1)

## Infomanagement-Service
- 0.4.2
  - [Releasenotes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-infomanagement-service%2F0.4.2)
  - [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-infomanagement-service/453243011?tag=0.4.2)

## Monitoring-Service
- 0.3.1
  - [Releasenotes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-monitoring-service%2F0.3.1)
  - [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-monitoring-service/453260394?tag=0.3.1)

## Wahlvorstand-Service
- 0.5.1
  - [Releasenotes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-wahlvorstand-service%2F0.5.1)
  - [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-wahlvorstand-service/453257348?tag=0.5.1)

## Admin-Gui
- 0.2.0
  - [Releasenotes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-gui-admintool%2F0.2.0)
  - [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-gui-admintool/453270744?tag=0.2.0)

## Wls-Gui
- 0.4.0
  - [Releasenotes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-gui-wahllokalsystem%2F0.4.0)
  - [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-gui-wahllokalsystem/453268048?tag=0.4.0)
- 0.4.1
  - [Releasenotes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-gui-wahllokalsystem%2F0.4.1)
  - [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-gui-wahllokalsystem/453937958?tag=0.4.1)

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
