### PR TITLE
Enable vuetify auto import

### DIFF
--- a/wls-gui-wahllokalsystem/src/App.vue
+++ b/wls-gui-wahllokalsystem/src/App.vue
@@ -22,7 +22,6 @@
 import localforage from "localforage";
 import { storeToRefs } from "pinia";
 import { onMounted, onUnmounted } from "vue";
-import { VApp, VContainer, VFadeTransition, VMain } from "vuetify/components";
 
 import TheBroadcastReadConfirmationDialog from "@/components/broadcast/TheBroadcastReadConfirmationDialog.vue";
 import TheWahlvorstandAnwesenheitsCheckPopupDialog from "@/components/wahlvorstand/TheWahlvorstandAnwesenheitsCheckPopupDialog.vue";

--- a/wls-gui-wahllokalsystem/src/components/basisdaten/BaseInfoHelpListItem.vue
+++ b/wls-gui-wahllokalsystem/src/components/basisdaten/BaseInfoHelpListItem.vue
@@ -27,8 +27,6 @@
   </v-hover>
 </template>
 <script setup lang="ts">
-import { VHover, VListItem } from "vuetify/components";
-
 import BaseInfoHelpListItemContent from "@/components/basisdaten/BaseInfoHelpListItemContent.vue";
 
 const LIST_ITEM_CONTENT_MARGIN = "mx-0 my-1";

--- a/wls-gui-wahllokalsystem/src/components/basisdaten/BaseInfoHelpListItemContent.vue
+++ b/wls-gui-wahllokalsystem/src/components/basisdaten/BaseInfoHelpListItemContent.vue
@@ -18,8 +18,6 @@
   </v-row>
 </template>
 <script setup lang="ts">
-import { VCol, VIcon, VRow } from "vuetify/components";
-
 defineProps({
   title: { type: String, required: true },
   text: { type: String, required: false, default: null },

--- a/wls-gui-wahllokalsystem/src/components/basisdaten/TheInfoHelpIcon.vue
+++ b/wls-gui-wahllokalsystem/src/components/basisdaten/TheInfoHelpIcon.vue
@@ -35,15 +35,6 @@
   </v-menu>
 </template>
 <script setup lang="ts">
-import {
-  VBtn,
-  VCard,
-  VDivider,
-  VList,
-  VListItem,
-  VMenu,
-} from "vuetify/components";
-
 import BaseInfoHelpListItem from "@/components/basisdaten/BaseInfoHelpListItem.vue";
 import { useHandbuchService } from "@/composables/basisdaten/handbuchService.ts";
 import { useHelpIconCallbacks } from "@/composables/basisdaten/helpIconCallbacks.ts";

--- a/wls-gui-wahllokalsystem/src/components/broadcast/TheBroadcastReadConfirmationDialog.vue
+++ b/wls-gui-wahllokalsystem/src/components/broadcast/TheBroadcastReadConfirmationDialog.vue
@@ -40,16 +40,6 @@
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
-import {
-  VBtn,
-  VCard,
-  VCardActions,
-  VCardText,
-  VCardTitle,
-  VCheckbox,
-  VDialog,
-  VIcon,
-} from "vuetify/components";
 
 import { useBroadcastStore } from "@/stores/broadcastStore.ts";
 

--- a/wls-gui-wahllokalsystem/src/components/common/DatetimeInput.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/DatetimeInput.vue
@@ -72,14 +72,6 @@
 <script setup lang="ts">
 import { mdiClose } from "@mdi/js";
 import { computed, onMounted, ref, watch } from "vue";
-import {
-  VBtn,
-  VCol,
-  VIcon,
-  VInput,
-  VRow,
-  VTextField,
-} from "vuetify/components";
 
 /**
  * The Date-Time-Input` field offers the possibility to enter date-times without additional

--- a/wls-gui-wahllokalsystem/src/components/common/DatetimeInput.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/DatetimeInput.vue
@@ -70,6 +70,8 @@
 </template>
 
 <script setup lang="ts">
+import type { VInput } from "vuetify/components";
+
 import { mdiClose } from "@mdi/js";
 import { computed, onMounted, ref, watch } from "vue";
 

--- a/wls-gui-wahllokalsystem/src/components/common/YesNoDialog.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/YesNoDialog.vue
@@ -52,17 +52,6 @@
 </template>
 
 <script setup lang="ts">
-import {
-  VBtn,
-  VCard,
-  VCardActions,
-  VCardText,
-  VCardTitle,
-  VDialog,
-  VIcon,
-  VSpacer,
-} from "vuetify/components";
-
 /**
  * The YesNo dialog is a generic dialog for yes/no queries to the user.
  * For example, it can be used to confirm the deletion of an entity.

--- a/wls-gui-wahllokalsystem/src/components/common/buttons/BaseButtonRefresh.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/buttons/BaseButtonRefresh.vue
@@ -1,7 +1,3 @@
 <template>
   <v-btn prepend-icon="$updateTime">Aktualisieren</v-btn>
 </template>
-
-<script setup lang="ts">
-import { VBtn } from "vuetify/components";
-</script>

--- a/wls-gui-wahllokalsystem/src/components/common/buttons/BaseButtonSave.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/buttons/BaseButtonSave.vue
@@ -8,8 +8,6 @@
 </template>
 
 <script setup lang="ts">
-import { VBtn } from "vuetify/components";
-
 const props = defineProps({
   /**
    * Is the Button interactable

--- a/wls-gui-wahllokalsystem/src/components/common/cards/BaseInputFeedbackCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/cards/BaseInputFeedbackCard.vue
@@ -29,7 +29,6 @@
 import type { InputFeedbackTypeEnum } from "@/types/common/InputFeedbackTypeEnum.ts";
 
 import { computed, useSlots } from "vue";
-import { VCard, VCardText, VCardTitle, VIcon } from "vuetify/components";
 
 import { useInputFeedbackUtils } from "@/composables/common/inputFeedbackUtils.ts";
 

--- a/wls-gui-wahllokalsystem/src/components/common/dialogs/BaseDialog.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/dialogs/BaseDialog.vue
@@ -37,17 +37,6 @@
 </template>
 
 <script setup lang="ts">
-import {
-  VBtn,
-  VCard,
-  VCardActions,
-  VCardText,
-  VCardTitle,
-  VDialog,
-  VIcon,
-  VSpacer,
-} from "vuetify/components";
-
 defineProps<{
   visible: boolean;
   dialogtitle: string;

--- a/wls-gui-wahllokalsystem/src/components/common/dialogs/BaseDialogBegruendung.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/dialogs/BaseDialogBegruendung.vue
@@ -56,17 +56,6 @@
 
 <script setup lang="ts">
 import { ref } from "vue";
-import {
-  VBtn,
-  VCard,
-  VCardActions,
-  VCardText,
-  VCardTitle,
-  VDialog,
-  VIcon,
-  VSpacer,
-  VTextarea,
-} from "vuetify/components";
 
 import BaseButtonSave from "@/components/common/buttons/BaseButtonSave.vue";
 import { MAX_LENGTH, MIN_LENGTH } from "@/util/rules.ts";

--- a/wls-gui-wahllokalsystem/src/components/common/icons/BaseIconWahlbezirksart.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/icons/BaseIconWahlbezirksart.vue
@@ -9,7 +9,6 @@
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
 import { computed } from "vue";
-import { VIcon } from "vuetify/components";
 
 import { useUserStore } from "@/stores/userStore.ts";
 

--- a/wls-gui-wahllokalsystem/src/components/common/inputs/BaseDateInput.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/inputs/BaseDateInput.vue
@@ -11,7 +11,6 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { VTextField } from "vuetify/components";
 
 import { useDateTimeFormatter } from "@/composables/common/dateTimeFormatter.ts";
 import { REQUIRED } from "@/util/rules.ts";

--- a/wls-gui-wahllokalsystem/src/components/common/inputs/BaseNumberInput.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/inputs/BaseNumberInput.vue
@@ -14,7 +14,6 @@
 <script setup lang="ts">
 import { computed, watch } from "vue";
 import { CurrencyDisplay, useCurrencyInput } from "vue-currency-input";
-import { VTextField } from "vuetify/components";
 
 const props = defineProps({
   label: {

--- a/wls-gui-wahllokalsystem/src/components/common/inputs/BaseTimeInput.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/inputs/BaseTimeInput.vue
@@ -13,8 +13,6 @@
 <script setup lang="ts">
 import type { PropType } from "vue";
 
-import { VTextField } from "vuetify/components";
-
 import { useDateTimeFormatter } from "@/composables/common/dateTimeFormatter.ts";
 import { REQUIRED } from "@/util/rules.ts";
 

--- a/wls-gui-wahllokalsystem/src/components/common/progressLinear/BaseProgressLinear.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/progressLinear/BaseProgressLinear.vue
@@ -21,14 +21,6 @@
 <script setup lang="ts">
 import type { Task } from "@/types/tasks/Task.ts";
 
-import {
-  VExpansionPanel,
-  VExpansionPanels,
-  VExpansionPanelText,
-  VExpansionPanelTitle,
-  VProgressLinear,
-} from "vuetify/components";
-
 defineProps<{
   titel: string;
   isLoading: boolean;

--- a/wls-gui-wahllokalsystem/src/components/ergebnisermittlung/TheErgebnisermittlungStimmzettelumschlaegeCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/ergebnisermittlung/TheErgebnisermittlungStimmzettelumschlaegeCard.vue
@@ -29,15 +29,6 @@
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
-import {
-  VCard,
-  VCardActions,
-  VCardText,
-  VCardTitle,
-  VContainer,
-  VForm,
-  VNumberInput,
-} from "vuetify/components";
 
 import BaseButtonSave from "@/components/common/buttons/BaseButtonSave.vue";
 import { useWahlenStore } from "@/stores/wahlenStore.ts";

--- a/wls-gui-wahllokalsystem/src/components/monitoring/TheWaehleranzahlCountButton.vue
+++ b/wls-gui-wahllokalsystem/src/components/monitoring/TheWaehleranzahlCountButton.vue
@@ -15,7 +15,6 @@
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
 import { onMounted, onUnmounted } from "vue";
-import { VBtn } from "vuetify/components";
 
 import { useMonitoringCronjobService } from "@/composables/monitoring/monitoringCronjobService.ts";
 import { useMonitoringStore } from "@/stores/monitoringStore.ts";

--- a/wls-gui-wahllokalsystem/src/components/navigation/TheBWBElectionListGroup.vue
+++ b/wls-gui-wahllokalsystem/src/components/navigation/TheBWBElectionListGroup.vue
@@ -26,8 +26,6 @@
 </template>
 
 <script setup lang="ts">
-import { VListGroup, VListItem } from "vuetify/components";
-
 import {
   ROUTE_BEGINN_STIMMABGABE,
   ROUTE_ERFASSUNG_WAHLBRIEFE,

--- a/wls-gui-wahllokalsystem/src/components/navigation/TheUWBElectionListGroup.vue
+++ b/wls-gui-wahllokalsystem/src/components/navigation/TheUWBElectionListGroup.vue
@@ -26,8 +26,6 @@
 </template>
 
 <script setup lang="ts">
-import { VListGroup, VListItem } from "vuetify/components";
-
 import {
   ROUTE_BEGINN_STIMMABGABE,
   ROUTE_STIMMABGABE,

--- a/wls-gui-wahllokalsystem/src/components/vorfaelleundvorkommnisse/BaseEreignisRow.vue
+++ b/wls-gui-wahllokalsystem/src/components/vorfaelleundvorkommnisse/BaseEreignisRow.vue
@@ -39,7 +39,6 @@ import type { Ereignis } from "@/types/vorfaelleundvorkommnisse/Ereignis.ts";
 import type { PropType } from "vue";
 
 import { computed, watch } from "vue";
-import { VCol, VIcon, VRow, VTextarea } from "vuetify/components";
 
 import BaseDateInput from "@/components/common/inputs/BaseDateInput.vue";
 import BaseTimeInput from "@/components/common/inputs/BaseTimeInput.vue";

--- a/wls-gui-wahllokalsystem/src/components/vorfaelleundvorkommnisse/TheEreignisseNoEventsCheckboxes.vue
+++ b/wls-gui-wahllokalsystem/src/components/vorfaelleundvorkommnisse/TheEreignisseNoEventsCheckboxes.vue
@@ -21,7 +21,6 @@
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
 import { computed } from "vue";
-import { VCheckbox } from "vuetify/components";
 
 import { useEreignisStore } from "@/stores/ereignisStore.ts";
 import { useUserStore } from "@/stores/userStore.ts";

--- a/wls-gui-wahllokalsystem/src/components/wahlhandlung/BaseWaehlerverzeichnisCheckCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlhandlung/BaseWaehlerverzeichnisCheckCard.vue
@@ -80,15 +80,6 @@
 
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
-import {
-  VCard,
-  VCardActions,
-  VCardText,
-  VCardTitle,
-  VCheckbox,
-  VRadio,
-  VRadioGroup,
-} from "vuetify/components";
 
 import BaseButtonSave from "@/components/common/buttons/BaseButtonSave.vue";
 import BaseInputFeedbackCard from "@/components/common/cards/BaseInputFeedbackCard.vue";

--- a/wls-gui-wahllokalsystem/src/components/wahlhandlung/BaseWahleroeffnungCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlhandlung/BaseWahleroeffnungCard.vue
@@ -48,13 +48,6 @@
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
-import {
-  VCard,
-  VCardActions,
-  VCardText,
-  VCardTitle,
-  VForm,
-} from "vuetify/components";
 
 import BaseButtonSave from "@/components/common/buttons/BaseButtonSave.vue";
 import BaseDialogBegruendung from "@/components/common/dialogs/BaseDialogBegruendung.vue";

--- a/wls-gui-wahllokalsystem/src/components/wahlhandlung/BaseWahlschliessungCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlhandlung/BaseWahlschliessungCard.vue
@@ -31,7 +31,6 @@
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
-import { VCardActions, VCardText, VCardTitle, VForm } from "vuetify/components";
 
 import BaseButtonSave from "@/components/common/buttons/BaseButtonSave.vue";
 import BaseTimeInput from "@/components/common/inputs/BaseTimeInput.vue";

--- a/wls-gui-wahllokalsystem/src/components/wahlhandlung/BaseWahlumgebungWahlurnenDiv.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlhandlung/BaseWahlumgebungWahlurnenDiv.vue
@@ -20,8 +20,6 @@
 <script setup lang="ts">
 import type { Wahlvorbereitung } from "@/types/wahlhandlung/Wahlvorbereitung.ts";
 
-import { VNumberInput } from "vuetify/components";
-
 import { useWahlenStore } from "@/stores/wahlenStore.ts";
 import { MAX_NUMBER, MIN_NUMBER, REQUIRED } from "@/util/rules.ts";
 

--- a/wls-gui-wahllokalsystem/src/components/wahlhandlung/TheUnguetilgeWahlscheineVerifyCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlhandlung/TheUnguetilgeWahlscheineVerifyCard.vue
@@ -100,6 +100,7 @@
 <script setup lang="ts">
 import type { UngueltigerWahlschein } from "@/types/wahlbezirk/UngueltigerWahlschein.ts";
 import type { ShallowRef } from "vue";
+import type { VForm } from "vuetify/components";
 
 import { storeToRefs } from "pinia";
 import { computed, ref, useTemplateRef } from "vue";

--- a/wls-gui-wahllokalsystem/src/components/wahlhandlung/TheUnguetilgeWahlscheineVerifyCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlhandlung/TheUnguetilgeWahlscheineVerifyCard.vue
@@ -103,15 +103,6 @@ import type { ShallowRef } from "vue";
 
 import { storeToRefs } from "pinia";
 import { computed, ref, useTemplateRef } from "vue";
-import {
-  VBtn,
-  VCardActions,
-  VCardText,
-  VCardTitle,
-  VForm,
-  VImg,
-  VNumberInput,
-} from "vuetify/components";
 
 import wahlscheinExampleImage from "@/assets/previewWahlscheinnummerOnWahlschein.png";
 import BaseButtonRefresh from "@/components/common/buttons/BaseButtonRefresh.vue";

--- a/wls-gui-wahllokalsystem/src/components/wahlhandlung/TheWahlbriefErfassungCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlhandlung/TheWahlbriefErfassungCard.vue
@@ -99,14 +99,6 @@
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
-import {
-  VCard,
-  VCardActions,
-  VCardText,
-  VCardTitle,
-  VForm,
-  VNumberInput,
-} from "vuetify/components";
 
 import BaseButtonSave from "@/components/common/buttons/BaseButtonSave.vue";
 import BaseTimeInput from "@/components/common/inputs/BaseTimeInput.vue";

--- a/wls-gui-wahllokalsystem/src/components/wahlhandlung/TheWahlumgebungBwbCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlhandlung/TheWahlumgebungBwbCard.vue
@@ -32,15 +32,6 @@
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
-import {
-  VCard,
-  VCardActions,
-  VCardText,
-  VCardTitle,
-  VCheckbox,
-  VContainer,
-  VForm,
-} from "vuetify/components";
 
 import BaseButtonSave from "@/components/common/buttons/BaseButtonSave.vue";
 import BaseWahlumgebungWahlurnenDiv from "@/components/wahlhandlung/BaseWahlumgebungWahlurnenDiv.vue";

--- a/wls-gui-wahllokalsystem/src/components/wahlhandlung/TheWahlumgebungUwbCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlhandlung/TheWahlumgebungUwbCard.vue
@@ -84,16 +84,6 @@
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
-import {
-  VCard,
-  VCardActions,
-  VCardText,
-  VCardTitle,
-  VCheckbox,
-  VContainer,
-  VForm,
-  VNumberInput,
-} from "vuetify/components";
 
 import BaseButtonSave from "@/components/common/buttons/BaseButtonSave.vue";
 import BaseInputFeedbackCard from "@/components/common/cards/BaseInputFeedbackCard.vue";

--- a/wls-gui-wahllokalsystem/src/components/wahlhandlung/beanstandeteWahlbriefe/TheBeanstandeteWahlbriefeErfassenCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlhandlung/beanstandeteWahlbriefe/TheBeanstandeteWahlbriefeErfassenCard.vue
@@ -26,14 +26,6 @@
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
-import {
-  VBtn,
-  VCard,
-  VCardActions,
-  VCardText,
-  VCardTitle,
-  VForm,
-} from "vuetify/components";
 
 import BaseButtonSave from "@/components/common/buttons/BaseButtonSave.vue";
 import TheBeanstandeteWahlbriefeTable from "@/components/wahlhandlung/beanstandeteWahlbriefe/TheBeanstandeteWahlbriefeTable.vue";

--- a/wls-gui-wahllokalsystem/src/components/wahlhandlung/beanstandeteWahlbriefe/TheBeanstandeteWahlbriefeRowStatusIcon.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlhandlung/beanstandeteWahlbriefe/TheBeanstandeteWahlbriefeRowStatusIcon.vue
@@ -10,7 +10,6 @@
 
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
-import { VIcon } from "vuetify/components";
 
 import { useWahlenStore } from "@/stores/wahlenStore.ts";
 

--- a/wls-gui-wahllokalsystem/src/components/wahlhandlung/beanstandeteWahlbriefe/TheBeanstandeteWahlbriefeTable.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlhandlung/beanstandeteWahlbriefe/TheBeanstandeteWahlbriefeTable.vue
@@ -92,7 +92,6 @@ import type { Wahl } from "@/types/wahl/Wahl.ts";
 
 import { storeToRefs } from "pinia";
 import { computed, onMounted, ref } from "vue";
-import { VAutocomplete, VBtn, VRow, VTable } from "vuetify/components";
 
 import TheBeanstandeteWahlbriefeRowStatusIcon from "@/components/wahlhandlung/beanstandeteWahlbriefe/TheBeanstandeteWahlbriefeRowStatusIcon.vue";
 import { useBeanstandeteWahlbriefeMapper } from "@/composables/briefwahl/beanstandeteWahlbriefeMapper.ts";

--- a/wls-gui-wahllokalsystem/src/components/wahlvorbereitung/beanstandeteWahlbriefe/TheBeanstandeteWahlbriefeBeschlussergebnis.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlvorbereitung/beanstandeteWahlbriefe/TheBeanstandeteWahlbriefeBeschlussergebnis.vue
@@ -53,7 +53,6 @@
 
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
-import { VCard, VCardText, VCardTitle, VTable } from "vuetify/components";
 
 import { useBeanstandeteWahlbriefeMapper } from "@/composables/briefwahl/beanstandeteWahlbriefeMapper.ts";
 import { useWahlenStore } from "@/stores/wahlenStore.ts";

--- a/wls-gui-wahllokalsystem/src/components/wahlvorstand/TheNachbesetzungDruckenButton.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlvorstand/TheNachbesetzungDruckenButton.vue
@@ -12,7 +12,6 @@
 import type { NachbesetzungsDruckInput } from "@/types/wahlvorstand/NachbesetzungsDruckInput.ts";
 
 import { storeToRefs } from "pinia";
-import { VBtn } from "vuetify/components";
 
 import { useDateTimeFormatter } from "@/composables/common/dateTimeFormatter.ts";
 import { useWahlvorstandNachbesetzungsDruck } from "@/composables/wahlvorstand/wahlvorstandNachbesetzungsDruck.ts";

--- a/wls-gui-wahllokalsystem/src/components/wahlvorstand/TheWahlvorstandLastSendDiv.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlvorstand/TheWahlvorstandLastSendDiv.vue
@@ -9,8 +9,6 @@
 </template>
 
 <script setup lang="ts">
-import { VIcon } from "vuetify/components";
-
 import { useDateTimeFormatter } from "@/composables/common/dateTimeFormatter.ts";
 import { useWahlvorstandStore } from "@/stores/wahlvorstandStore";
 

--- a/wls-gui-wahllokalsystem/src/components/wahlvorstand/TheWahlvorstandLatestLoadDiv.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlvorstand/TheWahlvorstandLatestLoadDiv.vue
@@ -9,8 +9,6 @@
 </template>
 
 <script setup lang="ts">
-import { VIcon } from "vuetify/components";
-
 import { useDateTimeFormatter } from "@/composables/common/dateTimeFormatter.ts";
 import { useWahlvorstandStore } from "@/stores/wahlvorstandStore";
 

--- a/wls-gui-wahllokalsystem/src/components/wahlvorstand/TheWahlvorstandMitgliederTable.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlvorstand/TheWahlvorstandMitgliederTable.vue
@@ -34,7 +34,6 @@
 import type { Wahlvorstandsmitglied } from "@/types/wahlvorstand/Wahlvorstandsmitglied";
 
 import { computed } from "vue";
-import { VCheckbox, VTable } from "vuetify/components";
 
 import { useWahlvorstandStore } from "@/stores/wahlvorstandStore";
 

--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/BaseOfflineLoading.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/BaseOfflineLoading.vue
@@ -45,7 +45,6 @@
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
 import { computed } from "vue";
-import { VContainer, VProgressLinear } from "vuetify/components";
 
 import BaseProgressLinear from "@/components/common/progressLinear/BaseProgressLinear.vue";
 import { useTaskManagerStore } from "@/stores/taskManagerStore.ts";

--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/OfflineSyncer.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/OfflineSyncer.vue
@@ -34,11 +34,10 @@ import type { IdbObject } from "@/types/wlsTypes/IdbObject";
 import axios from "axios";
 import localforage from "localforage";
 import { mergeProps, ref } from "vue";
-import { VBtn, VCard, VDialog, VTooltip } from "vuetify/components";
 
 import { basicPostConfig } from "@/api/axios-utils";
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { useInterval } from "@/composables/useInterval";
 
 const dialog = ref(false);
 const statusText = ref("");

--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/OfflineSyncer.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/OfflineSyncer.vue
@@ -36,8 +36,8 @@ import localforage from "localforage";
 import { mergeProps, ref } from "vue";
 
 import { basicPostConfig } from "@/api/axios-utils";
-
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { useInterval } from "@/composables/useInterval";
 
 const dialog = ref(false);
 const statusText = ref("");

--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/TheWlsAppBar.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/TheWlsAppBar.vue
@@ -64,15 +64,6 @@
 import { useToggle } from "@vueuse/core";
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
-import {
-  VAppBar,
-  VAppBarNavIcon,
-  VCol,
-  VList,
-  VListItem,
-  VNavigationDrawer,
-  VRow,
-} from "vuetify/components";
 
 import TheInfoHelpIcon from "@/components/basisdaten/TheInfoHelpIcon.vue";
 import BaseIconWahlbezirksart from "@/components/common/icons/BaseIconWahlbezirksart.vue";

--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/WlsHeartbeat.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/WlsHeartbeat.vue
@@ -48,16 +48,6 @@
 <script setup lang="ts">
 import axios from "axios";
 import { ref } from "vue";
-import {
-  VBtn,
-  VCard,
-  VDivider,
-  VList,
-  VListItem,
-  VMenu,
-  VRow,
-  VSpacer,
-} from "vuetify/components";
 
 import { basicPostConfig } from "@/api/axios-utils";
 import OfflineSyncer from "@/components/wlsComponents/OfflineSyncer.vue";

--- a/wls-gui-wahllokalsystem/src/views/EreignisseView.vue
+++ b/wls-gui-wahllokalsystem/src/views/EreignisseView.vue
@@ -31,14 +31,6 @@ import type { Ref } from "vue";
 
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
-import {
-  VBtn,
-  VCard,
-  VCardActions,
-  VCardText,
-  VCardTitle,
-  VForm,
-} from "vuetify/components";
 
 import BaseButtonSave from "@/components/common/buttons/BaseButtonSave.vue";
 import TheEreignisseNoEventsCheckboxes from "@/components/vorfaelleundvorkommnisse/TheEreignisseNoEventsCheckboxes.vue";

--- a/wls-gui-wahllokalsystem/src/views/ExampleError404View.vue
+++ b/wls-gui-wahllokalsystem/src/views/ExampleError404View.vue
@@ -14,7 +14,5 @@
 </template>
 
 <script setup lang="ts">
-import { VCol, VContainer } from "vuetify/components";
-
 import { ROUTES_HOME } from "@/constants";
 </script>

--- a/wls-gui-wahllokalsystem/src/views/HomeView.vue
+++ b/wls-gui-wahllokalsystem/src/views/HomeView.vue
@@ -5,7 +5,5 @@
 </template>
 
 <script setup lang="ts">
-import { VContainer } from "vuetify/components";
-
 import BaseOfflineLoading from "@/components/wlsComponents/BaseOfflineLoading.vue";
 </script>

--- a/wls-gui-wahllokalsystem/src/views/WahlvorstandAnwesenheitView.vue
+++ b/wls-gui-wahllokalsystem/src/views/WahlvorstandAnwesenheitView.vue
@@ -37,7 +37,6 @@
 
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
-import { VCard, VCardActions, VCardText, VCardTitle } from "vuetify/components";
 
 import BaseButtonRefresh from "@/components/common/buttons/BaseButtonRefresh.vue";
 import BaseButtonSave from "@/components/common/buttons/BaseButtonSave.vue";

--- a/wls-gui-wahllokalsystem/src/views/wahlhandlung/UWBStimmabgabeView.vue
+++ b/wls-gui-wahllokalsystem/src/views/wahlhandlung/UWBStimmabgabeView.vue
@@ -6,8 +6,6 @@
 </template>
 
 <script setup lang="ts">
-import { VCard } from "vuetify/components";
-
 import BaseWahlschliessungCard from "@/components/wahlhandlung/BaseWahlschliessungCard.vue";
 import TheUnguetilgeWahlscheineVerifyCard from "@/components/wahlhandlung/TheUnguetilgeWahlscheineVerifyCard.vue";
 </script>

--- a/wls-gui-wahllokalsystem/vite.config.ts
+++ b/wls-gui-wahllokalsystem/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
       styles: {
         configFile: "src/styles/settings.scss",
       },
-      autoImport: false,
+      autoImport: true,
     }),
     UnpluginFonts({
       fontsource: {

--- a/wls-gui-wahllokalsystem/vite.config.ts
+++ b/wls-gui-wahllokalsystem/vite.config.ts
@@ -21,7 +21,6 @@ export default defineConfig({
       styles: {
         configFile: "src/styles/settings.scss",
       },
-      autoImport: true,
     }),
     UnpluginFonts({
       fontsource: {


### PR DESCRIPTION
# Beschreibung:

- autoImport auf true gestellt
- manuelle imports entfernt



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automatic import of Vuetify components and styles, eliminating the need for manual imports throughout the application.
  * Removed explicit Vuetify component imports from all relevant files for a cleaner and more maintainable codebase.

No changes to functionality or user interface are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->