### PR TITLE
Add no empty tags eslint rule

### DIFF
--- a/wls-gui-wahllokalsystem/eslint.config.js
+++ b/wls-gui-wahllokalsystem/eslint.config.js
@@ -52,6 +52,7 @@ export default [
         },
       ],
       "vue/no-multiple-template-root": ["error"],
+      "vue/no-empty-component-block": ["error"],
     },
   },
   // overrides for specific files or directories

--- a/wls-gui-wahllokalsystem/src/components/stimmabgabevermerke/TheUWBStimmabgabevermerkeEingenommeneWahlscheineCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/stimmabgabevermerke/TheUWBStimmabgabevermerkeEingenommeneWahlscheineCard.vue
@@ -15,5 +15,3 @@ import { VCard, VCardText, VCardTitle } from "vuetify/components";
 
 import TheUWBStimmabgabevermerkeEingenommeneWahlscheineTable from "@/components/stimmabgabevermerke/TheUWBStimmabgabevermerkeEingenommeneWahlscheineTable.vue";
 </script>
-
-

--- a/wls-gui-wahllokalsystem/src/components/stimmabgabevermerke/TheUWBStimmabgabevermerkeEingenommeneWahlscheineCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/stimmabgabevermerke/TheUWBStimmabgabevermerkeEingenommeneWahlscheineCard.vue
@@ -16,4 +16,4 @@ import { VCard, VCardText, VCardTitle } from "vuetify/components";
 import TheUWBStimmabgabevermerkeEingenommeneWahlscheineTable from "@/components/stimmabgabevermerke/TheUWBStimmabgabevermerkeEingenommeneWahlscheineTable.vue";
 </script>
 
-<style scoped></style>
+

--- a/wls-gui-wahllokalsystem/src/components/stimmabgabevermerke/TheUWBStimmabgabevermerkeEingenommeneWahlscheineTable.vue
+++ b/wls-gui-wahllokalsystem/src/components/stimmabgabevermerke/TheUWBStimmabgabevermerkeEingenommeneWahlscheineTable.vue
@@ -72,4 +72,4 @@ function setMapValue(
 }
 </script>
 
-<style scoped></style>
+

--- a/wls-gui-wahllokalsystem/src/components/stimmabgabevermerke/TheUWBStimmabgabevermerkeEingenommeneWahlscheineTable.vue
+++ b/wls-gui-wahllokalsystem/src/components/stimmabgabevermerke/TheUWBStimmabgabevermerkeEingenommeneWahlscheineTable.vue
@@ -71,5 +71,3 @@ function setMapValue(
   wahldaten.eingenommeneWahlscheine.set(key, value);
 }
 </script>
-
-


### PR DESCRIPTION
# Beschreibung:

- eslint rule um leere tags wie `<style scoped></style>` zu vermeiden



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Removed unused empty style sections from components to reduce noise and improve readability. No visual or behavioral changes for users.
- Chores
  - Strengthened linting configuration to prevent empty component blocks, promoting a cleaner, more consistent codebase and avoiding future regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->