### PR TITLE
#1695 :recycle: pflegeWaehlerverzeichnis

### DIFF
--- a/wls-gui-wahllokalsystem/src/App.vue
+++ b/wls-gui-wahllokalsystem/src/App.vue
@@ -40,7 +40,7 @@ const { isUWB } = storeToRefs(useUserStore());
 const { initTasks } = useTaskManagerStore();
 const { loadWaehler } = useMonitoringStore();
 const { initWahlen } = useWahlenStore();
-const { loadPflegeWaehlerverzeichnis } = useWahlbezirkStore();
+const { pflegeWaehlerverzeichnisActions } = useWahlbezirkStore();
 const { initBeanstandeteWahlbriefe } = useWahlenStore();
 
 const { startBroadcastMessageInterval, stopBroadcastMessageInterval } =
@@ -56,7 +56,7 @@ onMounted(async () => {
     await initTasks();
     await loadEreignisse();
     await loadWaehler();
-    await loadPflegeWaehlerverzeichnis();
+    await pflegeWaehlerverzeichnisActions.loadPflegeWaehlerverzeichnis();
     await initBeanstandeteWahlbriefe();
   } catch (error) {
     console.debug(error);

--- a/wls-gui-wahllokalsystem/src/components/wahlhandlung/BaseWaehlerverzeichnisCheckCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlhandlung/BaseWaehlerverzeichnisCheckCard.vue
@@ -10,7 +10,10 @@
         vornehmen müssen.
       </base-input-feedback-card>
       <v-radio-group
-        v-model="pflegeWaehlerverzeichnis.waehlerverzeichnisUnchanged"
+        v-model="
+          pflegeWaehlerverzeichnisState.pflegeWaehlerverzeichnis
+            .waehlerverzeichnisUnchanged
+        "
         class="mb-4"
         hide-details
       >
@@ -33,7 +36,10 @@
         </v-radio>
       </v-radio-group>
       <v-checkbox
-        v-model="pflegeWaehlerverzeichnis.nachtraeglicheBerichtigung"
+        v-model="
+          pflegeWaehlerverzeichnisState.pflegeWaehlerverzeichnis
+            .nachtraeglicheBerichtigung
+        "
         hide-details
       >
         <template #label>
@@ -45,7 +51,8 @@
       </v-checkbox>
       <v-checkbox
         v-model="
-          pflegeWaehlerverzeichnis.mitteilungUeberUngueltigeWahlscheineErhalten
+          pflegeWaehlerverzeichnisState.pflegeWaehlerverzeichnis
+            .mitteilungUeberUngueltigeWahlscheineErhalten
         "
         hide-details
       >
@@ -55,7 +62,8 @@
       </v-checkbox>
       <base-input-feedback-card
         v-if="
-          !pflegeWaehlerverzeichnis.mitteilungUeberUngueltigeWahlscheineErhalten
+          !pflegeWaehlerverzeichnisState.pflegeWaehlerverzeichnis
+            .mitteilungUeberUngueltigeWahlscheineErhalten
         "
         title="Ungültige Eingabe"
         type="error"
@@ -69,9 +77,12 @@
       <base-button-save
         active
         :disabled="
-          !pflegeWaehlerverzeichnis.mitteilungUeberUngueltigeWahlscheineErhalten
+          !pflegeWaehlerverzeichnisState.pflegeWaehlerverzeichnis
+            .mitteilungUeberUngueltigeWahlscheineErhalten
         "
-        :loading="pflegeWaehlerverzeichnisIsSaving"
+        :loading="
+          pflegeWaehlerverzeichnisState.pflegeWaehlerverzeichnisIsSaving
+        "
         @click="onSavePflegeWaehlerverzeichnisClicked"
       />
     </v-card-actions>
@@ -88,11 +99,10 @@ import { useWahlbezirkStore } from "@/stores/wahlbezirkStore.ts";
 const TEXT_MITTEILUNG_UEBER_UNGUELTIGE_WAHLSCHEINE =
   "Der Wahlvorstand wurde unterrichtet, dass folgende Wahlscheine für ungültig erklärt worden sind (gemäß Anlage).";
 
-const wahlbezirkStore = useWahlbezirkStore();
-const { pflegeWaehlerverzeichnis, pflegeWaehlerverzeichnisIsSaving } =
-  storeToRefs(wahlbezirkStore);
+const { pflegeWaehlerverzeichnisActions } = useWahlbezirkStore();
+const { pflegeWaehlerverzeichnisState } = storeToRefs(useWahlbezirkStore());
 
 function onSavePflegeWaehlerverzeichnisClicked() {
-  wahlbezirkStore.sendPflegeWaehlerverzeichnis();
+  pflegeWaehlerverzeichnisActions.sendPflegeWaehlerverzeichnis();
 }
 </script>

--- a/wls-gui-wahllokalsystem/src/stores/wahlbezirkStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/wahlbezirkStore.ts
@@ -3,6 +3,7 @@ import type { PflegeWaehlerverzeichnis } from "@/types/wahlbezirk/PflegeWaehlerv
 import type { UngueltigerWahlschein } from "@/types/wahlbezirk/UngueltigerWahlschein.ts";
 import type { Urnenwahlvorbereitung } from "@/types/wahlhandlung/Urnenwahlvorbereitung.ts";
 import type { Wahlvorbereitung } from "@/types/wahlhandlung/Wahlvorbereitung.ts";
+import type { Ref } from "vue";
 
 import { defineStore, storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
@@ -47,14 +48,57 @@ export const useWahlbezirkStore = defineStore(storeID, () => {
   const eroeffnungsuhrzeitSent = ref<Date | undefined>(undefined);
   const eroeffnungsuhrzeitIsSaving = ref(false);
 
-  const pflegeWaehlerverzeichnis = ref<PflegeWaehlerverzeichnis>(
-    createDefaultPflegeWaehlerverzeichnis()
-  );
-  const pflegeWaehlerverzeichnisIsSaving = ref(false);
-
   const schliessungsuhrzeit = ref<Date | undefined>(undefined);
   const schliessungsuhrzeitSent = ref<Date | undefined>(undefined);
   const schliessungsuhrzeitIsSaving = ref(false);
+
+  /* --- pflegeWaehlerverzeichnis --- */
+  const pflegeWaehlerverzeichnisState: Ref<{
+    pflegeWaehlerverzeichnis: PflegeWaehlerverzeichnis;
+    pflegeWaehlerverzeichnisIsSaving: boolean;
+  }> = ref({
+    pflegeWaehlerverzeichnis: createDefaultPflegeWaehlerverzeichnis(),
+    pflegeWaehlerverzeichnisIsSaving: false,
+  });
+
+  const pflegeWaehlerverzeichnisActions = {
+    loadPflegeWaehlerverzeichnis: async function loadPflegeWaehlerverzeichnis(
+      sendNotification = true
+    ) {
+      const waehlerverzeichnisNummer =
+        getWaehlerverzeichnisNummerOrUndefinedById(
+          currentUserHauptWahlID.value
+        );
+      if (waehlerverzeichnisNummer !== undefined) {
+        pflegeWaehlerverzeichnisState.value.pflegeWaehlerverzeichnis =
+          await getWaehlerverzeichnis(
+            currentUserWahlbezirkID.value,
+            waehlerverzeichnisNummer,
+            sendNotification
+          );
+      }
+    },
+    sendPflegeWaehlerverzeichnis:
+      async function sendPflegeWaehlerverzeichnis() {
+        const waehlerverzeichnisNummer =
+          getWaehlerverzeichnisNummerOrUndefinedById(
+            currentUserHauptWahlID.value
+          );
+        if (waehlerverzeichnisNummer !== undefined) {
+          try {
+            pflegeWaehlerverzeichnisState.value.pflegeWaehlerverzeichnisIsSaving = true;
+            await postWaehlerverzeichnis(
+              currentUserWahlbezirkID.value,
+              waehlerverzeichnisNummer,
+              pflegeWaehlerverzeichnisState.value.pflegeWaehlerverzeichnis
+            );
+          } finally {
+            pflegeWaehlerverzeichnisState.value.pflegeWaehlerverzeichnisIsSaving = false;
+          }
+        }
+      },
+  };
+
   const urnenWahlVorbereitungIsSaving = ref(false);
   const briefWahlVorbereitungIsSaving = ref(false);
   const ungueltigeWahlscheine = ref<UngueltigerWahlschein[]>([]);
@@ -126,19 +170,6 @@ export const useWahlbezirkStore = defineStore(storeID, () => {
     );
   }
 
-  async function loadPflegeWaehlerverzeichnis(sendNotification = true) {
-    const waehlerverzeichnisNummer = getWaehlerverzeichnisNummerOrUndefinedById(
-      currentUserHauptWahlID.value
-    );
-    if (waehlerverzeichnisNummer !== undefined) {
-      pflegeWaehlerverzeichnis.value = await getWaehlerverzeichnis(
-        currentUserWahlbezirkID.value,
-        waehlerverzeichnisNummer,
-        sendNotification
-      );
-    }
-  }
-
   async function loadUngueltigeWahlscheine() {
     ungueltigeWahlscheineIsLoading.value = true;
     ungueltigeWahlscheineLoadingFailed.value = false;
@@ -168,24 +199,6 @@ export const useWahlbezirkStore = defineStore(storeID, () => {
         eroeffnungsuhrzeitSent.value = eroeffnungsuhrzeitToSave;
       } finally {
         eroeffnungsuhrzeitIsSaving.value = false;
-      }
-    }
-  }
-
-  async function sendPflegeWaehlerverzeichnis() {
-    const waehlerverzeichnisNummer = getWaehlerverzeichnisNummerOrUndefinedById(
-      currentUserHauptWahlID.value
-    );
-    if (waehlerverzeichnisNummer !== undefined) {
-      try {
-        pflegeWaehlerverzeichnisIsSaving.value = true;
-        await postWaehlerverzeichnis(
-          currentUserWahlbezirkID.value,
-          waehlerverzeichnisNummer,
-          pflegeWaehlerverzeichnis.value
-        );
-      } finally {
-        pflegeWaehlerverzeichnisIsSaving.value = false;
       }
     }
   }
@@ -252,21 +265,19 @@ export const useWahlbezirkStore = defineStore(storeID, () => {
     eroeffnungsuhrzeit,
     eroeffnungsuhrzeitIsSaving,
     eroeffnungsuhrzeitSent,
-    pflegeWaehlerverzeichnis,
-    pflegeWaehlerverzeichnisIsSaving,
     schliessungsuhrzeit,
     schliessungsuhrzeitIsSaving,
     schliessungsuhrzeitSent,
+    pflegeWaehlerverzeichnisState,
+    pflegeWaehlerverzeichnisActions,
     ungueltigeWahlscheine,
     ungueltigeWahlscheineIsLoading,
     ungueltigeWahlscheineIsEmpty,
     ungueltigeWahlscheineLoadingFailed,
     getUngueltigerWahlscheinByWahlscheinnummer,
     initUngueltigeWahlscheine,
-    loadPflegeWaehlerverzeichnis,
     loadUngueltigeWahlscheine,
     sendEroeffnungsuhrzeit,
-    sendPflegeWaehlerverzeichnis,
     sendSchliessungsuhrzeit,
     sendUrnenwahlvorbereitung,
     urnenwahlVorbereitung,

--- a/wls-gui-wahllokalsystem/src/stores/wahlbezirkStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/wahlbezirkStore.ts
@@ -111,52 +111,52 @@ export const useWahlbezirkStore = defineStore(storeID, () => {
     },
   };
 
-    /* --- pflegeWaehlerverzeichnis --- */
-    const pflegeWaehlerverzeichnisState: Ref<{
-        pflegeWaehlerverzeichnis: PflegeWaehlerverzeichnis;
-        pflegeWaehlerverzeichnisIsSaving: boolean;
-    }> = ref({
-        pflegeWaehlerverzeichnis: createDefaultPflegeWaehlerverzeichnis(),
-        pflegeWaehlerverzeichnisIsSaving: false,
-    });
+  /* --- pflegeWaehlerverzeichnis --- */
+  const pflegeWaehlerverzeichnisState: Ref<{
+    pflegeWaehlerverzeichnis: PflegeWaehlerverzeichnis;
+    pflegeWaehlerverzeichnisIsSaving: boolean;
+  }> = ref({
+    pflegeWaehlerverzeichnis: createDefaultPflegeWaehlerverzeichnis(),
+    pflegeWaehlerverzeichnisIsSaving: false,
+  });
 
-    const pflegeWaehlerverzeichnisActions = {
-        loadPflegeWaehlerverzeichnis: async function loadPflegeWaehlerverzeichnis(
-            sendNotification = true
-        ) {
-            const waehlerverzeichnisNummer =
-                getWaehlerverzeichnisNummerOrUndefinedById(
-                    currentUserHauptWahlID.value
-                );
-            if (waehlerverzeichnisNummer !== undefined) {
-                pflegeWaehlerverzeichnisState.value.pflegeWaehlerverzeichnis =
-                    await getWaehlerverzeichnis(
-                        currentUserWahlbezirkID.value,
-                        waehlerverzeichnisNummer,
-                        sendNotification
-                    );
-            }
-        },
-        sendPflegeWaehlerverzeichnis:
-            async function sendPflegeWaehlerverzeichnis() {
-                const waehlerverzeichnisNummer =
-                    getWaehlerverzeichnisNummerOrUndefinedById(
-                        currentUserHauptWahlID.value
-                    );
-                if (waehlerverzeichnisNummer !== undefined) {
-                    try {
-                        pflegeWaehlerverzeichnisState.value.pflegeWaehlerverzeichnisIsSaving = true;
-                        await postWaehlerverzeichnis(
-                            currentUserWahlbezirkID.value,
-                            waehlerverzeichnisNummer,
-                            pflegeWaehlerverzeichnisState.value.pflegeWaehlerverzeichnis
-                        );
-                    } finally {
-                        pflegeWaehlerverzeichnisState.value.pflegeWaehlerverzeichnisIsSaving = false;
-                    }
-                }
-            },
-    };
+  const pflegeWaehlerverzeichnisActions = {
+    loadPflegeWaehlerverzeichnis: async function loadPflegeWaehlerverzeichnis(
+      sendNotification = true
+    ) {
+      const waehlerverzeichnisNummer =
+        getWaehlerverzeichnisNummerOrUndefinedById(
+          currentUserHauptWahlID.value
+        );
+      if (waehlerverzeichnisNummer !== undefined) {
+        pflegeWaehlerverzeichnisState.value.pflegeWaehlerverzeichnis =
+          await getWaehlerverzeichnis(
+            currentUserWahlbezirkID.value,
+            waehlerverzeichnisNummer,
+            sendNotification
+          );
+      }
+    },
+    sendPflegeWaehlerverzeichnis:
+      async function sendPflegeWaehlerverzeichnis() {
+        const waehlerverzeichnisNummer =
+          getWaehlerverzeichnisNummerOrUndefinedById(
+            currentUserHauptWahlID.value
+          );
+        if (waehlerverzeichnisNummer !== undefined) {
+          try {
+            pflegeWaehlerverzeichnisState.value.pflegeWaehlerverzeichnisIsSaving = true;
+            await postWaehlerverzeichnis(
+              currentUserWahlbezirkID.value,
+              waehlerverzeichnisNummer,
+              pflegeWaehlerverzeichnisState.value.pflegeWaehlerverzeichnis
+            );
+          } finally {
+            pflegeWaehlerverzeichnisState.value.pflegeWaehlerverzeichnisIsSaving = false;
+          }
+        }
+      },
+  };
 
   const urnenWahlVorbereitungIsSaving = ref(false);
   const briefWahlVorbereitungIsSaving = ref(false);

--- a/wls-gui-wahllokalsystem/tests/components/wahlhandlung/BaseWaehlerverzeichnisCheckCard.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/components/wahlhandlung/BaseWaehlerverzeichnisCheckCard.spec.ts
@@ -43,7 +43,7 @@ describe("BaseWaehlerverzeichnisCheckCard.vue", () => {
 
   describe(COMPONENT_RENDER_TESTS, () => {
     it("should_renderWithNoChangesInWaehlerverzeichnisAndAllCheckboxesSelected_when_mounted", async (context) => {
-      useWahlbezirkStore().pflegeWaehlerverzeichnis =
+      useWahlbezirkStore().pflegeWaehlerverzeichnisState.pflegeWaehlerverzeichnis =
         preparePflegeWaehlerverzeichnis()
           .mitteilungUeberUngueltigeWahlscheineErhalten(true)
           .nachtraeglicheBerichtigung(true)
@@ -58,7 +58,7 @@ describe("BaseWaehlerverzeichnisCheckCard.vue", () => {
     });
 
     it("should_renderWithChangesInWaehlerverzeichnisAndAllCheckboxesSelected_when_mounted", async (context) => {
-      useWahlbezirkStore().pflegeWaehlerverzeichnis =
+      useWahlbezirkStore().pflegeWaehlerverzeichnisState.pflegeWaehlerverzeichnis =
         preparePflegeWaehlerverzeichnis()
           .mitteilungUeberUngueltigeWahlscheineErhalten(true)
           .nachtraeglicheBerichtigung(true)
@@ -73,7 +73,7 @@ describe("BaseWaehlerverzeichnisCheckCard.vue", () => {
     });
 
     it("should_renderWithNoChangesInWaehlerverzeichnisAndNoCheckboxesSelected_when_mounted", async (context) => {
-      useWahlbezirkStore().pflegeWaehlerverzeichnis =
+      useWahlbezirkStore().pflegeWaehlerverzeichnisState.pflegeWaehlerverzeichnis =
         preparePflegeWaehlerverzeichnis()
           .mitteilungUeberUngueltigeWahlscheineErhalten(false)
           .nachtraeglicheBerichtigung(false)
@@ -88,7 +88,7 @@ describe("BaseWaehlerverzeichnisCheckCard.vue", () => {
     });
 
     it("should_renderSaveButtonDisabled_when_mitteilungUeberUngueltigeWahlscheineErhaltenIsFalse", async (context) => {
-      useWahlbezirkStore().pflegeWaehlerverzeichnis =
+      useWahlbezirkStore().pflegeWaehlerverzeichnisState.pflegeWaehlerverzeichnis =
         preparePflegeWaehlerverzeichnis()
           .mitteilungUeberUngueltigeWahlscheineErhalten(false)
           .nachtraeglicheBerichtigung(false)
@@ -104,13 +104,13 @@ describe("BaseWaehlerverzeichnisCheckCard.vue", () => {
 
     it("should_renderSaveInLoadingState_when_pflegeWaehlerverzeichnisIsSavingIsTrue", async (context) => {
       const wahlbezirkStore = useWahlbezirkStore();
-      wahlbezirkStore.pflegeWaehlerverzeichnis =
+      wahlbezirkStore.pflegeWaehlerverzeichnisState.pflegeWaehlerverzeichnis =
         preparePflegeWaehlerverzeichnis()
           .mitteilungUeberUngueltigeWahlscheineErhalten(true)
           .nachtraeglicheBerichtigung(true)
           .waehlerverzeichnisUnchanged(true)
           .build();
-      wahlbezirkStore.pflegeWaehlerverzeichnisIsSaving = true;
+      wahlbezirkStore.pflegeWaehlerverzeichnisState.pflegeWaehlerverzeichnisIsSaving = true;
 
       await flushPromises();
 
@@ -123,7 +123,7 @@ describe("BaseWaehlerverzeichnisCheckCard.vue", () => {
   describe(COMPONENT_EVENT_TESTS, () => {
     it("should_triggerSendPflegeWaehlerverzeichnis_when_saveButtonIsClicked", async () => {
       const wahlbezirkStore = useWahlbezirkStore();
-      wahlbezirkStore.pflegeWaehlerverzeichnis =
+      wahlbezirkStore.pflegeWaehlerverzeichnisState.pflegeWaehlerverzeichnis =
         preparePflegeWaehlerverzeichnis()
           .mitteilungUeberUngueltigeWahlscheineErhalten(true)
           .nachtraeglicheBerichtigung(true)
@@ -132,15 +132,19 @@ describe("BaseWaehlerverzeichnisCheckCard.vue", () => {
 
       await flushPromises();
 
+      const sendPflegeWaehlerverzeichnisSpy = vi.spyOn(
+        wahlbezirkStore.pflegeWaehlerverzeichnisActions,
+        "sendPflegeWaehlerverzeichnis"
+      );
+
       const saveButton = wrapper.findComponent('[data-test="buttonSave"]');
 
       expect(
-        wahlbezirkStore.sendPflegeWaehlerverzeichnis
+        wahlbezirkStore.pflegeWaehlerverzeichnisActions
+          .sendPflegeWaehlerverzeichnis
       ).toHaveBeenCalledTimes(0);
       await saveButton.trigger("click");
-      expect(
-        wahlbezirkStore.sendPflegeWaehlerverzeichnis
-      ).toHaveBeenCalledTimes(1);
+      expect(sendPflegeWaehlerverzeichnisSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/wls-gui-wahllokalsystem/tests/components/wahlhandlung/BaseWaehlerverzeichnisCheckCard.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/components/wahlhandlung/BaseWaehlerverzeichnisCheckCard.spec.ts
@@ -139,10 +139,7 @@ describe("BaseWaehlerverzeichnisCheckCard.vue", () => {
 
       const saveButton = wrapper.findComponent('[data-test="buttonSave"]');
 
-      expect(
-        wahlbezirkStore.pflegeWaehlerverzeichnisActions
-          .sendPflegeWaehlerverzeichnis
-      ).toHaveBeenCalledTimes(0);
+      expect(sendPflegeWaehlerverzeichnisSpy).toHaveBeenCalledTimes(0);
       await saveButton.trigger("click");
       expect(sendPflegeWaehlerverzeichnisSpy).toHaveBeenCalledTimes(1);
     });

--- a/wls-gui-wahllokalsystem/tests/stores/wahlbezirkStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/wahlbezirkStore.spec.ts
@@ -152,7 +152,7 @@ describe("wahlbezirkStore.ts", () => {
         waehlerverzeichnisNummer
       );
 
-      unitUnderTest.loadPflegeWaehlerverzeichnis();
+      unitUnderTest.pflegeWaehlerverzeichnisActions.loadPflegeWaehlerverzeichnis();
 
       expect(mockDefinitions.getWaehlerverzeichnis.mock.calls).toStrictEqual([
         [wahlbezirkID, waehlerverzeichnisNummer, true],
@@ -167,7 +167,7 @@ describe("wahlbezirkStore.ts", () => {
         undefined
       );
 
-      unitUnderTest.loadPflegeWaehlerverzeichnis();
+      unitUnderTest.pflegeWaehlerverzeichnisActions.loadPflegeWaehlerverzeichnis();
 
       expect(
         mockDefinitions.getWaehlerverzeichnis.mock.calls.length
@@ -398,7 +398,8 @@ describe("wahlbezirkStore.ts", () => {
       );
 
       const pflegeWaehlerverzeichnis = createPflegeWaehlerverzeichnis();
-      unitUnderTest.pflegeWaehlerverzeichnis = pflegeWaehlerverzeichnis;
+      unitUnderTest.pflegeWaehlerverzeichnisState.pflegeWaehlerverzeichnis =
+        pflegeWaehlerverzeichnis;
 
       const mockedWaehlerverzeichnisNummer = "wvzNummer";
       mockDefinitions.getWaehlerverzeichnisNummerOrUndefinedById.mockReturnValue(
@@ -414,21 +415,24 @@ describe("wahlbezirkStore.ts", () => {
         })
       );
 
-      expect(unitUnderTest.pflegeWaehlerverzeichnisIsSaving).toStrictEqual(
-        false
-      );
+      expect(
+        unitUnderTest.pflegeWaehlerverzeichnisState
+          .pflegeWaehlerverzeichnisIsSaving
+      ).toStrictEqual(false);
       const sendPflegeWaehlerverzeichnisPromise =
-        unitUnderTest.sendPflegeWaehlerverzeichnis();
-      expect(unitUnderTest.pflegeWaehlerverzeichnisIsSaving).toStrictEqual(
-        true
-      );
+        unitUnderTest.pflegeWaehlerverzeichnisActions.sendPflegeWaehlerverzeichnis();
+      expect(
+        unitUnderTest.pflegeWaehlerverzeichnisState
+          .pflegeWaehlerverzeichnisIsSaving
+      ).toStrictEqual(true);
 
       vi.advanceTimersByTime(timeout);
       await sendPflegeWaehlerverzeichnisPromise;
 
-      expect(unitUnderTest.pflegeWaehlerverzeichnisIsSaving).toStrictEqual(
-        false
-      );
+      expect(
+        unitUnderTest.pflegeWaehlerverzeichnisState
+          .pflegeWaehlerverzeichnisIsSaving
+      ).toStrictEqual(false);
       expect(mockDefinitions.postWaehlerverzeichnis.mock.calls).toStrictEqual([
         [
           userWahlbezirkID,
@@ -445,7 +449,8 @@ describe("wahlbezirkStore.ts", () => {
       );
 
       const pflegeWaehlerverzeichnis = createPflegeWaehlerverzeichnis();
-      unitUnderTest.pflegeWaehlerverzeichnis = pflegeWaehlerverzeichnis;
+      unitUnderTest.pflegeWaehlerverzeichnisState.pflegeWaehlerverzeichnis =
+        pflegeWaehlerverzeichnis;
 
       const mockedWaehlerverzeichnisNummer = "wvzNummer";
       mockDefinitions.getWaehlerverzeichnisNummerOrUndefinedById.mockReturnValue(
@@ -461,21 +466,24 @@ describe("wahlbezirkStore.ts", () => {
         })
       );
 
-      expect(unitUnderTest.pflegeWaehlerverzeichnisIsSaving).toStrictEqual(
-        false
-      );
+      expect(
+        unitUnderTest.pflegeWaehlerverzeichnisState
+          .pflegeWaehlerverzeichnisIsSaving
+      ).toStrictEqual(false);
       const sendPflegeWaehlerverzeichnisPromise =
-        unitUnderTest.sendPflegeWaehlerverzeichnis();
-      expect(unitUnderTest.pflegeWaehlerverzeichnisIsSaving).toStrictEqual(
-        true
-      );
+        unitUnderTest.pflegeWaehlerverzeichnisActions.sendPflegeWaehlerverzeichnis();
+      expect(
+        unitUnderTest.pflegeWaehlerverzeichnisState
+          .pflegeWaehlerverzeichnisIsSaving
+      ).toStrictEqual(true);
 
       vi.advanceTimersByTime(timeout);
       await expect(sendPflegeWaehlerverzeichnisPromise).rejects.toThrow();
 
-      expect(unitUnderTest.pflegeWaehlerverzeichnisIsSaving).toStrictEqual(
-        false
-      );
+      expect(
+        unitUnderTest.pflegeWaehlerverzeichnisState
+          .pflegeWaehlerverzeichnisIsSaving
+      ).toStrictEqual(false);
       expect(mockDefinitions.postWaehlerverzeichnis.mock.calls).toStrictEqual([
         [
           userWahlbezirkID,
@@ -490,7 +498,7 @@ describe("wahlbezirkStore.ts", () => {
         undefined
       );
 
-      await unitUnderTest.sendPflegeWaehlerverzeichnis();
+      await unitUnderTest.pflegeWaehlerverzeichnisActions.sendPflegeWaehlerverzeichnis();
 
       expect(
         mockDefinitions.postWaehlerverzeichnis.mock.calls.length


### PR DESCRIPTION
# Beschreibung:

Teil 3 zu #1695: refactoring der pflegeWaehlerverzeichnis

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] Unit-Tests gepflegt
- [x] Komponententests gepflegt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined handling of the Pflege-Wählerverzeichnis by consolidating related state and actions, improving consistency and maintainability.
  - Updated app and component logic to use the new grouped state and action access patterns.
  - No changes to user-facing behavior or workflows.

- Tests
  - Adapted store and component tests to the reorganized API.
  - Introduced spy-based verification for save operations to ensure reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->