### PR TITLE
1688 erweiterung navigation um ergebnisermittlung

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/navigation/TheKommunalwahlenScoresListGroup.vue
+++ b/wls-gui-wahllokalsystem/src/components/navigation/TheKommunalwahlenScoresListGroup.vue
@@ -6,7 +6,7 @@
         title="Ergebnisermittlung"
       />
     </template>
-    <v-list-item :title="isBWB ? 'Wahlscheine' : 'Stimmabgabevermerke'" />
+    <v-list-item :title="title" />
     <the-o-b-w-scores-list-group />
     <the-s-r-w-scores-list-group />
     <the-b-a-w-scores-list-group />
@@ -15,6 +15,7 @@
 
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
+import { computed } from "vue";
 
 import TheBAWScoresListGroup from "@/components/navigation/auszaehlung_wahlarten/TheBAWScoresListGroup.vue";
 import TheOBWScoresListGroup from "@/components/navigation/auszaehlung_wahlarten/TheOBWScoresListGroup.vue";
@@ -22,4 +23,8 @@ import TheSRWScoresListGroup from "@/components/navigation/auszaehlung_wahlarten
 import { useUserStore } from "@/stores/userStore.ts";
 
 const { isBWB } = storeToRefs(useUserStore());
+
+const title = computed(() =>
+  isBWB.value ? "Wahlscheine" : "Stimmabgabevermerke"
+);
 </script>

--- a/wls-gui-wahllokalsystem/src/components/navigation/TheKommunalwahlenScoresListGroup.vue
+++ b/wls-gui-wahllokalsystem/src/components/navigation/TheKommunalwahlenScoresListGroup.vue
@@ -6,7 +6,7 @@
         title="Ergebnisermittlung"
       />
     </template>
-    <v-list-item title="Stimmabgabevermerke" />
+    <v-list-item :title="isBWB ? 'Wahlscheine' : 'Stimmabgabevermerke'" />
     <the-o-b-w-scores-list-group />
     <the-s-r-w-scores-list-group />
     <the-b-a-w-scores-list-group />
@@ -14,7 +14,12 @@
 </template>
 
 <script setup lang="ts">
+import { storeToRefs } from "pinia";
+
 import TheBAWScoresListGroup from "@/components/navigation/auszaehlung_wahlarten/TheBAWScoresListGroup.vue";
 import TheOBWScoresListGroup from "@/components/navigation/auszaehlung_wahlarten/TheOBWScoresListGroup.vue";
 import TheSRWScoresListGroup from "@/components/navigation/auszaehlung_wahlarten/TheSRWScoresListGroup.vue";
+import { useUserStore } from "@/stores/userStore.ts";
+
+const { isBWB } = storeToRefs(useUserStore());
 </script>

--- a/wls-gui-wahllokalsystem/src/components/navigation/TheUWBKommunalwahlenScoresListGroup.vue
+++ b/wls-gui-wahllokalsystem/src/components/navigation/TheUWBKommunalwahlenScoresListGroup.vue
@@ -1,0 +1,20 @@
+<template>
+  <v-list-group value="Ergebnisse">
+    <template #activator="{ props }">
+      <v-list-item
+        v-bind="props"
+        title="Ergebnisermittlung"
+      />
+    </template>
+    <v-list-item title="Stimmabgabevermerke" />
+    <the-o-b-w-scores-list-group />
+    <the-s-r-w-scores-list-group />
+    <the-b-a-w-scores-list-group />
+  </v-list-group>
+</template>
+
+<script setup lang="ts">
+import TheBAWScoresListGroup from "@/components/navigation/auszaehlung_wahlarten/TheBAWScoresListGroup.vue";
+import TheOBWScoresListGroup from "@/components/navigation/auszaehlung_wahlarten/TheOBWScoresListGroup.vue";
+import TheSRWScoresListGroup from "@/components/navigation/auszaehlung_wahlarten/TheSRWScoresListGroup.vue";
+</script>

--- a/wls-gui-wahllokalsystem/src/components/navigation/auszaehlung_wahlarten/TheBAWScoresListGroup.vue
+++ b/wls-gui-wahllokalsystem/src/components/navigation/auszaehlung_wahlarten/TheBAWScoresListGroup.vue
@@ -1,0 +1,16 @@
+<template>
+  <v-list-group value="BAW_Scores">
+    <template #activator="{ props }">
+      <v-list-item
+        v-bind="props"
+        title="🚧 Wahl des Bezirksausschusses"
+      />
+    </template>
+    <v-list-item title="Zählen der Stimmzettel" />
+    <v-list-item title="Ungültige Stimmzettel" />
+    <v-list-item title="Gültige Stimmzettel" />
+    <v-list-item title="Schnellmeldung" />
+    <v-list-item title="Kandidatinnen- und Kandidatenstimmen" />
+    <v-list-item title="Niederschrift" />
+  </v-list-group>
+</template>

--- a/wls-gui-wahllokalsystem/src/components/navigation/auszaehlung_wahlarten/TheOBWScoresListGroup.vue
+++ b/wls-gui-wahllokalsystem/src/components/navigation/auszaehlung_wahlarten/TheOBWScoresListGroup.vue
@@ -1,0 +1,16 @@
+<template>
+  <v-list-group value="OBW_Scores">
+    <template #activator="{ props }">
+      <v-list-item
+        v-bind="props"
+        title="🚧 Wahl des Oberbürgermeisters"
+      />
+    </template>
+    <v-list-item title="Zählen der Stimmzettel" />
+    <v-list-item title="Stapel c" />
+    <v-list-item title="Stapel b" />
+    <v-list-item title="Stapel a" />
+    <v-list-item title="Schnellmeldung" />
+    <v-list-item title="Niederschrift" />
+  </v-list-group>
+</template>

--- a/wls-gui-wahllokalsystem/src/components/navigation/auszaehlung_wahlarten/TheSRWScoresListGroup.vue
+++ b/wls-gui-wahllokalsystem/src/components/navigation/auszaehlung_wahlarten/TheSRWScoresListGroup.vue
@@ -1,0 +1,16 @@
+<template>
+  <v-list-group value="SRW_Scores">
+    <template #activator="{ props }">
+      <v-list-item
+        v-bind="props"
+        title="🚧 Wahl des Stadtrats"
+      />
+    </template>
+    <v-list-item title="Zählen der Stimmzettel" />
+    <v-list-item title="Ungültige Stimmzettel" />
+    <v-list-item title="Gültige Stimmzettel" />
+    <v-list-item title="Schnellmeldung" />
+    <v-list-item title="Kandidatinnen- und Kandidatenstimmen" />
+    <v-list-item title="Niederschrift" />
+  </v-list-group>
+</template>

--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/TheWlsAppBar.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/TheWlsAppBar.vue
@@ -41,21 +41,32 @@
       </v-row>
     </v-app-bar>
     <v-navigation-drawer v-model="drawer">
-      <v-list>
-        <v-list-item
-          title="Home"
-          :to="'/'"
-        />
-        <v-list-item
-          title="Wahlvorstand"
-          :to="ROUTE_WAHLVORSTAND"
-        />
-        <the-b-w-b-election-list-group v-if="isBWB" />
-        <the-u-w-b-election-list-group v-if="isUWB" />
-        <v-list-item
-          title="Ereignisse"
-          :to="ROUTE_EREIGNISSE"
-        />
+      <v-list class="pt-0">
+        <v-list-group
+          value="Allgemein"
+          class="bg-primary"
+        >
+          <template #activator="{ props }">
+            <v-list-item
+              v-bind="props"
+              title="Allgemein"
+            />
+          </template>
+          <v-list-item
+            title="Home"
+            :to="'/'"
+          />
+          <v-list-item
+            title="Wahlvorstand"
+            :to="ROUTE_WAHLVORSTAND"
+          />
+          <the-b-w-b-election-list-group v-if="isBWB" />
+          <the-u-w-b-election-list-group v-if="isUWB" />
+          <v-list-item
+            title="Ereignisse"
+            :to="ROUTE_EREIGNISSE"
+          />
+        </v-list-group>
       </v-list>
     </v-navigation-drawer>
   </div>

--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/TheWlsAppBar.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/TheWlsAppBar.vue
@@ -67,6 +67,7 @@
             :to="ROUTE_EREIGNISSE"
           />
         </v-list-group>
+        <the-uwb-kommunalwahlen-scores-list-group v-if="isUWB" />
       </v-list>
     </v-navigation-drawer>
   </div>
@@ -81,6 +82,7 @@ import BaseIconWahlbezirksart from "@/components/common/icons/BaseIconWahlbezirk
 import TheWaehleranzahlCountButton from "@/components/monitoring/TheWaehleranzahlCountButton.vue";
 import TheBWBElectionListGroup from "@/components/navigation/TheBWBElectionListGroup.vue";
 import TheUWBElectionListGroup from "@/components/navigation/TheUWBElectionListGroup.vue";
+import TheUwbKommunalwahlenScoresListGroup from "@/components/navigation/TheUWBKommunalwahlenScoresListGroup.vue";
 import TheWlsOnlineOfflineMenu from "@/components/wlsComponents/TheWlsOnlineOfflineMenu.vue";
 import WlsClock from "@/components/wlsComponents/WlsClock.vue";
 import { useDateTimeFormatter } from "@/composables/common/dateTimeFormatter.ts";

--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/TheWlsAppBar.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/TheWlsAppBar.vue
@@ -67,7 +67,7 @@
             :to="ROUTE_EREIGNISSE"
           />
         </v-list-group>
-        <the-uwb-kommunalwahlen-scores-list-group v-if="isUWB" />
+        <the-kommunalwahlen-scores-list-group />
       </v-list>
     </v-navigation-drawer>
   </div>
@@ -81,8 +81,8 @@ import TheInfoHelpIcon from "@/components/basisdaten/TheInfoHelpIcon.vue";
 import BaseIconWahlbezirksart from "@/components/common/icons/BaseIconWahlbezirksart.vue";
 import TheWaehleranzahlCountButton from "@/components/monitoring/TheWaehleranzahlCountButton.vue";
 import TheBWBElectionListGroup from "@/components/navigation/TheBWBElectionListGroup.vue";
+import TheKommunalwahlenScoresListGroup from "@/components/navigation/TheKommunalwahlenScoresListGroup.vue";
 import TheUWBElectionListGroup from "@/components/navigation/TheUWBElectionListGroup.vue";
-import TheUwbKommunalwahlenScoresListGroup from "@/components/navigation/TheUWBKommunalwahlenScoresListGroup.vue";
 import TheWlsOnlineOfflineMenu from "@/components/wlsComponents/TheWlsOnlineOfflineMenu.vue";
 import WlsClock from "@/components/wlsComponents/WlsClock.vue";
 import { useDateTimeFormatter } from "@/composables/common/dateTimeFormatter.ts";

--- a/wls-gui-wahllokalsystem/tests/components/wlsComponents/__snapshots__/TheWlsAppBar.vue/visual logic/should_notRenderNavigationDrawerIcon_when_initializationOfTaskHasNotCompletelyRun.html
+++ b/wls-gui-wahllokalsystem/tests/components/wlsComponents/__snapshots__/TheWlsAppBar.vue/visual logic/should_notRenderNavigationDrawerIcon_when_initializationOfTaskHasNotCompletelyRun.html
@@ -38,29 +38,12 @@
         <!---->
         <!---->
         <div class="v-navigation-drawer__content">
-          <div class="v-list v-theme--light bg-transparent v-list--density-default v-list--one-line" tabindex="0" role="listbox"><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
-              <!---->
-              <div class="v-list-item__content" data-no-activator="">
-                <div class="v-list-item-title">Home</div>
-                <!---->
-                <!---->
-              </div>
-              <!---->
-            </a><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
-              <!---->
-              <div class="v-list-item__content" data-no-activator="">
-                <div class="v-list-item-title">Wahlvorstand</div>
-                <!---->
-                <!---->
-              </div>
-              <!---->
-            </a>
-            <!--v-if-->
-            <div class="v-list-group">
-              <div class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text v-list-group__header" tabindex="-2" aria-selected="false" id="v-list-group--id-Wahlhandlung"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+          <div class="v-list v-theme--light bg-transparent v-list--density-default v-list--one-line pt-0" tabindex="0" role="listbox">
+            <div class="v-list-group bg-primary">
+              <div class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text v-list-group__header" tabindex="-2" aria-selected="false" id="v-list-group--id-Allgemein"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
                 <!---->
                 <div class="v-list-item__content" data-no-activator="">
-                  <div class="v-list-item-title">Wahlhandlung</div>
+                  <div class="v-list-item-title">Allgemein</div>
                   <!---->
                   <!---->
                 </div>
@@ -72,10 +55,10 @@
                 </div>
               </div>
               <transition-stub name="" appear="false" persisted="false" css="false">
-                <div class="v-list-group__items" role="group" aria-labelledby="v-list-group--id-Wahlhandlung" style="display: none;"><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                <div class="v-list-group__items" role="group" aria-labelledby="v-list-group--id-Allgemein" style="display: none;"><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
                     <!---->
                     <div class="v-list-item__content" data-no-activator="">
-                      <div class="v-list-item-title">Wahlumgebung</div>
+                      <div class="v-list-item-title">Home</div>
                       <!---->
                       <!---->
                     </div>
@@ -83,38 +66,345 @@
                   </a><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
                     <!---->
                     <div class="v-list-item__content" data-no-activator="">
-                      <div class="v-list-item-title">Wählerverzeichnis</div>
+                      <div class="v-list-item-title">Wahlvorstand</div>
                       <!---->
                       <!---->
                     </div>
                     <!---->
-                  </a><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                  </a>
+                  <!--v-if-->
+                  <div class="v-list-group">
+                    <div class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text v-list-group__header" tabindex="-2" aria-selected="false" id="v-list-group--id-Wahlhandlung"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                      <!---->
+                      <div class="v-list-item__content" data-no-activator="">
+                        <div class="v-list-item-title">Wahlhandlung</div>
+                        <!---->
+                        <!---->
+                      </div>
+                      <div class="v-list-item__append"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true" density="default"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+                            <path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"></path>
+                          </svg></i>
+                        <!---->
+                        <div class="v-list-item__spacer"></div>
+                      </div>
+                    </div>
+                    <transition-stub name="" appear="false" persisted="false" css="false">
+                      <div class="v-list-group__items" role="group" aria-labelledby="v-list-group--id-Wahlhandlung" style="display: none;"><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Wahlumgebung</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </a><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Wählerverzeichnis</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </a><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Beginn Stimmabgabe</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </a><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Stimmabgabe</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </a></div>
+                    </transition-stub>
+                  </div><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
                     <!---->
                     <div class="v-list-item__content" data-no-activator="">
-                      <div class="v-list-item-title">Beginn Stimmabgabe</div>
+                      <div class="v-list-item-title">Ereignisse</div>
                       <!---->
                       <!---->
                     </div>
                     <!---->
-                  </a><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
-                    <!---->
-                    <div class="v-list-item__content" data-no-activator="">
-                      <div class="v-list-item-title">Stimmabgabe</div>
-                      <!---->
-                      <!---->
-                    </div>
-                    <!---->
-                  </a></div>
+                  </a>
+                </div>
               </transition-stub>
-            </div><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
-              <!---->
-              <div class="v-list-item__content" data-no-activator="">
-                <div class="v-list-item-title">Ereignisse</div>
+            </div>
+            <div class="v-list-group">
+              <div class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text v-list-group__header" tabindex="-2" aria-selected="false" id="v-list-group--id-Ergebnisse"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
                 <!---->
-                <!---->
+                <div class="v-list-item__content" data-no-activator="">
+                  <div class="v-list-item-title">Ergebnisermittlung</div>
+                  <!---->
+                  <!---->
+                </div>
+                <div class="v-list-item__append"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true" density="default"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+                      <path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"></path>
+                    </svg></i>
+                  <!---->
+                  <div class="v-list-item__spacer"></div>
+                </div>
               </div>
-              <!---->
-            </a>
+              <transition-stub name="" appear="false" persisted="false" css="false">
+                <div class="v-list-group__items" role="group" aria-labelledby="v-list-group--id-Ergebnisse" style="display: none;">
+                  <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                    <!----><span class="v-list-item__underlay"></span>
+                    <!---->
+                    <div class="v-list-item__content" data-no-activator="">
+                      <div class="v-list-item-title">Stimmabgabevermerke</div>
+                      <!---->
+                      <!---->
+                    </div>
+                    <!---->
+                  </div>
+                  <div class="v-list-group">
+                    <div class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text v-list-group__header" tabindex="-2" aria-selected="false" id="v-list-group--id-OBW_Scores"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                      <!---->
+                      <div class="v-list-item__content" data-no-activator="">
+                        <div class="v-list-item-title">🚧 Wahl des Oberbürgermeisters</div>
+                        <!---->
+                        <!---->
+                      </div>
+                      <div class="v-list-item__append"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true" density="default"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+                            <path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"></path>
+                          </svg></i>
+                        <!---->
+                        <div class="v-list-item__spacer"></div>
+                      </div>
+                    </div>
+                    <transition-stub name="" appear="false" persisted="false" css="false">
+                      <div class="v-list-group__items" role="group" aria-labelledby="v-list-group--id-OBW_Scores" style="display: none;">
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Zählen der Stimmzettel</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Stapel c</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Stapel b</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Stapel a</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Schnellmeldung</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Niederschrift</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                      </div>
+                    </transition-stub>
+                  </div>
+                  <div class="v-list-group">
+                    <div class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text v-list-group__header" tabindex="-2" aria-selected="false" id="v-list-group--id-SRW_Scores"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                      <!---->
+                      <div class="v-list-item__content" data-no-activator="">
+                        <div class="v-list-item-title">🚧 Wahl des Stadtrats</div>
+                        <!---->
+                        <!---->
+                      </div>
+                      <div class="v-list-item__append"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true" density="default"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+                            <path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"></path>
+                          </svg></i>
+                        <!---->
+                        <div class="v-list-item__spacer"></div>
+                      </div>
+                    </div>
+                    <transition-stub name="" appear="false" persisted="false" css="false">
+                      <div class="v-list-group__items" role="group" aria-labelledby="v-list-group--id-SRW_Scores" style="display: none;">
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Zählen der Stimmzettel</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Ungültige Stimmzettel</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Gültige Stimmzettel</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Schnellmeldung</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Kandidatinnen- und Kandidatenstimmen</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Niederschrift</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                      </div>
+                    </transition-stub>
+                  </div>
+                  <div class="v-list-group">
+                    <div class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text v-list-group__header" tabindex="-2" aria-selected="false" id="v-list-group--id-BAW_Scores"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                      <!---->
+                      <div class="v-list-item__content" data-no-activator="">
+                        <div class="v-list-item-title">🚧 Wahl des Bezirksausschusses</div>
+                        <!---->
+                        <!---->
+                      </div>
+                      <div class="v-list-item__append"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true" density="default"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+                            <path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"></path>
+                          </svg></i>
+                        <!---->
+                        <div class="v-list-item__spacer"></div>
+                      </div>
+                    </div>
+                    <transition-stub name="" appear="false" persisted="false" css="false">
+                      <div class="v-list-group__items" role="group" aria-labelledby="v-list-group--id-BAW_Scores" style="display: none;">
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Zählen der Stimmzettel</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Ungültige Stimmzettel</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Gültige Stimmzettel</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Schnellmeldung</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Kandidatinnen- und Kandidatenstimmen</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Niederschrift</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                      </div>
+                    </transition-stub>
+                  </div>
+                </div>
+              </transition-stub>
+            </div>
           </div>
         </div>
         <!---->

--- a/wls-gui-wahllokalsystem/tests/components/wlsComponents/__snapshots__/TheWlsAppBar.vue/visual logic/should_renderNavigationDrawerIcon_when_initializationOfTaskHasCompletelyRun.html
+++ b/wls-gui-wahllokalsystem/tests/components/wlsComponents/__snapshots__/TheWlsAppBar.vue/visual logic/should_renderNavigationDrawerIcon_when_initializationOfTaskHasCompletelyRun.html
@@ -40,29 +40,12 @@
         <!---->
         <!---->
         <div class="v-navigation-drawer__content">
-          <div class="v-list v-theme--light bg-transparent v-list--density-default v-list--one-line" tabindex="0" role="listbox"><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
-              <!---->
-              <div class="v-list-item__content" data-no-activator="">
-                <div class="v-list-item-title">Home</div>
-                <!---->
-                <!---->
-              </div>
-              <!---->
-            </a><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
-              <!---->
-              <div class="v-list-item__content" data-no-activator="">
-                <div class="v-list-item-title">Wahlvorstand</div>
-                <!---->
-                <!---->
-              </div>
-              <!---->
-            </a>
-            <!--v-if-->
-            <div class="v-list-group">
-              <div class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text v-list-group__header" tabindex="-2" aria-selected="false" id="v-list-group--id-Wahlhandlung"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+          <div class="v-list v-theme--light bg-transparent v-list--density-default v-list--one-line pt-0" tabindex="0" role="listbox">
+            <div class="v-list-group bg-primary">
+              <div class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text v-list-group__header" tabindex="-2" aria-selected="false" id="v-list-group--id-Allgemein"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
                 <!---->
                 <div class="v-list-item__content" data-no-activator="">
-                  <div class="v-list-item-title">Wahlhandlung</div>
+                  <div class="v-list-item-title">Allgemein</div>
                   <!---->
                   <!---->
                 </div>
@@ -74,10 +57,10 @@
                 </div>
               </div>
               <transition-stub name="" appear="false" persisted="false" css="false">
-                <div class="v-list-group__items" role="group" aria-labelledby="v-list-group--id-Wahlhandlung" style="display: none;"><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                <div class="v-list-group__items" role="group" aria-labelledby="v-list-group--id-Allgemein" style="display: none;"><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
                     <!---->
                     <div class="v-list-item__content" data-no-activator="">
-                      <div class="v-list-item-title">Wahlumgebung</div>
+                      <div class="v-list-item-title">Home</div>
                       <!---->
                       <!---->
                     </div>
@@ -85,38 +68,345 @@
                   </a><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
                     <!---->
                     <div class="v-list-item__content" data-no-activator="">
-                      <div class="v-list-item-title">Wählerverzeichnis</div>
+                      <div class="v-list-item-title">Wahlvorstand</div>
                       <!---->
                       <!---->
                     </div>
                     <!---->
-                  </a><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                  </a>
+                  <!--v-if-->
+                  <div class="v-list-group">
+                    <div class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text v-list-group__header" tabindex="-2" aria-selected="false" id="v-list-group--id-Wahlhandlung"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                      <!---->
+                      <div class="v-list-item__content" data-no-activator="">
+                        <div class="v-list-item-title">Wahlhandlung</div>
+                        <!---->
+                        <!---->
+                      </div>
+                      <div class="v-list-item__append"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true" density="default"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+                            <path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"></path>
+                          </svg></i>
+                        <!---->
+                        <div class="v-list-item__spacer"></div>
+                      </div>
+                    </div>
+                    <transition-stub name="" appear="false" persisted="false" css="false">
+                      <div class="v-list-group__items" role="group" aria-labelledby="v-list-group--id-Wahlhandlung" style="display: none;"><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Wahlumgebung</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </a><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Wählerverzeichnis</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </a><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Beginn Stimmabgabe</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </a><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Stimmabgabe</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </a></div>
+                    </transition-stub>
+                  </div><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
                     <!---->
                     <div class="v-list-item__content" data-no-activator="">
-                      <div class="v-list-item-title">Beginn Stimmabgabe</div>
+                      <div class="v-list-item-title">Ereignisse</div>
                       <!---->
                       <!---->
                     </div>
                     <!---->
-                  </a><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
-                    <!---->
-                    <div class="v-list-item__content" data-no-activator="">
-                      <div class="v-list-item-title">Stimmabgabe</div>
-                      <!---->
-                      <!---->
-                    </div>
-                    <!---->
-                  </a></div>
+                  </a>
+                </div>
               </transition-stub>
-            </div><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
-              <!---->
-              <div class="v-list-item__content" data-no-activator="">
-                <div class="v-list-item-title">Ereignisse</div>
+            </div>
+            <div class="v-list-group">
+              <div class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text v-list-group__header" tabindex="-2" aria-selected="false" id="v-list-group--id-Ergebnisse"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
                 <!---->
-                <!---->
+                <div class="v-list-item__content" data-no-activator="">
+                  <div class="v-list-item-title">Ergebnisermittlung</div>
+                  <!---->
+                  <!---->
+                </div>
+                <div class="v-list-item__append"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true" density="default"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+                      <path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"></path>
+                    </svg></i>
+                  <!---->
+                  <div class="v-list-item__spacer"></div>
+                </div>
               </div>
-              <!---->
-            </a>
+              <transition-stub name="" appear="false" persisted="false" css="false">
+                <div class="v-list-group__items" role="group" aria-labelledby="v-list-group--id-Ergebnisse" style="display: none;">
+                  <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                    <!----><span class="v-list-item__underlay"></span>
+                    <!---->
+                    <div class="v-list-item__content" data-no-activator="">
+                      <div class="v-list-item-title">Stimmabgabevermerke</div>
+                      <!---->
+                      <!---->
+                    </div>
+                    <!---->
+                  </div>
+                  <div class="v-list-group">
+                    <div class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text v-list-group__header" tabindex="-2" aria-selected="false" id="v-list-group--id-OBW_Scores"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                      <!---->
+                      <div class="v-list-item__content" data-no-activator="">
+                        <div class="v-list-item-title">🚧 Wahl des Oberbürgermeisters</div>
+                        <!---->
+                        <!---->
+                      </div>
+                      <div class="v-list-item__append"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true" density="default"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+                            <path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"></path>
+                          </svg></i>
+                        <!---->
+                        <div class="v-list-item__spacer"></div>
+                      </div>
+                    </div>
+                    <transition-stub name="" appear="false" persisted="false" css="false">
+                      <div class="v-list-group__items" role="group" aria-labelledby="v-list-group--id-OBW_Scores" style="display: none;">
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Zählen der Stimmzettel</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Stapel c</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Stapel b</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Stapel a</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Schnellmeldung</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Niederschrift</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                      </div>
+                    </transition-stub>
+                  </div>
+                  <div class="v-list-group">
+                    <div class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text v-list-group__header" tabindex="-2" aria-selected="false" id="v-list-group--id-SRW_Scores"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                      <!---->
+                      <div class="v-list-item__content" data-no-activator="">
+                        <div class="v-list-item-title">🚧 Wahl des Stadtrats</div>
+                        <!---->
+                        <!---->
+                      </div>
+                      <div class="v-list-item__append"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true" density="default"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+                            <path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"></path>
+                          </svg></i>
+                        <!---->
+                        <div class="v-list-item__spacer"></div>
+                      </div>
+                    </div>
+                    <transition-stub name="" appear="false" persisted="false" css="false">
+                      <div class="v-list-group__items" role="group" aria-labelledby="v-list-group--id-SRW_Scores" style="display: none;">
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Zählen der Stimmzettel</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Ungültige Stimmzettel</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Gültige Stimmzettel</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Schnellmeldung</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Kandidatinnen- und Kandidatenstimmen</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Niederschrift</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                      </div>
+                    </transition-stub>
+                  </div>
+                  <div class="v-list-group">
+                    <div class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text v-list-group__header" tabindex="-2" aria-selected="false" id="v-list-group--id-BAW_Scores"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                      <!---->
+                      <div class="v-list-item__content" data-no-activator="">
+                        <div class="v-list-item-title">🚧 Wahl des Bezirksausschusses</div>
+                        <!---->
+                        <!---->
+                      </div>
+                      <div class="v-list-item__append"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true" density="default"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
+                            <path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"></path>
+                          </svg></i>
+                        <!---->
+                        <div class="v-list-item__spacer"></div>
+                      </div>
+                    </div>
+                    <transition-stub name="" appear="false" persisted="false" css="false">
+                      <div class="v-list-group__items" role="group" aria-labelledby="v-list-group--id-BAW_Scores" style="display: none;">
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Zählen der Stimmzettel</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Ungültige Stimmzettel</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Gültige Stimmzettel</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Schnellmeldung</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Kandidatinnen- und Kandidatenstimmen</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                        <div class="v-list-item v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text">
+                          <!----><span class="v-list-item__underlay"></span>
+                          <!---->
+                          <div class="v-list-item__content" data-no-activator="">
+                            <div class="v-list-item-title">Niederschrift</div>
+                            <!---->
+                            <!---->
+                          </div>
+                          <!---->
+                        </div>
+                      </div>
+                    </transition-stub>
+                  </div>
+                </div>
+              </transition-stub>
+            </div>
           </div>
         </div>
         <!---->


### PR DESCRIPTION
# Beschreibung:

- allgemeine navigationselemente gruppiert und wie im altystem mit der hintergrundfarbe primary versehen
- auszählungs navigationselemente ergänzt
- keine zwei komonenten, da das zu viel redundanter/doppelter code wäre

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [ ] [Naming Conventions][naming-conventions-link] beachtet
- [ ] Doku aktualisiert
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
- [ ] Unit-Tests gepflegt
- [ ] Komponententests gepflegt
- [x] Texte auf Rechtschreibung und Grammatik geprüft

# Referenzen[^1]:

Closes #1688

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added collapsible navigation groups for election results, including sections for Oberbürgermeister-, Stadtrats- und Bezirksausschusswahl.
  - Dynamic labeling in results navigation (e.g., “Wahlscheine” vs. “Stimmabgabevermerke”) based on user context.
- Refactor
  - Reorganized the navigation drawer into grouped lists for clearer structure.
  - Moved general items into an “Allgemein” group and separated the new results navigation for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->