### PR TITLE
1354 Erweiterung input feedback card um Typ success und mehr Abstand mit Text

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/common/cards/BaseInputFeedbackCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/cards/BaseInputFeedbackCard.vue
@@ -8,7 +8,7 @@
       <div class="d-flex align-center">
         <v-icon
           :color="iconColor"
-          class="mr-2"
+          class="mr-5"
           :icon="icon"
         />
         <div :class="textColor">

--- a/wls-gui-wahllokalsystem/src/composables/common/inputFeedbackUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/common/inputFeedbackUtils.ts
@@ -9,6 +9,8 @@ export function useInputFeedbackUtils() {
         return "$invalid";
       case InputFeedbackTypeEnum.information:
         return "$information";
+      case InputFeedbackTypeEnum.success:
+        return "$valid";
     }
   }
 
@@ -20,6 +22,8 @@ export function useInputFeedbackUtils() {
         return "error";
       case InputFeedbackTypeEnum.information:
         return "info";
+      case InputFeedbackTypeEnum.success:
+        return "success";
     }
   }
 
@@ -31,6 +35,8 @@ export function useInputFeedbackUtils() {
         return "text-error";
       case InputFeedbackTypeEnum.information:
         return "text-info";
+      case InputFeedbackTypeEnum.success:
+        return "text-success";
     }
   }
 
@@ -42,6 +48,8 @@ export function useInputFeedbackUtils() {
         return "border-error";
       case InputFeedbackTypeEnum.information:
         return "border-info";
+      case InputFeedbackTypeEnum.success:
+        return "border-success";
     }
   }
 

--- a/wls-gui-wahllokalsystem/src/types/common/InputFeedbackTypeEnum.ts
+++ b/wls-gui-wahllokalsystem/src/types/common/InputFeedbackTypeEnum.ts
@@ -1,6 +1,7 @@
 export const InputFeedbackTypeEnum = {
   error: "error",
   information: "information",
+  success: "success",
 };
 
 export type InputFeedbackTypeEnum =

--- a/wls-gui-wahllokalsystem/stories/components/common/cards/BaseInputFeedbackCard.stories.ts
+++ b/wls-gui-wahllokalsystem/stories/components/common/cards/BaseInputFeedbackCard.stories.ts
@@ -45,3 +45,10 @@ export const Information: Story = {
     type: InputFeedbackTypeEnum.information,
   },
 };
+
+export const Success: Story = {
+  args: {
+    title: "Titel zu einer Erfolgsmeldung",
+    type: InputFeedbackTypeEnum.success,
+  },
+};

--- a/wls-gui-wahllokalsystem/tests/components/common/cards/__snapshots__/BaseInputFeedbackCard.vue/visual logic/should_renderWithAdditionalFeedback_when_additionalFeedbackSlotIsUsed.html
+++ b/wls-gui-wahllokalsystem/tests/components/common/cards/__snapshots__/BaseInputFeedbackCard.vue/visual logic/should_renderWithAdditionalFeedback_when_additionalFeedbackSlotIsUsed.html
@@ -18,7 +18,7 @@
   <!---->
   <div class="v-card-title bg-grey-lighten-3 border-b border-grey-lighten-1 mb-2" style="font-size: 1rem;">test title for component under test</div>
   <div class="v-card-text">
-    <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-mockedIconColor mr-2" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+    <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-mockedIconColor mr-5" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
           <path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path>
         </svg></i>
       <div class="mockedTextColor">the default slot content</div>

--- a/wls-gui-wahllokalsystem/tests/components/common/cards/__snapshots__/BaseInputFeedbackCard.vue/visual logic/should_renderWithoutAdditionalFeedback_when_additionalFeedbackSlotIsNotUsed.html
+++ b/wls-gui-wahllokalsystem/tests/components/common/cards/__snapshots__/BaseInputFeedbackCard.vue/visual logic/should_renderWithoutAdditionalFeedback_when_additionalFeedbackSlotIsNotUsed.html
@@ -18,7 +18,7 @@
   <!---->
   <div class="v-card-title bg-grey-lighten-3 border-b border-grey-lighten-1 mb-2" style="font-size: 1rem;">test title for component under test</div>
   <div class="v-card-text">
-    <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-mockedIconColor mr-2" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+    <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-mockedIconColor mr-5" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
           <path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path>
         </svg></i>
       <div class="mockedTextColor">the default slot content</div>

--- a/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/__snapshots__/BaseWaehlerverzeichnisCheckCard.vue/visual logic/should_renderSaveButtonDisabled_when_mitteilungUeberUngueltigeWahlscheineErhaltenIsFalse.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/__snapshots__/BaseWaehlerverzeichnisCheckCard.vue/visual logic/should_renderSaveButtonDisabled_when_mitteilungUeberUngueltigeWahlscheineErhaltenIsFalse.html
@@ -38,7 +38,7 @@
       <!---->
       <div class="v-card-title bg-grey-lighten-3 border-b border-grey-lighten-1 mb-2" style="font-size: 1rem;">Bearbeitungshinweis</div>
       <div class="v-card-text">
-        <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-info mr-2" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+        <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-info mr-5" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
               <path d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"></path>
             </svg></i>
           <div class="text-info">Das Wahlamt informiert Sie, wenn Sie auf dieser Maske Änderungen vornehmen müssen. </div>
@@ -132,7 +132,7 @@
       <!---->
       <div class="v-card-title bg-grey-lighten-3 border-b border-grey-lighten-1 mb-2" style="font-size: 1rem;">Ungültige Eingabe</div>
       <div class="v-card-text">
-        <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-error mr-2" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+        <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-error mr-5" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
               <path d="M4.15,21.46L5.47,19.58C3.35,17.74 2,15.03 2,12A10,10 0 0,1 12,2C13.78,2 15.44,2.46 16.89,3.27L18.21,1.39L19.85,2.54L18.53,4.42C20.65,6.26 22,8.97 22,12A10,10 0 0,1 12,22C10.22,22 8.56,21.54 7.11,20.73L5.79,22.61L4.15,21.46M12,4A8,8 0 0,0 4,12C4,14.35 5,16.46 6.63,17.93L15.73,4.92C14.62,4.33 13.35,4 12,4M12,20A8,8 0 0,0 20,12C20,9.65 19,7.54 17.37,6.07L8.27,19.08C9.38,19.67 10.65,20 12,20Z"></path>
             </svg></i>
           <div class="text-error">Bitte setzen sie einen Haken bei: "Der Wahlvorstand wurde unterrichtet, dass folgende Wahlscheine für ungültig erklärt worden sind (gemäß Anlage)." </div>

--- a/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/__snapshots__/BaseWaehlerverzeichnisCheckCard.vue/visual logic/should_renderSaveInLoadingState_when_pflegeWaehlerverzeichnisIsSavingIsTrue.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/__snapshots__/BaseWaehlerverzeichnisCheckCard.vue/visual logic/should_renderSaveInLoadingState_when_pflegeWaehlerverzeichnisIsSavingIsTrue.html
@@ -38,7 +38,7 @@
       <!---->
       <div class="v-card-title bg-grey-lighten-3 border-b border-grey-lighten-1 mb-2" style="font-size: 1rem;">Bearbeitungshinweis</div>
       <div class="v-card-text">
-        <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-info mr-2" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+        <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-info mr-5" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
               <path d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"></path>
             </svg></i>
           <div class="text-info">Das Wahlamt informiert Sie, wenn Sie auf dieser Maske Änderungen vornehmen müssen. </div>

--- a/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/__snapshots__/BaseWaehlerverzeichnisCheckCard.vue/visual logic/should_renderWithChangesInWaehlerverzeichnisAndAllCheckboxesSelected_when_mounted.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/__snapshots__/BaseWaehlerverzeichnisCheckCard.vue/visual logic/should_renderWithChangesInWaehlerverzeichnisAndAllCheckboxesSelected_when_mounted.html
@@ -38,7 +38,7 @@
       <!---->
       <div class="v-card-title bg-grey-lighten-3 border-b border-grey-lighten-1 mb-2" style="font-size: 1rem;">Bearbeitungshinweis</div>
       <div class="v-card-text">
-        <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-info mr-2" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+        <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-info mr-5" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
               <path d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"></path>
             </svg></i>
           <div class="text-info">Das Wahlamt informiert Sie, wenn Sie auf dieser Maske Änderungen vornehmen müssen. </div>

--- a/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/__snapshots__/BaseWaehlerverzeichnisCheckCard.vue/visual logic/should_renderWithNoChangesInWaehlerverzeichnisAndAllCheckboxesSelected_when_mounted.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/__snapshots__/BaseWaehlerverzeichnisCheckCard.vue/visual logic/should_renderWithNoChangesInWaehlerverzeichnisAndAllCheckboxesSelected_when_mounted.html
@@ -38,7 +38,7 @@
       <!---->
       <div class="v-card-title bg-grey-lighten-3 border-b border-grey-lighten-1 mb-2" style="font-size: 1rem;">Bearbeitungshinweis</div>
       <div class="v-card-text">
-        <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-info mr-2" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+        <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-info mr-5" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
               <path d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"></path>
             </svg></i>
           <div class="text-info">Das Wahlamt informiert Sie, wenn Sie auf dieser Maske Änderungen vornehmen müssen. </div>

--- a/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/__snapshots__/BaseWaehlerverzeichnisCheckCard.vue/visual logic/should_renderWithNoChangesInWaehlerverzeichnisAndNoCheckboxesSelected_when_mounted.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/__snapshots__/BaseWaehlerverzeichnisCheckCard.vue/visual logic/should_renderWithNoChangesInWaehlerverzeichnisAndNoCheckboxesSelected_when_mounted.html
@@ -38,7 +38,7 @@
       <!---->
       <div class="v-card-title bg-grey-lighten-3 border-b border-grey-lighten-1 mb-2" style="font-size: 1rem;">Bearbeitungshinweis</div>
       <div class="v-card-text">
-        <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-info mr-2" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+        <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-info mr-5" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
               <path d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"></path>
             </svg></i>
           <div class="text-info">Das Wahlamt informiert Sie, wenn Sie auf dieser Maske Änderungen vornehmen müssen. </div>
@@ -132,7 +132,7 @@
       <!---->
       <div class="v-card-title bg-grey-lighten-3 border-b border-grey-lighten-1 mb-2" style="font-size: 1rem;">Ungültige Eingabe</div>
       <div class="v-card-text">
-        <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-error mr-2" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+        <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-error mr-5" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
               <path d="M4.15,21.46L5.47,19.58C3.35,17.74 2,15.03 2,12A10,10 0 0,1 12,2C13.78,2 15.44,2.46 16.89,3.27L18.21,1.39L19.85,2.54L18.53,4.42C20.65,6.26 22,8.97 22,12A10,10 0 0,1 12,22C10.22,22 8.56,21.54 7.11,20.73L5.79,22.61L4.15,21.46M12,4A8,8 0 0,0 4,12C4,14.35 5,16.46 6.63,17.93L15.73,4.92C14.62,4.33 13.35,4 12,4M12,20A8,8 0 0,0 20,12C20,9.65 19,7.54 17.37,6.07L8.27,19.08C9.38,19.67 10.65,20 12,20Z"></path>
             </svg></i>
           <div class="text-error">Bitte setzen sie einen Haken bei: "Der Wahlvorstand wurde unterrichtet, dass folgende Wahlscheine für ungültig erklärt worden sind (gemäß Anlage)." </div>

--- a/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/__snapshots__/TheWahlumgebungUwbCard.vue/visual logic/should_renderWithFiveInputFieldsAndDisabledSaveButton_when_twoWahlenAreGiven.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/__snapshots__/TheWahlumgebungUwbCard.vue/visual logic/should_renderWithFiveInputFieldsAndDisabledSaveButton_when_twoWahlenAreGiven.html
@@ -397,7 +397,7 @@
         <!---->
         <div class="v-card-title bg-grey-lighten-3 border-b border-grey-lighten-1 mb-2" style="font-size: 1rem;">Ungültige Eingaben</div>
         <div class="v-card-text">
-          <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-error mr-2" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+          <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-error mr-5" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                 <path d="M4.15,21.46L5.47,19.58C3.35,17.74 2,15.03 2,12A10,10 0 0,1 12,2C13.78,2 15.44,2.46 16.89,3.27L18.21,1.39L19.85,2.54L18.53,4.42C20.65,6.26 22,8.97 22,12A10,10 0 0,1 12,22C10.22,22 8.56,21.54 7.11,20.73L5.79,22.61L4.15,21.46M12,4A8,8 0 0,0 4,12C4,14.35 5,16.46 6.63,17.93L15.73,4.92C14.62,4.33 13.35,4 12,4M12,20A8,8 0 0,0 20,12C20,9.65 19,7.54 17.37,6.07L8.27,19.08C9.38,19.67 10.65,20 12,20Z"></path>
               </svg></i>
             <div class="text-error"> Die Summe der Kabinen, Tische und Nebenräume muss mindestens 1 betragen. </div>

--- a/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/__snapshots__/TheWahlumgebungUwbCard.vue/visual logic/should_renderWithThreeInputFieldsAndDisabledSaveButton_when_noWahlenAreGiven.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/__snapshots__/TheWahlumgebungUwbCard.vue/visual logic/should_renderWithThreeInputFieldsAndDisabledSaveButton_when_noWahlenAreGiven.html
@@ -266,7 +266,7 @@
         <!---->
         <div class="v-card-title bg-grey-lighten-3 border-b border-grey-lighten-1 mb-2" style="font-size: 1rem;">Ungültige Eingaben</div>
         <div class="v-card-text">
-          <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-error mr-2" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+          <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-error mr-5" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                 <path d="M4.15,21.46L5.47,19.58C3.35,17.74 2,15.03 2,12A10,10 0 0,1 12,2C13.78,2 15.44,2.46 16.89,3.27L18.21,1.39L19.85,2.54L18.53,4.42C20.65,6.26 22,8.97 22,12A10,10 0 0,1 12,22C10.22,22 8.56,21.54 7.11,20.73L5.79,22.61L4.15,21.46M12,4A8,8 0 0,0 4,12C4,14.35 5,16.46 6.63,17.93L15.73,4.92C14.62,4.33 13.35,4 12,4M12,20A8,8 0 0,0 20,12C20,9.65 19,7.54 17.37,6.07L8.27,19.08C9.38,19.67 10.65,20 12,20Z"></path>
               </svg></i>
             <div class="text-error"> Die Summe der Kabinen, Tische und Nebenräume muss mindestens 1 betragen. </div>

--- a/wls-gui-wahllokalsystem/tests/components/wahlvorstand/__snapshots__/TheWahlvorstandAnwesenheitRequirementCard.vue/visual logic/should_showErrorText_when_mindestAnwesenheitIsNotGiven.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlvorstand/__snapshots__/TheWahlvorstandAnwesenheitRequirementCard.vue/visual logic/should_showErrorText_when_mindestAnwesenheitIsNotGiven.html
@@ -18,7 +18,7 @@
   <!---->
   <div class="v-card-title bg-grey-lighten-3 border-b border-grey-lighten-1 mb-2" style="font-size: 1rem;">Ungültige Zusammensetzung des Wahlvorstands</div>
   <div class="v-card-text">
-    <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-error mr-2" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+    <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-error mr-5" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
           <path d="M4.15,21.46L5.47,19.58C3.35,17.74 2,15.03 2,12A10,10 0 0,1 12,2C13.78,2 15.44,2.46 16.89,3.27L18.21,1.39L19.85,2.54L18.53,4.42C20.65,6.26 22,8.97 22,12A10,10 0 0,1 12,22C10.22,22 8.56,21.54 7.11,20.73L5.79,22.61L4.15,21.46M12,4A8,8 0 0,0 4,12C4,14.35 5,16.46 6.63,17.93L15.73,4.92C14.62,4.33 13.35,4 12,4M12,20A8,8 0 0,0 20,12C20,9.65 19,7.54 17.37,6.07L8.27,19.08C9.38,19.67 10.65,20 12,20Z"></path>
         </svg></i>
       <div class="text-error">

--- a/wls-gui-wahllokalsystem/tests/components/wahlvorstand/__snapshots__/TheWahlvorstandAnwesenheitRequirementCard.vue/visual logic/should_showErrorText_when_schriftfuehrerIsNotAnwesend.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlvorstand/__snapshots__/TheWahlvorstandAnwesenheitRequirementCard.vue/visual logic/should_showErrorText_when_schriftfuehrerIsNotAnwesend.html
@@ -18,7 +18,7 @@
   <!---->
   <div class="v-card-title bg-grey-lighten-3 border-b border-grey-lighten-1 mb-2" style="font-size: 1rem;">Ungültige Zusammensetzung des Wahlvorstands</div>
   <div class="v-card-text">
-    <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-error mr-2" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+    <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-error mr-5" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
           <path d="M4.15,21.46L5.47,19.58C3.35,17.74 2,15.03 2,12A10,10 0 0,1 12,2C13.78,2 15.44,2.46 16.89,3.27L18.21,1.39L19.85,2.54L18.53,4.42C20.65,6.26 22,8.97 22,12A10,10 0 0,1 12,22C10.22,22 8.56,21.54 7.11,20.73L5.79,22.61L4.15,21.46M12,4A8,8 0 0,0 4,12C4,14.35 5,16.46 6.63,17.93L15.73,4.92C14.62,4.33 13.35,4 12,4M12,20A8,8 0 0,0 20,12C20,9.65 19,7.54 17.37,6.07L8.27,19.08C9.38,19.67 10.65,20 12,20Z"></path>
         </svg></i>
       <div class="text-error">

--- a/wls-gui-wahllokalsystem/tests/components/wahlvorstand/__snapshots__/TheWahlvorstandAnwesenheitRequirementCard.vue/visual logic/should_showErrorText_when_wahlvorsteherIsNotAnwesend.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlvorstand/__snapshots__/TheWahlvorstandAnwesenheitRequirementCard.vue/visual logic/should_showErrorText_when_wahlvorsteherIsNotAnwesend.html
@@ -18,7 +18,7 @@
   <!---->
   <div class="v-card-title bg-grey-lighten-3 border-b border-grey-lighten-1 mb-2" style="font-size: 1rem;">Ungültige Zusammensetzung des Wahlvorstands</div>
   <div class="v-card-text">
-    <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-error mr-2" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+    <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-error mr-5" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
           <path d="M4.15,21.46L5.47,19.58C3.35,17.74 2,15.03 2,12A10,10 0 0,1 12,2C13.78,2 15.44,2.46 16.89,3.27L18.21,1.39L19.85,2.54L18.53,4.42C20.65,6.26 22,8.97 22,12A10,10 0 0,1 12,22C10.22,22 8.56,21.54 7.11,20.73L5.79,22.61L4.15,21.46M12,4A8,8 0 0,0 4,12C4,14.35 5,16.46 6.63,17.93L15.73,4.92C14.62,4.33 13.35,4 12,4M12,20A8,8 0 0,0 20,12C20,9.65 19,7.54 17.37,6.07L8.27,19.08C9.38,19.67 10.65,20 12,20Z"></path>
         </svg></i>
       <div class="text-error">

--- a/wls-gui-wahllokalsystem/tests/components/wahlvorstand/__snapshots__/TheWahlvorstandAnwesenheitRequirementCard.vue/visual logic/should_showNoErrorTexts_when_allRequirementsAreSatisfied.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlvorstand/__snapshots__/TheWahlvorstandAnwesenheitRequirementCard.vue/visual logic/should_showNoErrorTexts_when_allRequirementsAreSatisfied.html
@@ -18,7 +18,7 @@
   <!---->
   <div class="v-card-title bg-grey-lighten-3 border-b border-grey-lighten-1 mb-2" style="font-size: 1rem;">Ungültige Zusammensetzung des Wahlvorstands</div>
   <div class="v-card-text">
-    <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-error mr-2" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+    <div class="d-flex align-center"><i class="v-icon notranslate v-theme--light v-icon--size-default text-error mr-5" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
           <path d="M4.15,21.46L5.47,19.58C3.35,17.74 2,15.03 2,12A10,10 0 0,1 12,2C13.78,2 15.44,2.46 16.89,3.27L18.21,1.39L19.85,2.54L18.53,4.42C20.65,6.26 22,8.97 22,12A10,10 0 0,1 12,22C10.22,22 8.56,21.54 7.11,20.73L5.79,22.61L4.15,21.46M12,4A8,8 0 0,0 4,12C4,14.35 5,16.46 6.63,17.93L15.73,4.92C14.62,4.33 13.35,4 12,4M12,20A8,8 0 0,0 20,12C20,9.65 19,7.54 17.37,6.07L8.27,19.08C9.38,19.67 10.65,20 12,20Z"></path>
         </svg></i>
       <div class="text-error"></div>

--- a/wls-gui-wahllokalsystem/tests/composables/common/inputFeedbackUtils.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/common/inputFeedbackUtils.spec.ts
@@ -21,6 +21,10 @@ describe("inputFeedbackUtils.ts", () => {
         inputFeedbackType: InputFeedbackTypeEnum.information,
         expectedResult: "border-info",
       },
+      {
+        inputFeedbackType: InputFeedbackTypeEnum.success,
+        expectedResult: "border-success",
+      },
     ])(
       "should_returnCorrectValue_when_inputFeedbackType'$inputFeedbackType'IsGiven",
       (params) => {
@@ -41,6 +45,10 @@ describe("inputFeedbackUtils.ts", () => {
       {
         inputFeedbackType: InputFeedbackTypeEnum.information,
         expectedResult: "info",
+      },
+      {
+        inputFeedbackType: InputFeedbackTypeEnum.success,
+        expectedResult: "success",
       },
     ])(
       "should_returnCorrectValue_when_inputFeedbackType'$inputFeedbackType'IsGiven",
@@ -63,6 +71,10 @@ describe("inputFeedbackUtils.ts", () => {
         inputFeedbackType: InputFeedbackTypeEnum.information,
         expectedResult: "$information",
       },
+      {
+        inputFeedbackType: InputFeedbackTypeEnum.success,
+        expectedResult: "$valid",
+      },
     ])(
       "should_returnCorrectValue_when_inputFeedbackType'$inputFeedbackType'IsGiven",
       (params) => {
@@ -81,6 +93,10 @@ describe("inputFeedbackUtils.ts", () => {
       {
         inputFeedbackType: InputFeedbackTypeEnum.information,
         expectedResult: "text-info",
+      },
+      {
+        inputFeedbackType: InputFeedbackTypeEnum.success,
+        expectedResult: "text-success",
       },
     ])(
       "should_returnCorrectValue_when_inputFeedbackType'$inputFeedbackType'IsGiven",


### PR DESCRIPTION
# Beschreibung:

- neuer Typ `success` ergänzt
- der Abstand zwischen Icon und Text wurde vergrößert, da so Platz für Aufzählungen ist
  - vorher:  <img width="958" height="154" alt="grafik" src="https://github.com/user-attachments/assets/bd441315-5f7b-46e5-bdd6-015a725dbf74" />
  - nachher:  <img width="958" height="154" alt="grafik" src="https://github.com/user-attachments/assets/c115e220-0790-44ec-b0cb-a6a10ae7eb83" />


## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Doku aktualisiert - kein Update erforderlich
- [X] Unit-Tests gepflegt
- [X] Komponententests gepflegt
- [x] Texte auf Rechtschreibung und Grammatik geprüft

# Referenzen[^1]:

Verwandt mit Issue #1354

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "success" feedback type for input feedback cards, providing clearer visual feedback for successful actions.
  * Introduced a new story to showcase the "success" feedback card variant.

* **Style**
  * Increased the horizontal spacing between icons and adjacent text in feedback and error cards for improved readability.

* **Tests**
  * Expanded test coverage to include the new "success" feedback type, ensuring correct behavior and appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->