### PR TITLE
Revert "chore(deps): update dependency org.sonatype.central:central-publishing-maven-plugin to v0.8.0"

### DIFF
--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -197,7 +197,7 @@
                 <plugin>
                     <groupId>org.sonatype.central</groupId>
                     <artifactId>central-publishing-maven-plugin</artifactId>
-                    <version>0.8.0</version>
+                    <version>0.7.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Grund Problem bei [Release](https://github.com/it-at-m/Wahllokalsystem/actions/runs/16494537459/job/46637010126):

<img width="2150" height="244" alt="grafik" src="https://github.com/user-attachments/assets/194c83f2-8b89-4db0-b721-df917aebfbc7" />
<img width="2122" height="338" alt="grafik" src="https://github.com/user-attachments/assets/9de1bbeb-6331-4ecd-b8d4-60f14cc3c187" />
<img width="1661" height="194" alt="grafik" src="https://github.com/user-attachments/assets/8b4f7f0e-de65-4a7d-98a3-b6bb0c3b1456" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to use an earlier version of a publishing plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->