### PR TITLE
Retro - Link zu fachlichen Anforderungen für FE-Todo-Doku eränzt

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@
 ### Frontend
 - [ ] [Naming Conventions][naming-conventions-link] beachtet
 - [ ] Doku aktualisiert
-  - [Fachliche Beschreibung}[fachliche-beschreibung-link]
+  - [Fachliche Beschreibung][fachliche-beschreibung-link]
 - [ ] Unit-Tests gepflegt
 - [ ] Komponententests gepflegt
 - [ ] Texte auf Rechtschreibung und Grammatik geprüft

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,6 +24,7 @@
 ### Frontend
 - [ ] [Naming Conventions][naming-conventions-link] beachtet
 - [ ] Doku aktualisiert
+  - [Fachliche Beschreibung}[fachliche-beschreibung-link]
 - [ ] Unit-Tests gepflegt
 - [ ] Komponententests gepflegt
 - [ ] Texte auf Rechtschreibung und Grammatik geprüft
@@ -37,3 +38,4 @@ Closes #
 > [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_
 
 [naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
+[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen


### PR DESCRIPTION
# Beschreibung:
Link zur Beschreibung der fachlichen Anforderungen bei Frontend-PR-Todos entsprechend der letzten Retro in PR-Template ergänzt.
Sieht dann so aus:  
<img width="417" height="215" alt="grafik" src="https://github.com/user-attachments/assets/147b7aca-8ff0-47c5-b08b-0b06e73e6a93" />


## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

# Referenzen[^1]:

Verwandt mit Issue #

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Documentation
  - Enhanced pull request template with a “Fachliche Beschreibung” checklist item to ensure functional context is documented for frontend changes.
  - Added a direct link to the project’s functional requirements documentation for clearer guidance.

- Chores
  - Updated contribution workflow guidance in the PR template, including an updated review effort note to improve review consistency and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->