### PR TITLE
fix black progress to warning color

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/BaseOfflineLoading.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/BaseOfflineLoading.vue
@@ -38,7 +38,7 @@
       :current="numberOfFailedTasks"
       :total="numberOfTasksToRun"
       :tasks="failedTasks"
-      color="warn"
+      color="warning"
     />
   </v-container>
 </template>

--- a/wls-gui-wahllokalsystem/tests/__snapshots__/App/visual logic/should_notRenderWahlvorstandAnwesenheitsCheckPopupDialog_when_wahlbezirkArtBWB.html
+++ b/wls-gui-wahllokalsystem/tests/__snapshots__/App/visual logic/should_notRenderWahlvorstandAnwesenheitsCheckPopupDialog_when_wahlbezirkArtBWB.html
@@ -55,10 +55,10 @@
                 </div>
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 50px; --v-progress-linear-height: 50px;" role="progressbar" aria-hidden="false" aria-valuemin="0" aria-valuemax="0" aria-valuenow="0">
                   <!---->
-                  <div class="v-progress-linear__background bg-warn"></div>
-                  <div class="v-progress-linear__buffer bg-warn"></div>
+                  <div class="v-progress-linear__background bg-warning"></div>
+                  <div class="v-progress-linear__buffer bg-warning"></div>
                   <transition-stub name="slide-x-transition" appear="false" persisted="false" css="true">
-                    <div class="v-progress-linear__determinate bg-warn"></div>
+                    <div class="v-progress-linear__determinate bg-warning"></div>
                   </transition-stub>
                   <!---->
                 </div>

--- a/wls-gui-wahllokalsystem/tests/__snapshots__/App/visual logic/should_renderWahlvorstandAnwesenheitsCheckPopupDialog_when_wahlbezirkArtUWB.html
+++ b/wls-gui-wahllokalsystem/tests/__snapshots__/App/visual logic/should_renderWahlvorstandAnwesenheitsCheckPopupDialog_when_wahlbezirkArtUWB.html
@@ -55,10 +55,10 @@
                 </div>
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 50px; --v-progress-linear-height: 50px;" role="progressbar" aria-hidden="false" aria-valuemin="0" aria-valuemax="0" aria-valuenow="0">
                   <!---->
-                  <div class="v-progress-linear__background bg-warn"></div>
-                  <div class="v-progress-linear__buffer bg-warn"></div>
+                  <div class="v-progress-linear__background bg-warning"></div>
+                  <div class="v-progress-linear__buffer bg-warning"></div>
                   <transition-stub name="slide-x-transition" appear="false" persisted="false" css="true">
-                    <div class="v-progress-linear__determinate bg-warn"></div>
+                    <div class="v-progress-linear__determinate bg-warning"></div>
                   </transition-stub>
                   <!---->
                 </div>

--- a/wls-gui-wahllokalsystem/tests/components/wlsComponents/__snapshots__/BaseOfflineLoading.vue/visual logic/should_showHeadlineLoadingText_when_stillLoading.html
+++ b/wls-gui-wahllokalsystem/tests/components/wlsComponents/__snapshots__/BaseOfflineLoading.vue/visual logic/should_showHeadlineLoadingText_when_stillLoading.html
@@ -48,10 +48,10 @@
     </div>
     <div class="v-progress-linear v-progress-linear--striped v-theme--light v-locale--is-ltr" style="top: 0px; height: 50px; --v-progress-linear-height: 50px;" role="progressbar" aria-hidden="false" aria-valuemin="0" aria-valuemax="5" aria-valuenow="0">
       <!---->
-      <div class="v-progress-linear__background bg-warn"></div>
-      <div class="v-progress-linear__buffer bg-warn" style="width: 0%;"></div>
+      <div class="v-progress-linear__background bg-warning"></div>
+      <div class="v-progress-linear__buffer bg-warning" style="width: 0%;"></div>
       <transition-stub name="slide-x-transition" appear="false" persisted="false" css="true">
-        <div class="v-progress-linear__determinate bg-warn" style="width: 0%;"></div>
+        <div class="v-progress-linear__determinate bg-warning" style="width: 0%;"></div>
       </transition-stub>
       <!---->
     </div>

--- a/wls-gui-wahllokalsystem/tests/components/wlsComponents/__snapshots__/BaseOfflineLoading.vue/visual logic/should_showOneTaskFail_when_runFailed.html
+++ b/wls-gui-wahllokalsystem/tests/components/wlsComponents/__snapshots__/BaseOfflineLoading.vue/visual logic/should_showOneTaskFail_when_runFailed.html
@@ -48,10 +48,10 @@
     </div>
     <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 50px; --v-progress-linear-height: 50px;" role="progressbar" aria-hidden="false" aria-valuemin="0" aria-valuemax="1" aria-valuenow="1">
       <!---->
-      <div class="v-progress-linear__background bg-warn"></div>
-      <div class="v-progress-linear__buffer bg-warn" style="width: 0%;"></div>
+      <div class="v-progress-linear__background bg-warning"></div>
+      <div class="v-progress-linear__buffer bg-warning" style="width: 0%;"></div>
       <transition-stub name="slide-x-transition" appear="false" persisted="false" css="true">
-        <div class="v-progress-linear__determinate bg-warn" style="width: 100%;"></div>
+        <div class="v-progress-linear__determinate bg-warning" style="width: 100%;"></div>
       </transition-stub>
       <!---->
     </div>

--- a/wls-gui-wahllokalsystem/tests/components/wlsComponents/__snapshots__/BaseOfflineLoading.vue/visual logic/should_showOneTaskSuccessfulRun_when_runSuccessful.html
+++ b/wls-gui-wahllokalsystem/tests/components/wlsComponents/__snapshots__/BaseOfflineLoading.vue/visual logic/should_showOneTaskSuccessfulRun_when_runSuccessful.html
@@ -48,10 +48,10 @@
     </div>
     <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 50px; --v-progress-linear-height: 50px;" role="progressbar" aria-hidden="false" aria-valuemin="0" aria-valuemax="1" aria-valuenow="0">
       <!---->
-      <div class="v-progress-linear__background bg-warn"></div>
-      <div class="v-progress-linear__buffer bg-warn" style="width: 0%;"></div>
+      <div class="v-progress-linear__background bg-warning"></div>
+      <div class="v-progress-linear__buffer bg-warning" style="width: 0%;"></div>
       <transition-stub name="slide-x-transition" appear="false" persisted="false" css="true">
-        <div class="v-progress-linear__determinate bg-warn" style="width: 0%;"></div>
+        <div class="v-progress-linear__determinate bg-warning" style="width: 0%;"></div>
       </transition-stub>
       <!---->
     </div>

--- a/wls-gui-wahllokalsystem/tests/components/wlsComponents/__snapshots__/BaseOfflineLoading.vue/visual logic/should_showTaskNamesInExpansionPanel_when_runFailed.html
+++ b/wls-gui-wahllokalsystem/tests/components/wlsComponents/__snapshots__/BaseOfflineLoading.vue/visual logic/should_showTaskNamesInExpansionPanel_when_runFailed.html
@@ -48,10 +48,10 @@
     </div>
     <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 50px; --v-progress-linear-height: 50px;" role="progressbar" aria-hidden="false" aria-valuemin="0" aria-valuemax="1" aria-valuenow="1">
       <!---->
-      <div class="v-progress-linear__background bg-warn"></div>
-      <div class="v-progress-linear__buffer bg-warn" style="width: 0%;"></div>
+      <div class="v-progress-linear__background bg-warning"></div>
+      <div class="v-progress-linear__buffer bg-warning" style="width: 0%;"></div>
       <transition-stub name="slide-x-transition" appear="false" persisted="false" css="true">
-        <div class="v-progress-linear__determinate bg-warn" style="width: 100%;"></div>
+        <div class="v-progress-linear__determinate bg-warning" style="width: 100%;"></div>
       </transition-stub>
       <!---->
     </div>

--- a/wls-gui-wahllokalsystem/tests/components/wlsComponents/__snapshots__/BaseOfflineLoading.vue/visual logic/should_showTaskNamesInExpansionPanel_when_runSuccessful.html
+++ b/wls-gui-wahllokalsystem/tests/components/wlsComponents/__snapshots__/BaseOfflineLoading.vue/visual logic/should_showTaskNamesInExpansionPanel_when_runSuccessful.html
@@ -48,10 +48,10 @@
     </div>
     <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 50px; --v-progress-linear-height: 50px;" role="progressbar" aria-hidden="false" aria-valuemin="0" aria-valuemax="1" aria-valuenow="0">
       <!---->
-      <div class="v-progress-linear__background bg-warn"></div>
-      <div class="v-progress-linear__buffer bg-warn" style="width: 0%;"></div>
+      <div class="v-progress-linear__background bg-warning"></div>
+      <div class="v-progress-linear__buffer bg-warning" style="width: 0%;"></div>
       <transition-stub name="slide-x-transition" appear="false" persisted="false" css="true">
-        <div class="v-progress-linear__determinate bg-warn" style="width: 0%;"></div>
+        <div class="v-progress-linear__determinate bg-warning" style="width: 0%;"></div>
       </transition-stub>
       <!---->
     </div>


### PR DESCRIPTION
# Beschreibung:

bug: der fehlgeschlagen balken ist nicht mehr gelb sondern schwarz
<img width="813" height="441" alt="grafik" src="https://github.com/user-attachments/assets/3d6c06f2-8ba0-43c9-89c8-b43ab3c69b5e" />


## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] Komponententests gepflegt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated the failed-state progress bar to use the “warning” color for improved visual consistency and clarity across offline loading and related dialogs.
- Tests
  - Refreshed visual snapshots to reflect the new warning color on progress bars; no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->