### PR TITLE
update vue-component-type-helpers to 3.0.3

### DIFF
--- a/wls-gui-wahllokalsystem/package-lock.json
+++ b/wls-gui-wahllokalsystem/package-lock.json
@@ -3553,8 +3553,8 @@
       }
     },
     "node_modules/@storybook/vue3/node_modules/vue-component-type-helpers": {
-      "version": "3.0.1",
-      "integrity": "sha512-j23mCB5iEbGsyIhnVdXdWUOg+UdwmVxpKnYYf2j+4ppCt5VSFXKjwu9YFt0QYxUaf5G99PuHsVfRScjHCRSsGQ==",
+      "version": "3.0.3",
+      "integrity": "sha512-koiBu7lO8e6w/UlbZAAIW11qcFQocYIl7Nh/SVwGZ804ej5KrncU32bRxi2zfU2Kyf6HWuk1CeeVP2rhIL+vyQ==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
# Beschreibung:

Hebung in package-lock (wird von Storybook verwendet via latest)

Soll Problem bei [Build](https://github.com/it-at-m/Wahllokalsystem/actions/runs/16411478976/job/46367292562?pr=1582) beheben.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

# Referenzen[^1]:

Verwandt mit Issue #1478

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
