### PR TITLE
1685 - "Störungen" soll "Ereignisse" heissen

### DIFF
--- a/docs/src/about/index.md
+++ b/docs/src/about/index.md
@@ -45,7 +45,7 @@ trotzdem möglich. Das erfolgreiche Laden ermöglicht später auch eine reibungs
 Folgende Daten werden bei einer **Kommunalwahl** von beiden Wahlbezirksarten "Urnenwahlbezirk" und "Briefwahlbezirk"
 geladen:
 *Wahlvorstand*, *Wahlvorschläge*, *Kopfdaten*, *Konfigurationen*, *Handbuch*, *Wahlvorbereitung*, *Eröffnungsuhrzeit*,
-*Störungen*, *Druckstatus*, *Stapel c - gültige Stimmzettel*, *Stapel c - ungültige Stimmzettel*, *Stapel b -
+*Ereignisse*, *Druckstatus*, *Stapel c - gültige Stimmzettel*, *Stapel c - ungültige Stimmzettel*, *Stapel b -
 ungekennzeichnete Stimmzettel*, *Begründung - Stapel a*, *Stapel d*, *Stapel a*, *Stapel b*, *Begründung Stapel ab*,
 *Stapel b-c*, *FortsetzungsUhrzeit*, *UnterbrechungsUhrzeit*
 

--- a/wls-gui-wahllokalsystem/src/components/wahlvorbereitung/TheUnguetilgeWahlscheineVerifyCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlvorbereitung/TheUnguetilgeWahlscheineVerifyCard.vue
@@ -53,7 +53,7 @@
               </li>
               <li>
                 Erfassen Sie dies als besonderes Vorkommnis unter dem Punkt
-                "Störungen".
+                "Ereignisse".
               </li>
             </ul>
           </div>

--- a/wls-gui-wahllokalsystem/src/composables/vorfaelleundvorkommnisse/ereignisService.ts
+++ b/wls-gui-wahllokalsystem/src/composables/vorfaelleundvorkommnisse/ereignisService.ts
@@ -39,14 +39,14 @@ export function useEreignisService() {
       );
       if (sendNotification) {
         userNotificationService.addNotification(
-          "Die Störungen wurden erfolgreich gespeichert",
+          "Die Ereignisse wurden erfolgreich gespeichert",
           UserNotificationCategoryEnum.SUCCESS
         );
       }
     } catch (error) {
       if (sendNotification) {
         userNotificationService.addNotification(
-          "Das Speichern der Störungen schlug fehl.",
+          "Das Speichern der Ereignisse schlug fehl.",
           UserNotificationCategoryEnum.ERROR
         );
       }

--- a/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/__snapshots__/TheUnguetilgeWahlscheineVerifyCard.vue/visual logic/should_renderInvalidWahlscheinAndChangeSearchButtonLabel_when_wahlscheinnummerIsPartOfUngueltigeWahlscheine.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/__snapshots__/TheUnguetilgeWahlscheineVerifyCard.vue/visual logic/should_renderInvalidWahlscheinAndChangeSearchButtonLabel_when_wahlscheinnummerIsPartOfUngueltigeWahlscheine.html
@@ -91,7 +91,7 @@
                   <li> Die Person darf mit diesem Wahlschein keine Stimme abgeben! </li>
                   <li>Behalten Sie den Wahlschein ein.</li>
                   <li> Fassen Sie einen Beschluss über die Zurückweisung der wählenden Person. </li>
-                  <li> Erfassen Sie dies als besonderes Vorkommnis unter dem Punkt "Störungen". </li>
+                  <li> Erfassen Sie dies als besonderes Vorkommnis unter dem Punkt "Ereignisse". </li>
                 </ul>
               </div>
             </div>

--- a/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/__snapshots__/TheUnguetilgeWahlscheineVerifyCard.vue/visual logic/should_renderInvalidWahlschein_when_wahlscheinnummerIsPartOfUngueltigeWahlscheine.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlvorbereitung/__snapshots__/TheUnguetilgeWahlscheineVerifyCard.vue/visual logic/should_renderInvalidWahlschein_when_wahlscheinnummerIsPartOfUngueltigeWahlscheine.html
@@ -108,7 +108,7 @@
                   <li> Die Person darf mit diesem Wahlschein keine Stimme abgeben! </li>
                   <li>Behalten Sie den Wahlschein ein.</li>
                   <li> Fassen Sie einen Beschluss über die Zurückweisung der wählenden Person. </li>
-                  <li> Erfassen Sie dies als besonderes Vorkommnis unter dem Punkt "Störungen". </li>
+                  <li> Erfassen Sie dies als besonderes Vorkommnis unter dem Punkt "Ereignisse". </li>
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
# Beschreibung:

*Beschreben Sie hier die wesentlichen Aufgaben, die damit erledigt wurden und geben sie Hinweise zum Review.*

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Dokumentation -->
### Dokumentation
- [x] Links geprüft
- [x] Texte auf Rechtschreibung und Grammatik geprüft

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Doku aktualisiert
- [x] Unit-Tests gepflegt
- [x] Komponententests gepflegt
- [x] Texte auf Rechtschreibung und Grammatik geprüft

# Referenzen[^1]:

Verwandt mit Issue #

Closes #1685

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology in the municipal election use case documentation, replacing "Störungen" with "Ereignisse" in the initial data loading step.

* **Bug Fixes**
  * Changed UI labels and user instructions to use "Ereignisse" instead of "Störungen" when recording special incidents related to invalid voting certificates.
  * Updated notification messages to reflect the new terminology.

* **Tests**
  * Adjusted test snapshots to match the updated terminology in user-facing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->