### PR TITLE
#1746 fix mocking in test

### DIFF
--- a/wls-gui-wahllokalsystem/tests/stores/wahlbezirkStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/wahlbezirkStore.spec.ts
@@ -255,7 +255,7 @@ describe("wahlbezirkStore.ts", () => {
       mockDefinitions.getUngueltigeWahlscheine.mockReturnValue(
         new Promise((resolve) => {
           setTimeout(() => {
-            resolve(createUngueltigerWahlschein());
+            resolve([createUngueltigerWahlschein()]);
           }, timeout);
         })
       );


### PR DESCRIPTION
# Beschreibung:

- test mockReturnValue gefixed

# Referenzen[^1]:

Closes #1746 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tests to expect array-based results for invalid vote-by-mail certificates, aligning with current service behavior.
  * Adjusted success path to verify loading state updates when array responses are returned.
  * No functional changes to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->