### PR TITLE
make baseBtnSave text optional with default

### DIFF
--- a/wls-gui-wahllokalsystem/package-lock.json
+++ b/wls-gui-wahllokalsystem/package-lock.json
@@ -3850,8 +3850,8 @@
       }
     },
     "node_modules/@storybook/vue3/node_modules/vue-component-type-helpers": {
-      "version": "3.0.5",
-      "integrity": "sha512-uoNZaJ+a1/zppa/Vgmi8zIOP2PHXDN2rT8NyF+zQRK6ZG94lNB9prcV0GdLJbY9i9lrD47JOVIH92SaiA7oJ1A==",
+      "version": "3.0.6",
+      "integrity": "sha512-6CRM8X7EJqWCJOiKPvSLQG+hJPb/Oy2gyJx3pLjUEhY7PuaCthQu3e0zAGI1lqUBobrrk9IT0K8sG2GsCluxoQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/wls-gui-wahllokalsystem/src/components/common/buttons/BaseButtonSave.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/buttons/BaseButtonSave.vue
@@ -17,6 +17,9 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  /**
+   * Custom Save Text
+   */
   saveText: {
     type: String,
     default: "Speichern",

--- a/wls-gui-wahllokalsystem/src/components/common/buttons/BaseButtonSave.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/buttons/BaseButtonSave.vue
@@ -1,7 +1,7 @@
 <template>
   <v-btn
     prepend-icon="$save"
-    :disabled="props.disabled"
+    :disabled="disabled"
     data-test="buttonSave"
   >
     {{ saveText }}
@@ -9,7 +9,7 @@
 </template>
 
 <script setup lang="ts">
-const props = defineProps({
+defineProps({
   /**
    * Is the Button interactable
    */

--- a/wls-gui-wahllokalsystem/src/components/common/buttons/BaseButtonSave.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/buttons/BaseButtonSave.vue
@@ -16,12 +16,10 @@ const props = defineProps({
   disabled: {
     type: Boolean,
     default: false,
-    required: false,
   },
   saveText: {
     type: String,
     default: "Speichern",
-    required: false,
   },
 });
 </script>

--- a/wls-gui-wahllokalsystem/src/components/common/buttons/BaseButtonSave.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/buttons/BaseButtonSave.vue
@@ -3,8 +3,9 @@
     prepend-icon="$save"
     :disabled="props.disabled"
     data-test="buttonSave"
-    >Speichern</v-btn
   >
+    {{ saveText }}
+  </v-btn>
 </template>
 
 <script setup lang="ts">
@@ -15,6 +16,11 @@ const props = defineProps({
   disabled: {
     type: Boolean,
     default: false,
+    required: false,
+  },
+  saveText: {
+    type: String,
+    default: "Speichern",
     required: false,
   },
 });

--- a/wls-gui-wahllokalsystem/stories/components/common/buttons/BaseButtonSave.stories.ts
+++ b/wls-gui-wahllokalsystem/stories/components/common/buttons/BaseButtonSave.stories.ts
@@ -18,3 +18,9 @@ export const Disabled: Story = {
     disabled: true,
   },
 };
+
+export const CustomText: Story = {
+  args: {
+    saveText: "Beliebiger Speichertext",
+  },
+};


### PR DESCRIPTION
# Beschreibung:

In #1657 kam der wunsch auf einen Speichern Button mit dem Text `Beschluss speichern` zu versehen. Daher wurde der Standardtext in ein optionales Prop mit dem default Wert "Speichern" verpackt, sodass sich erst mal nichts ändert, aber für das Issue später der Text wie gewünscht angepasst werden kann

- optional prop hinzugefügt
- redundantes `required: false` entfernt
- nicht benötigte props deklaration entfernt (siehe [doku](https://vuejs.org/api/sfc-script-setup#reactive-props-destructure)

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] Storybook Story mit neuem Text ergänzt

# Referenzen[^1]:

Grundlage zur Umsetzung von Issue #1657


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Save button label is now customizable, allowing you to set context-specific text while keeping the default unchanged.

* **Documentation**
  * Added a Storybook example demonstrating how to display a custom label on the save button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->