### PR TITLE
1596 - instabile frontend test - Ergänzung Stub ereignisse service in Test

### DIFF
--- a/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/BaseWahleroeffnungCard.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/BaseWahleroeffnungCard.spec.ts
@@ -25,6 +25,13 @@ declare module "@vue/runtime-core" {
 
 const mockDefinitions = vi.hoisted(() => ({
   postEroeffnungsuhrzeit: vi.fn(),
+  saveEreignisse: vi.fn(),
+}));
+
+vi.mock("@/composables/vorfaelleundvorkommnisse/ereignisService.ts", () => ({
+  useEreignisService: () => ({
+    saveEreignisse: mockDefinitions.saveEreignisse,
+  }),
 }));
 
 vi.mock("@/composables/wahlvorbereitung/wahlvorbereitungService", () => ({
@@ -265,6 +272,7 @@ describe("BaseWahleroeffnungCard.vue", () => {
           ereignisStore.wahlbezirkEreignisse.ereigniseintraege[0].beschreibung
         ).toBe(begruendung);
       }
+      expect(mockDefinitions.saveEreignisse).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
# Beschreibung:

Die Vermutung ist das vue3Toasty das Problem ist wenn es aufpoppt. Damit das nicht passiert wurde der Service gemockt. Ist für Tests von Komponenten auch ausreichend.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Doku aktualisiert - keine Update erforderlich
- [x] Unit-Tests gepflegt - nur Komponententest aktualisiert
- [x] Komponententests gepflegt
- [X] Texte auf Rechtschreibung und Grammatik geprüft

# Referenzen[^1]:

Verwandt mit Issue #

Closes #1596

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the event creation process when confirming with a justification, ensuring correct behavior is verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->