### PR TITLE
#1695 :recycle: schliessungsuhrzeit

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/vorfaelleundvorkommnisse/TheEreignisseNoEventsCheckboxes.vue
+++ b/wls-gui-wahllokalsystem/src/components/vorfaelleundvorkommnisse/TheEreignisseNoEventsCheckboxes.vue
@@ -26,7 +26,7 @@ import { useEreignisStore } from "@/stores/ereignisStore.ts";
 import { useUserStore } from "@/stores/userStore.ts";
 import { useWahlbezirkStore } from "@/stores/wahlbezirkStore.ts";
 
-const { schliessungsuhrzeitSent } = storeToRefs(useWahlbezirkStore());
+const { schliessungsuhrzeitState } = storeToRefs(useWahlbezirkStore());
 const { wahlbezirkEreignisse, hasVorkommnisse, hasVorfaelle } =
   storeToRefs(useEreignisStore());
 const { isBWB } = storeToRefs(useUserStore());
@@ -39,7 +39,7 @@ const isCheckboxNoVorkommnisseDisabled = computed(() => {
   if (isBWB.value) {
     return false;
   }
-  return schliessungsuhrzeitSent.value === undefined;
+  return schliessungsuhrzeitState.value.schliessungsuhrzeitSent === undefined;
 });
 const showCheckboxNoVorfaelle = computed(() => !isBWB.value);
 </script>

--- a/wls-gui-wahllokalsystem/src/components/wahlhandlung/BaseWahlschliessungCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlhandlung/BaseWahlschliessungCard.vue
@@ -6,7 +6,7 @@
       erklärt wurde.
       <v-form v-model="schliessungsuhrzeitValidForm">
         <base-time-input
-          v-model="schliessungsuhrzeit"
+          v-model="schliessungsuhrzeitState.schliessungsuhrzeit"
           class="mt-5"
           max-width="300"
           :rules="[
@@ -20,7 +20,7 @@
     <v-card-actions>
       <base-button-save
         active
-        :loading="schliessungsuhrzeitIsSaving"
+        :loading="schliessungsuhrzeitState.schliessungsuhrzeitIsSaving"
         :disabled="isSaveButtonDisabled"
         @click="onSaveSchliessungsuhrzeitClicked"
       />
@@ -42,9 +42,8 @@ import {
   TIME_NOT_IN_FUTURE,
 } from "@/util/rules.ts";
 
-const { sendSchliessungsuhrzeit } = useWahlbezirkStore();
-const { schliessungsuhrzeit, schliessungsuhrzeitIsSaving } =
-  storeToRefs(useWahlbezirkStore());
+const { schliessungsuhrzeitActions } = useWahlbezirkStore();
+const { schliessungsuhrzeitState } = storeToRefs(useWahlbezirkStore());
 const { fruehesteSchliessungsuhrzeit } = storeToRefs(useInfomanagementStore());
 
 const schliessungsuhrzeitValidForm = ref<null | boolean>(null);
@@ -54,6 +53,6 @@ const isSaveButtonDisabled = computed(
 );
 
 function onSaveSchliessungsuhrzeitClicked() {
-  sendSchliessungsuhrzeit();
+  schliessungsuhrzeitActions.sendSchliessungsuhrzeit();
 }
 </script>

--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/TheWlsAppBar.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/TheWlsAppBar.vue
@@ -30,7 +30,7 @@
           <the-waehleranzahl-count-button
             v-if="
               eroeffnungsuhrzeitSent !== undefined &&
-              schliessungsuhrzeitSent === undefined &&
+              schliessungsuhrzeitState.schliessungsuhrzeitSent === undefined &&
               isUWB
             "
           />
@@ -78,7 +78,7 @@ import { useTaskManagerStore } from "@/stores/taskManagerStore.ts";
 import { useUserStore } from "@/stores/userStore.ts";
 import { useWahlbezirkStore } from "@/stores/wahlbezirkStore.ts";
 
-const { eroeffnungsuhrzeitSent, schliessungsuhrzeitSent } =
+const { eroeffnungsuhrzeitSent, schliessungsuhrzeitState } =
   storeToRefs(useWahlbezirkStore());
 
 const { toGermanDateFormat } = useDateTimeFormatter();

--- a/wls-gui-wahllokalsystem/src/stores/ereignisStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/ereignisStore.ts
@@ -30,7 +30,7 @@ export const useEreignisStore = defineStore(storeID, () => {
   const error = ref<string | null>(null);
 
   const { currentUserWahlbezirkID, isUWB } = storeToRefs(useUserStore());
-  const { schliessungsuhrzeitSent } = storeToRefs(useWahlbezirkStore());
+  const { schliessungsuhrzeitState } = storeToRefs(useWahlbezirkStore());
 
   const isSaving = ref(false);
 
@@ -58,7 +58,7 @@ export const useEreignisStore = defineStore(storeID, () => {
     () =>
       hasVorfaelle.value !== wahlbezirkEreignisse.value.keineVorfaelle &&
       (hasVorkommnisse.value !== wahlbezirkEreignisse.value.keineVorkommnisse ||
-        !schliessungsuhrzeitSent.value)
+        !schliessungsuhrzeitState.value.schliessungsuhrzeitSent)
   );
 
   const hasMissingEreignisFlagsForBWB = computed(
@@ -73,7 +73,10 @@ export const useEreignisStore = defineStore(storeID, () => {
       : hasMissingEreignisFlagsForBWB.value;
   });
 
-  watch(schliessungsuhrzeitSent, _onSchliessunguhrzeitSentChanged);
+  watch(
+    () => schliessungsuhrzeitState.value.schliessungsuhrzeitSent,
+    _onSchliessunguhrzeitSentChanged
+  );
 
   function addEreignis(ereignisToAddTemplate?: EreignisCreateTemplate) {
     const ereignisToAdd = _createEreignis(ereignisToAddTemplate);
@@ -110,7 +113,7 @@ export const useEreignisStore = defineStore(storeID, () => {
         ereignisToChange.ereignisart =
           getEreignisArtForDateRelatedToSchliessungsuhrzeit(
             uhrzeit,
-            schliessungsuhrzeitSent.value
+            schliessungsuhrzeitState.value.schliessungsuhrzeitSent
           );
         _updateKeineFlagsOfEreignisseBasedOnCurrentState();
       } else {
@@ -167,7 +170,7 @@ export const useEreignisStore = defineStore(storeID, () => {
     const uhrzeit = nonDefaultValues?.uhrzeit ?? new Date();
     const ereignisart = getEreignisArtForDateRelatedToSchliessungsuhrzeit(
       uhrzeit,
-      schliessungsuhrzeitSent.value
+      schliessungsuhrzeitState.value.schliessungsuhrzeitSent
     );
     const beschreibung = nonDefaultValues?.beschreibung;
 
@@ -187,7 +190,7 @@ export const useEreignisStore = defineStore(storeID, () => {
   }
 
   function _hasToUpdateKeineVorkommnisse(): boolean {
-    return schliessungsuhrzeitSent.value !== undefined;
+    return schliessungsuhrzeitState.value.schliessungsuhrzeitSent !== undefined;
   }
 
   function _onSchliessunguhrzeitSentChanged(

--- a/wls-gui-wahllokalsystem/src/stores/wahlbezirkStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/wahlbezirkStore.ts
@@ -3,6 +3,7 @@ import type { PflegeWaehlerverzeichnis } from "@/types/wahlbezirk/PflegeWaehlerv
 import type { UngueltigerWahlschein } from "@/types/wahlbezirk/UngueltigerWahlschein.ts";
 import type { Urnenwahlvorbereitung } from "@/types/wahlhandlung/Urnenwahlvorbereitung.ts";
 import type { Wahlvorbereitung } from "@/types/wahlhandlung/Wahlvorbereitung.ts";
+import type { Ref } from "vue";
 
 import { defineStore, storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
@@ -47,14 +48,45 @@ export const useWahlbezirkStore = defineStore(storeID, () => {
   const eroeffnungsuhrzeitSent = ref<Date | undefined>(undefined);
   const eroeffnungsuhrzeitIsSaving = ref(false);
 
+  /* --- schliessungsuhrzeit --- */
+  const schliessungsuhrzeitState: Ref<{
+    schliessungsuhrzeit: Date | undefined;
+    schliessungsuhrzeitSent: Date | undefined;
+    schliessungsuhrzeitIsSaving: boolean;
+  }> = ref({
+    schliessungsuhrzeit: undefined,
+    schliessungsuhrzeitSent: undefined,
+    schliessungsuhrzeitIsSaving: false,
+  });
+
+  const schliessungsuhrzeitActions = {
+    sendSchliessungsuhrzeit: async function sendSchliessungsuhrzeit() {
+      if (schliessungsuhrzeitState.value.schliessungsuhrzeit) {
+        const schliessungszeitToSave = new Date(
+          schliessungsuhrzeitState.value.schliessungsuhrzeit
+        );
+        if (isValidDate(schliessungszeitToSave)) {
+          schliessungsuhrzeitState.value.schliessungsuhrzeitIsSaving = true;
+          try {
+            await postUrnenwahlSchliessungsuhrzeit(
+              currentUserWahlbezirkID.value,
+              schliessungszeitToSave
+            );
+            schliessungsuhrzeitState.value.schliessungsuhrzeitSent =
+              schliessungszeitToSave;
+          } finally {
+            schliessungsuhrzeitState.value.schliessungsuhrzeitIsSaving = false;
+          }
+        }
+      }
+    },
+  };
+
   const pflegeWaehlerverzeichnis = ref<PflegeWaehlerverzeichnis>(
     createDefaultPflegeWaehlerverzeichnis()
   );
   const pflegeWaehlerverzeichnisIsSaving = ref(false);
 
-  const schliessungsuhrzeit = ref<Date | undefined>(undefined);
-  const schliessungsuhrzeitSent = ref<Date | undefined>(undefined);
-  const schliessungsuhrzeitIsSaving = ref(false);
   const urnenWahlVorbereitungIsSaving = ref(false);
   const briefWahlVorbereitungIsSaving = ref(false);
   const ungueltigeWahlscheine = ref<UngueltigerWahlschein[]>([]);
@@ -190,24 +222,6 @@ export const useWahlbezirkStore = defineStore(storeID, () => {
     }
   }
 
-  async function sendSchliessungsuhrzeit() {
-    if (schliessungsuhrzeit.value) {
-      const schliessungszeitToSave = new Date(schliessungsuhrzeit.value);
-      if (isValidDate(schliessungszeitToSave)) {
-        schliessungsuhrzeitIsSaving.value = true;
-        try {
-          await postUrnenwahlSchliessungsuhrzeit(
-            currentUserWahlbezirkID.value,
-            schliessungszeitToSave
-          );
-          schliessungsuhrzeitSent.value = schliessungszeitToSave;
-        } finally {
-          schliessungsuhrzeitIsSaving.value = false;
-        }
-      }
-    }
-  }
-
   async function sendUrnenwahlvorbereitung() {
     const wahlbezirkID = currentUserWahlbezirkID.value;
     urnenWahlVorbereitungIsSaving.value = true;
@@ -252,11 +266,10 @@ export const useWahlbezirkStore = defineStore(storeID, () => {
     eroeffnungsuhrzeit,
     eroeffnungsuhrzeitIsSaving,
     eroeffnungsuhrzeitSent,
+    schliessungsuhrzeitState,
+    schliessungsuhrzeitActions,
     pflegeWaehlerverzeichnis,
     pflegeWaehlerverzeichnisIsSaving,
-    schliessungsuhrzeit,
-    schliessungsuhrzeitIsSaving,
-    schliessungsuhrzeitSent,
     ungueltigeWahlscheine,
     ungueltigeWahlscheineIsLoading,
     ungueltigeWahlscheineIsEmpty,
@@ -267,7 +280,6 @@ export const useWahlbezirkStore = defineStore(storeID, () => {
     loadUngueltigeWahlscheine,
     sendEroeffnungsuhrzeit,
     sendPflegeWaehlerverzeichnis,
-    sendSchliessungsuhrzeit,
     sendUrnenwahlvorbereitung,
     urnenwahlVorbereitung,
     urnenWahlVorbereitungIsSaving,

--- a/wls-gui-wahllokalsystem/src/stores/wahlvorstandStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/wahlvorstandStore.ts
@@ -24,7 +24,7 @@ const { registerStoreHMR } = useHmrUpdate();
 
 export const useWahlvorstandStore = defineStore(storeID, () => {
   const { currentUserWahlbezirkID } = storeToRefs(useUserStore());
-  const { schliessungsuhrzeitSent } = storeToRefs(useWahlbezirkStore());
+  const { schliessungsuhrzeitState } = storeToRefs(useWahlbezirkStore());
 
   const isLoading = ref(false);
   const isSaving = ref(false);
@@ -46,7 +46,7 @@ export const useWahlvorstandStore = defineStore(storeID, () => {
     const anwesend = wahlvorstand.value.wahlvorstandsmitglieder.filter(
       (mitglied) => mitglied.anwesend
     ).length;
-    if (!schliessungsuhrzeitSent.value) {
+    if (!schliessungsuhrzeitState.value.schliessungsuhrzeitSent) {
       return anwesend >= MIN_WAHLVORSTAND_ANWESEND_VOR_SCHLIESSUNG;
     } else {
       return anwesend >= MIN_WAHLVORSTAND_ANWESEND_NACH_SCHLIESSUNG;

--- a/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/TheEreignisseNoEventsCheckboxes.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/TheEreignisseNoEventsCheckboxes.spec.ts
@@ -99,7 +99,8 @@ describe("TheEreignisseNoEventsCheckboxes.vue", () => {
         useEreignisStore().wahlbezirkEreignisse.ereigniseintraege = [
           { ereignisart: "VORKOMMNIS" },
         ];
-        useWahlbezirkStore().schliessungsuhrzeitSent = undefined;
+        useWahlbezirkStore().schliessungsuhrzeitState.schliessungsuhrzeitSent =
+          undefined;
 
         await nextTick();
 
@@ -110,7 +111,8 @@ describe("TheEreignisseNoEventsCheckboxes.vue", () => {
 
       it("should_renderKeineVorkommnisseEnabled_when_noVorkommnisseAreGivenInStoreAndSchliessunguhrzeitIsSetForUWB", async (context) => {
         useEreignisStore().wahlbezirkEreignisse.ereigniseintraege = [];
-        useWahlbezirkStore().schliessungsuhrzeitSent = new Date();
+        useWahlbezirkStore().schliessungsuhrzeitState.schliessungsuhrzeitSent =
+          new Date();
 
         await nextTick();
 
@@ -121,7 +123,8 @@ describe("TheEreignisseNoEventsCheckboxes.vue", () => {
 
       it("should_renderKeineVorkommnisseDisabled_when_noVorkommnisseAreGivenInStoreButSchliessungsuhrzeitIsNotSetForUWB", async (context) => {
         useEreignisStore().wahlbezirkEreignisse.ereigniseintraege = [];
-        useWahlbezirkStore().schliessungsuhrzeitSent = undefined;
+        useWahlbezirkStore().schliessungsuhrzeitState.schliessungsuhrzeitSent =
+          undefined;
 
         await nextTick();
 
@@ -132,7 +135,8 @@ describe("TheEreignisseNoEventsCheckboxes.vue", () => {
 
       it("should_renderKeineVorkommnisseEnabled_when_noVorkommnisseAreGivenInStoreAndSchliessungsuhrzeitIsNotSetForBWB", async (context) => {
         useEreignisStore().wahlbezirkEreignisse.ereigniseintraege = [];
-        useWahlbezirkStore().schliessungsuhrzeitSent = undefined;
+        useWahlbezirkStore().schliessungsuhrzeitState.schliessungsuhrzeitSent =
+          undefined;
 
         useUserStore().setUser(
           prepareUser().wahlbezirksArt(WahlbezirksArtEnum.BWB).build()

--- a/wls-gui-wahllokalsystem/tests/components/wahlhandlung/BaseWahlschliessungCard.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/components/wahlhandlung/BaseWahlschliessungCard.spec.ts
@@ -72,7 +72,7 @@ describe("BaseWahlschliessungCard.vue", () => {
   describe(COMPONENT_RENDER_TESTS, () => {
     it("should_renderWithDisabledSaveButton_when_noUhrzeitIsEntered", async (context) => {
       const wahlbezirkStore = useWahlbezirkStore();
-      wahlbezirkStore.schliessungsuhrzeit = undefined;
+      wahlbezirkStore.schliessungsuhrzeitState.schliessungsuhrzeit = undefined;
 
       await flushPromises(); //update databinding and keep button disabled
 
@@ -87,7 +87,9 @@ describe("BaseWahlschliessungCard.vue", () => {
       infomanagementStore.fruehesteSchliessungsuhrzeit = "18:00:00";
 
       const wahlbezirkStore = useWahlbezirkStore();
-      wahlbezirkStore.schliessungsuhrzeit = new Date("2025-05-23T17:30:00");
+      wahlbezirkStore.schliessungsuhrzeitState.schliessungsuhrzeit = new Date(
+        "2025-05-23T17:30:00"
+      );
 
       await flushPromises(); //update databinding and keep button disabled
 
@@ -103,7 +105,7 @@ describe("BaseWahlschliessungCard.vue", () => {
 
       const date = new Date("2025-05-23T17:30:00");
       const wahlbezirkStore = useWahlbezirkStore();
-      wahlbezirkStore.schliessungsuhrzeit = date;
+      wahlbezirkStore.schliessungsuhrzeitState.schliessungsuhrzeit = date;
 
       await flushPromises(); //update databinding and enabled button
 
@@ -114,7 +116,7 @@ describe("BaseWahlschliessungCard.vue", () => {
 
     it("should_renderWithSaveButtonInLoadingState_when_isSavingIsTrue", async (context) => {
       const wahlbezirkStore = useWahlbezirkStore();
-      wahlbezirkStore.schliessungsuhrzeitIsSaving = true;
+      wahlbezirkStore.schliessungsuhrzeitState.schliessungsuhrzeitIsSaving = true;
 
       await nextTick();
 
@@ -128,15 +130,17 @@ describe("BaseWahlschliessungCard.vue", () => {
     it("should_updateSchliessungsuhrzeitInStore_when_validDateIsEntered", async () => {
       const wahlbezirkStore = useWahlbezirkStore();
 
-      expect(wahlbezirkStore.schliessungsuhrzeit).toBeUndefined();
+      expect(
+        wahlbezirkStore.schliessungsuhrzeitState.schliessungsuhrzeit
+      ).toBeUndefined();
 
       const schliessungsuhrzeitTimeInput = wrapper.findComponent(BaseTimeInput);
       const enteredTime = new Date();
       schliessungsuhrzeitTimeInput.vm.$emit("update:modelValue", enteredTime);
 
-      expect(wahlbezirkStore.schliessungsuhrzeit?.getTime()).toStrictEqual(
-        enteredTime.getTime()
-      );
+      expect(
+        wahlbezirkStore.schliessungsuhrzeitState.schliessungsuhrzeit?.getTime()
+      ).toStrictEqual(enteredTime.getTime());
     });
 
     it("should_callSendSchliessungsuhrzeit_when_saveButtonIsClicked", async () => {
@@ -145,9 +149,16 @@ describe("BaseWahlschliessungCard.vue", () => {
       infomanagementStore.fruehesteSchliessungsuhrzeit = "17:00:00";
 
       const wahlbezirkStore = useWahlbezirkStore();
-      wahlbezirkStore.schliessungsuhrzeit = new Date("2025-05-23T17:30:00");
+      wahlbezirkStore.schliessungsuhrzeitState.schliessungsuhrzeit = new Date(
+        "2025-05-23T17:30:00"
+      );
 
       await flushPromises();
+
+      const sendUhrzeitSpy = vi.spyOn(
+        wahlbezirkStore.schliessungsuhrzeitActions,
+        "sendSchliessungsuhrzeit"
+      );
 
       const saveButton = wrapper.findComponent(BaseButtonSave);
       await saveButton.trigger("click");
@@ -156,7 +167,7 @@ describe("BaseWahlschliessungCard.vue", () => {
         Promise.resolve()
       );
 
-      expect(wahlbezirkStore.sendSchliessungsuhrzeit).toHaveBeenCalled();
+      expect(sendUhrzeitSpy).toHaveBeenCalled();
     });
   });
 });

--- a/wls-gui-wahllokalsystem/tests/stores/ereignisStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/ereignisStore.spec.ts
@@ -69,7 +69,7 @@ describe("ereignisStore.ts", () => {
           );
 
           const wahlbezirkStore = useWahlbezirkStore();
-          wahlbezirkStore.schliessungsuhrzeitSent =
+          wahlbezirkStore.schliessungsuhrzeitState.schliessungsuhrzeitSent =
             data.schliessungsuhrzeitSent;
 
           // @ts-expect-error: cannot set readonly
@@ -565,7 +565,8 @@ describe("ereignisStore.ts", () => {
         unitUnderTest.wahlbezirkEreignisse.ereigniseintraege =
           ereignisEintraege;
 
-        wahlbezirkStore.schliessungsuhrzeitSent = schliessungsuhrzeitSend;
+        wahlbezirkStore.schliessungsuhrzeitState.schliessungsuhrzeitSent =
+          schliessungsuhrzeitSend;
 
         const spyGetEreignisArtForDateRelatedToSchliessungsuhrzeit = spyOn(
           ImportAllFromEreignisArt,

--- a/wls-gui-wahllokalsystem/tests/stores/wahlbezirkStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/wahlbezirkStore.spec.ts
@@ -501,7 +501,8 @@ describe("wahlbezirkStore.ts", () => {
   describe("sendSchliessungsuhrzeit", () => {
     it("should_updateIsSavingAndSetSentValue_when_succeeded", async () => {
       const schliessungsuhrzeit = mockedNow;
-      unitUnderTest.schliessungsuhrzeit = schliessungsuhrzeit;
+      unitUnderTest.schliessungsuhrzeitState.schliessungsuhrzeit =
+        schliessungsuhrzeit;
 
       const wahlbezirkID = "wahlbezirkID";
       useUserStore().setUser(prepareUser().wahlbezirkID(wahlbezirkID).build());
@@ -515,10 +516,14 @@ describe("wahlbezirkStore.ts", () => {
         })
       );
 
-      expect(unitUnderTest.schliessungsuhrzeitIsSaving).toStrictEqual(false);
+      expect(
+        unitUnderTest.schliessungsuhrzeitState.schliessungsuhrzeitIsSaving
+      ).toStrictEqual(false);
       const sendSchliessungsuhrzeitPromise =
-        unitUnderTest.sendSchliessungsuhrzeit();
-      expect(unitUnderTest.schliessungsuhrzeitIsSaving).toStrictEqual(true);
+        unitUnderTest.schliessungsuhrzeitActions.sendSchliessungsuhrzeit();
+      expect(
+        unitUnderTest.schliessungsuhrzeitState.schliessungsuhrzeitIsSaving
+      ).toStrictEqual(true);
 
       vi.advanceTimersByTime(timeout);
       await sendSchliessungsuhrzeitPromise;
@@ -526,10 +531,12 @@ describe("wahlbezirkStore.ts", () => {
       expect(
         mockDefinitions.postUrnenwahlSchliessungsuhrzeit.mock.calls
       ).toStrictEqual([[wahlbezirkID, schliessungsuhrzeit]]);
-      expect(unitUnderTest.schliessungsuhrzeitIsSaving).toStrictEqual(false);
-      expect(unitUnderTest.schliessungsuhrzeit?.getTime()).toStrictEqual(
-        schliessungsuhrzeit.getTime()
-      );
+      expect(
+        unitUnderTest.schliessungsuhrzeitState.schliessungsuhrzeitIsSaving
+      ).toStrictEqual(false);
+      expect(
+        unitUnderTest.schliessungsuhrzeitState.schliessungsuhrzeit?.getTime()
+      ).toStrictEqual(schliessungsuhrzeit.getTime());
     });
 
     it("should_notUpdateSchliessungsUhrzeitSent_when_postUrnenwahlSchliessungsuhrzeitFails", async () => {
@@ -537,7 +544,7 @@ describe("wahlbezirkStore.ts", () => {
       const wahlbezirkID = "wahlbezirkID";
       userStore.setUser(prepareUser().wahlbezirkID(wahlbezirkID).build());
 
-      unitUnderTest.schliessungsuhrzeit = mockedNow;
+      unitUnderTest.schliessungsuhrzeitState.schliessungsuhrzeit = mockedNow;
 
       const mockedError = new Error("Speicherfehler!");
       mockDefinitions.postUrnenwahlSchliessungsuhrzeit.mockImplementationOnce(
@@ -547,10 +554,12 @@ describe("wahlbezirkStore.ts", () => {
       );
 
       try {
-        await unitUnderTest.sendSchliessungsuhrzeit();
+        await unitUnderTest.schliessungsuhrzeitActions.sendSchliessungsuhrzeit();
       } catch (error) {
         expect(error).equals(mockedError);
-        expect(unitUnderTest.schliessungsuhrzeitSent).toBe(undefined);
+        expect(
+          unitUnderTest.schliessungsuhrzeitState.schliessungsuhrzeitSent
+        ).toBe(undefined);
         expect(
           mockDefinitions.postUrnenwahlSchliessungsuhrzeit
         ).toHaveBeenCalledWith(wahlbezirkID, mockedNow);

--- a/wls-gui-wahllokalsystem/tests/stores/wahlvorstandStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/wahlvorstandStore.spec.ts
@@ -250,8 +250,9 @@ describe("wahlvorstandStore.ts", () => {
     ])(
       "should_return'$expected'_when_schliessungsuhrzeitIs'$schliessungsuhrzeit'And'$anwesend'MitgliederAreAnwesend",
       ({ expected, schliessungsuhrzeit, anwesend }) => {
-        const { schliessungsuhrzeitSent } = storeToRefs(useWahlbezirkStore());
-        schliessungsuhrzeitSent.value = schliessungsuhrzeit;
+        const { schliessungsuhrzeitState } = storeToRefs(useWahlbezirkStore());
+        schliessungsuhrzeitState.value.schliessungsuhrzeitSent =
+          schliessungsuhrzeit;
 
         _addAnwesendeWahlvorstandsmitglieder(anwesend);
 


### PR DESCRIPTION
# Beschreibung:

Teil 2 zu #1695: refactoring der schliessungsuhrzeit

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] Unit-Tests gepflegt
- [x] Komponententests gepflegt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing feature changes.
- Refactor
  - Consolidated closing-time state and actions into a single, structured namespace to streamline data flow.
  - Updated related UI components to use the new structure; behavior and visuals remain unchanged.
- Tests
  - Adjusted unit tests to align with the reorganized state/actions structure, preserving existing test coverage and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->