### PR TITLE
1560 images shas für wls images nicht pinnen

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -176,6 +176,10 @@ export default withMermaid({
               text: "ArchUnit Rules Testen",
               link: `${PATH_GUIDES}archunit-rule-tests.md`,
             },
+            {
+              text: "Aktualisierung von Images",
+              link: `${PATH_GUIDES}update-images.md`,
+            },
           ],
         },
         {

--- a/docs/src/technik/guides/update-images.md
+++ b/docs/src/technik/guides/update-images.md
@@ -1,0 +1,13 @@
+# Aktualisierung von Images
+
+Um die bestehenden Images zu aktualisieren und neue Versionen zu erhalten, müssen die folgenden Schritte durchgeführt werden:
+
+1. Zuerst müssen die neuen Images heruntergeladen werden:
+```bash
+docker-compose pull
+```
+
+2. Anschließend müssen die Images gestartet werden, damit sie über die GUI verwendet werden können:
+```bash
+docker-compose up
+```

--- a/docs/src/technik/guides/update-images.md
+++ b/docs/src/technik/guides/update-images.md
@@ -2,7 +2,7 @@
 
 Um die bestehenden Images zu aktualisieren und neue Versionen zu erhalten, müssen die folgenden Schritte durchgeführt werden:
 
-1. Zuerst müssen die bestehenden Container über die GUI gelöscht werden.
+1. Zuerst müssen die bestehenden Container über die Podman-GUI gelöscht werden.
 
 2. Anschließend müssen die neuen Images heruntergeladen werden:
 

--- a/docs/src/technik/guides/update-images.md
+++ b/docs/src/technik/guides/update-images.md
@@ -5,11 +5,11 @@ Um die bestehenden Images zu aktualisieren und neue Versionen zu erhalten, müss
 1. Zuerst müssen die bestehenden Container über die GUI gelöscht werden.
 
 2. Anschließend müssen die neuen Images heruntergeladen werden:
-```bash
-docker-compose pull
-```
+    ```bash
+    docker-compose pull
+    ```
 
 3. Zuletzt müssen die Images gestartet werden, damit sie über die GUI verwendet werden können:
-```bash
-docker-compose up
-```
+    ```bash
+    docker-compose up
+    ```

--- a/docs/src/technik/guides/update-images.md
+++ b/docs/src/technik/guides/update-images.md
@@ -5,11 +5,13 @@ Um die bestehenden Images zu aktualisieren und neue Versionen zu erhalten, müss
 1. Zuerst müssen die bestehenden Container über die GUI gelöscht werden.
 
 2. Anschließend müssen die neuen Images heruntergeladen werden:
+
     ```bash
     docker-compose pull
     ```
 
 3. Zuletzt müssen die Images gestartet werden, damit sie über die GUI verwendet werden können:
+
     ```bash
     docker-compose up
     ```

--- a/docs/src/technik/guides/update-images.md
+++ b/docs/src/technik/guides/update-images.md
@@ -2,12 +2,14 @@
 
 Um die bestehenden Images zu aktualisieren und neue Versionen zu erhalten, müssen die folgenden Schritte durchgeführt werden:
 
-1. Zuerst müssen die neuen Images heruntergeladen werden:
+1. Zuerst müssen die bestehenden Container über die GUI gelöscht werden.
+
+2. Anschließend müssen die neuen Images heruntergeladen werden:
 ```bash
 docker-compose pull
 ```
 
-2. Anschließend müssen die Images gestartet werden, damit sie über die GUI verwendet werden können:
+3. Zuletzt müssen die Images gestartet werden, damit sie über die GUI verwendet werden können:
 ```bash
 docker-compose up
 ```

--- a/renovate.json5
+++ b/renovate.json5
@@ -10,6 +10,20 @@
     "org.projectlombok:lombok",
     //#248 https://github.com/it-at-m/Wahllokalsystem/issues/248#issuecomment-2228404217
     "quay.io/keycloak/keycloak",
+    "ghcr.io/it-at-m/wahllokalsystem-wls-broadcast-service",
+    "ghcr.io/it-at-m/wahllokalsystem-wls-infomanagement-service",
+    "ghcr.io/it-at-m/wahllokalsystem-wls-briefwahl-service",
+    "ghcr.io/it-at-m/wahllokalsystem-wls-wahlvorbereitung-service",
+    "ghcr.io/it-at-m/wahllokalsystem-wls-vorfaelleundvorkommnisse-service",
+    "ghcr.io/it-at-m/wahllokalsystem-wls-basisdaten-service",
+    "ghcr.io/it-at-m/wahllokalsystem-wls-monitoring-service",
+    "ghcr.io/it-at-m/wahllokalsystem-wls-wahlvorstand-service",
+    "ghcr.io/it-at-m/wahllokalsystem-wls-ergebnismeldung-service",
+    "ghcr.io/it-at-m/wahllokalsystem-wls-admin-service",
+    "ghcr.io/it-at-m/wahllokalsystem-wls-eai-service",
+    "ghcr.io/it-at-m/wahllokalsystem-wls-auth-service",
+    "ghcr.io/it-at-m/wahllokalsystem-wls-gui-wahllokalsystem",
+    "ghcr.io/it-at-m/wahllokalsystem-wls-gui-admintool"
   ],
   prConcurrentLimit: 5,
 }

--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   ### WLS-Backend Services
   wls-broadcast-service:
     container_name: wls-broadcast-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-broadcast-service:latest@sha256:73ee058b2e36a1c90cd1cab5a78105e7c28b48a7ea1405bec3624cc056265e19
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-broadcast-service:latest
     depends_on:
       - wls-db-oracle
     env_file:
@@ -24,7 +24,7 @@ services:
 
   wls-infomanagement-service:
     container_name: wls-infomanagement-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-infomanagement-service:latest@sha256:87f6ef2536cffdc70bae2f7a1e146c596144b3c867cc884ca0670a6bdefadadf
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-infomanagement-service:latest
     depends_on:
       - wls-db-oracle
     env_file:
@@ -44,7 +44,7 @@ services:
 
   wls-briefwahl-service:
     container_name: wls-briefwahl-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-briefwahl-service:latest@sha256:cb0cb4c5babcd14aaa7e1557c49e94b14f8861bd106f23232a56de3dac77c45a
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-briefwahl-service:latest
     depends_on:
       - wls-db-oracle
     env_file:
@@ -64,7 +64,7 @@ services:
 
   wls-wahlvorbereitung-service:
     container_name: wls-wahlvorbereitung-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-wahlvorbereitung-service:latest@sha256:0e790dc235dfdd214bf5a918b13a69010fb2ac0425c4a9a0e64f1b2b05e66ec1
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-wahlvorbereitung-service:latest
     depends_on:
       - wls-db-oracle
     env_file:
@@ -84,7 +84,7 @@ services:
 
   wls-vorfaelleundvorkommnisse-service:
     container_name: wls-vorfaelleundvorkommnisse-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-vorfaelleundvorkommnisse-service:latest@sha256:ae86126fcac34d5d891897a862cc9c4c95f07052635ac813d2173a6c59bb9db9
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-vorfaelleundvorkommnisse-service:latest
     depends_on:
       - wls-db-oracle
     env_file:
@@ -104,7 +104,7 @@ services:
 
   wls-basisdaten-service:
     container_name: wls-basisdaten-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-basisdaten-service:latest@sha256:ebdc291ba3620051adc23a0571ca52066af1d33e37e459e4222f03acb533695d
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-basisdaten-service:latest
     depends_on:
       - wls-db-oracle
     env_file:
@@ -126,7 +126,7 @@ services:
 
   wls-monitoring-service:
     container_name: wls-monitoring-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-monitoring-service:latest@sha256:4696eadd0a3cb677d6b774780d5c39d943348d21f4e6021bf42fabc77412a71f
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-monitoring-service:latest
     depends_on:
       - wls-db-oracle
     env_file:
@@ -147,7 +147,7 @@ services:
 
   wls-wahlvorstand-service:
     container_name: wls-wahlvorstand-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-wahlvorstand-service:latest@sha256:4cca8199e8a05836b7f9a5b670a561abf9dd97ad7652815260d519659177b9e8
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-wahlvorstand-service:latest
     depends_on:
       - wls-db-oracle
     env_file:
@@ -170,7 +170,7 @@ services:
 
   wls-ergebnismeldung-service:
     container_name: wls-ergebnismeldung-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-ergebnismeldung-service:latest@sha256:b5fd51801803c8e085418371e632949f5cd788b7850b9fe96fb1e6c59978ac4f
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-ergebnismeldung-service:latest
     depends_on:
       - wls-db-oracle
     env_file:
@@ -196,7 +196,7 @@ services:
 
   wls-admin-service:
     container_name: wls-admin-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-admin-service:latest@sha256:e9681685ac9c17916e9152cc00544a9ed20d9a10c766eb63c23314f659a5527d
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-admin-service:latest
     depends_on:
       - wls-db-oracle
     env_file:
@@ -220,7 +220,7 @@ services:
 
   wls-eai-service:
     container_name: wls-eai-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-eai-service:latest@sha256:a759083f2a5b90922da0582cce01b22ed43f76f59002feed3c5d82a19cfb5594
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-eai-service:latest
     depends_on:
       - wls-db-oracle
     env_file:
@@ -321,7 +321,7 @@ services:
 
   wls-auth-service:
     container_name: wls-auth-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-auth-service:latest@sha256:70ed4d1b567742af94ebc60a2f36619889bff75642b660ac0ab195a3c20e806d
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-auth-service:latest
     depends_on:
       - wls-db-oracle
     env_file:
@@ -384,7 +384,7 @@ services:
 
   wls-gui-wahllokalsystem:
     container_name: wls-gui-wahllokalsystem
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-gui-wahllokalsystem:latest@sha256:63fc2c5138e11408b6e035480ada534e574d5bd590bc0534b2f5ee4636a429c6
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-gui-wahllokalsystem:latest
     ports:
       - 8400:8080
     extra_hosts:
@@ -394,7 +394,7 @@ services:
 
   wls-gui-admintool:
     container_name: wls-gui-admintool
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-gui-admintool:latest@sha256:5f682fbefed65a5a0a87d6923077a8966deeeb7082877aac403935acddee8877
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-gui-admintool:latest
     ports:
       - 8401:8080
     extra_hosts:

--- a/stack/docker-compose_latest-dev.yml
+++ b/stack/docker-compose_latest-dev.yml
@@ -4,7 +4,7 @@ services:
   ### WLS-Backend Services
   wls-broadcast-service:
     container_name: wls-broadcast-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-broadcast-service:latest-dev@sha256:1da808b189f4159cd18ac960583130a505e6881d67a757a2826728cd760c10bf
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-broadcast-service:latest-dev
     depends_on:
       - wls-db-oracle
     env_file:
@@ -24,7 +24,7 @@ services:
 
   wls-infomanagement-service:
     container_name: wls-infomanagement-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-infomanagement-service:latest-dev@sha256:227a1e004e50654f1cbfcecd910aefb1b97b8ac10b3519a43b94660f51c7ee22
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-infomanagement-service:latest-dev
     depends_on:
       - wls-db-oracle
     env_file:
@@ -44,7 +44,7 @@ services:
 
   wls-briefwahl-service:
     container_name: wls-briefwahl-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-briefwahl-service:latest-dev@sha256:3167a29164d8b28c8093f94117b08bbba800c7243c1abda9635adfd8746b153a
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-briefwahl-service:latest-dev
     depends_on:
       - wls-db-oracle
     env_file:
@@ -64,7 +64,7 @@ services:
 
   wls-wahlvorbereitung-service:
     container_name: wls-wahlvorbereitung-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-wahlvorbereitung-service:latest-dev@sha256:5ed0ba831972501281c458131ee0b6c8fa9f737993f0ac5933cf62f8bec87de5
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-wahlvorbereitung-service:latest-dev
     depends_on:
       - wls-db-oracle
     env_file:
@@ -84,7 +84,7 @@ services:
 
   wls-vorfaelleundvorkommnisse-service:
     container_name: wls-vorfaelleundvorkommnisse-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-vorfaelleundvorkommnisse-service:latest-dev@sha256:e8b8526c02616ce3dceeb05cf314bde22ec0fda270f150bdaafd8ab402615810
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-vorfaelleundvorkommnisse-service:latest-dev
     depends_on:
       - wls-db-oracle
     env_file:
@@ -104,7 +104,7 @@ services:
 
   wls-basisdaten-service:
     container_name: wls-basisdaten-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-basisdaten-service:latest-dev@sha256:31e6c09b3f3dbac75b61f070d13ff95490589ec864ec947d4d8fb67959b468d2
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-basisdaten-service:latest-dev
     depends_on:
       - wls-db-oracle
     env_file:
@@ -126,7 +126,7 @@ services:
 
   wls-monitoring-service:
     container_name: wls-monitoring-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-monitoring-service:latest-dev@sha256:c3d3ed0bee03506184f945989ae18e4a50c1b05331b705be189fa22eef252a6d
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-monitoring-service:latest-dev
     depends_on:
       - wls-db-oracle
     env_file:
@@ -147,7 +147,7 @@ services:
 
   wls-wahlvorstand-service:
     container_name: wls-wahlvorstand-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-wahlvorstand-service:latest-dev@sha256:9ab93f4f71581c91bc98e968e7551e332c08b56b0a54f85dbb42a1beb6312668
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-wahlvorstand-service:latest-dev
     depends_on:
       - wls-db-oracle
     env_file:
@@ -170,7 +170,7 @@ services:
 
   wls-ergebnismeldung-service:
     container_name: wls-ergebnismeldung-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-ergebnismeldung-service:latest-dev@sha256:02d7a5373f02d49ef773c66d9ea7e1c1819f5681086268614dfb1b72be1e1c9c
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-ergebnismeldung-service:latest-dev
     depends_on:
       - wls-db-oracle
     env_file:
@@ -196,7 +196,7 @@ services:
 
   wls-admin-service:
     container_name: wls-admin-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-admin-service:latest-dev@sha256:04abfa7637428cba443dcded4b6bb0d3df6b7eb3d7ea1e833f517a15945dd3ca
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-admin-service:latest-dev
     depends_on:
       - wls-db-oracle
     env_file:
@@ -220,7 +220,7 @@ services:
 
   wls-eai-service:
     container_name: wls-eai-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-eai-service:latest-dev@sha256:7d42dbbb4feb1a125ce2a1a56f976196f01175bb20c3e61dfd39d723b4059335
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-eai-service:latest-dev
     depends_on:
       - wls-db-oracle
     env_file:
@@ -321,7 +321,7 @@ services:
 
   wls-auth-service:
     container_name: wls-auth-service
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-auth-service:latest-dev@sha256:bca4f28304508cef77abb25b23ee81aa0171b0acf6153173cb674eeae1649473
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-auth-service:latest-dev
     depends_on:
       - wls-db-oracle
     env_file:
@@ -384,7 +384,7 @@ services:
 
   wls-gui-wahllokalsystem:
     container_name: wls-gui-wahllokalsystem
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-gui-wahllokalsystem:latest-dev@sha256:6e54ac66f8e8bf41fdebeaeaad760988fee888c027655826a85419c7bf68781d
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-gui-wahllokalsystem:latest-dev
     ports:
       - 8400:8080
     extra_hosts:
@@ -394,7 +394,7 @@ services:
 
   wls-gui-admintool:
     container_name: wls-gui-admintool
-    image: ghcr.io/it-at-m/wahllokalsystem-wls-gui-admintool:latest-dev@sha256:bb3a9ee9615048e8ef19a4112a9c282370086cd59b527cc635bc2a3148e8c5fe
+    image: ghcr.io/it-at-m/wahllokalsystem-wls-gui-admintool:latest-dev
     ports:
       - 8401:8080
     extra_hosts:


### PR DESCRIPTION
# Beschreibung:

- digest von container entfernt
- projekt latest images sollen ignoriert werden

Verwandt mit Issue #

Closes #1560 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new guide on updating Docker images, including step-by-step instructions.
  * Updated the technical documentation sidebar to include the new guide.
* **Chores**
  * Updated dependency management configuration to ignore additional container image dependencies.
  * Simplified Docker image references in configuration files by removing SHA256 digests, using only tag-based references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->