### PR TITLE
Change renovate config to refarch standard

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -11,5 +11,5 @@
     //#248 https://github.com/it-at-m/Wahllokalsystem/issues/248#issuecomment-2228404217
     "quay.io/keycloak/keycloak",
   ],
-  prConcurrentLimit: 2,
+  prConcurrentLimit: 5,
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "github>it-at-m/refarch//refarch-tools/refarch-renovate/refarch-renovate-config.json5"
   ],
   "addLabels": [
     "renovate"


### PR DESCRIPTION
# Beschreibung:

- Refarch default config für renovate verwendet


[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to use a custom preset and increased the maximum number of concurrent pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->