### PR TITLE
Fix no stimmabgabevermerke on start

### DIFF
--- a/wls-gui-wahllokalsystem/src/composables/stimmabgabevermerke/stimmabgabevermerkeUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/stimmabgabevermerke/stimmabgabevermerkeUtils.ts
@@ -11,10 +11,10 @@ export function useStimmabgabevermerkeUtils() {
       wahlbezirkID: wahlbezirkID,
       wahldaten: [
         {
-          wahlbezirkID: wahlbezirkID,
-          waehlerverzeichnisNummer: waehlerverzeichnisNummer,
+          wahlbezirkID,
+          waehlerverzeichnisNummer,
           vermerke: [],
-          wahlID: wahlID,
+          wahlID,
           eingenommeneWahlscheine: new Map(),
         },
       ],

--- a/wls-gui-wahllokalsystem/src/composables/stimmabgabevermerke/stimmabgabevermerkeUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/stimmabgabevermerke/stimmabgabevermerkeUtils.ts
@@ -1,0 +1,28 @@
+import type { Stimmabgabevermerke } from "@/types/stimmabgabevermerke/Stimmabgabevermerke.ts";
+
+export function useStimmabgabevermerkeUtils() {
+  function createEmptyStimmabgabevermerke(
+    wahlID: string,
+    wahlbezirkID: string,
+    waehlerverzeichnisNummer: number
+  ): Stimmabgabevermerke {
+    return {
+      waehlerverzeichnisNummer: waehlerverzeichnisNummer,
+      wahlbezirkID: wahlbezirkID,
+      wahldaten: [
+        {
+          wahlbezirkID: wahlbezirkID,
+          waehlerverzeichnisNummer: waehlerverzeichnisNummer,
+          vermerke: [],
+          wahlID: wahlID,
+          eingenommeneWahlscheine: new Map(),
+        },
+      ],
+      anzahlBlaetter: 0,
+    };
+  }
+
+  return {
+    createEmptyStimmabgabevermerke,
+  };
+}

--- a/wls-gui-wahllokalsystem/src/stores/stimmabgabevermerkeStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/stimmabgabevermerkeStore.ts
@@ -1,11 +1,13 @@
 import type { Stimmabgabevermerke } from "@/types/stimmabgabevermerke/Stimmabgabevermerke.ts";
 import type { Vermerke } from "@/types/stimmabgabevermerke/Vermerke.ts";
 
-import { defineStore } from "pinia";
+import { defineStore, storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 
 import { useLogging } from "@/composables/common/logging.ts";
 import { useStimmabgabevermerkeService } from "@/composables/stimmabgabevermerke/stimmabgabevermerkeService.ts";
+import { useStimmabgabevermerkeUtils } from "@/composables/stimmabgabevermerke/stimmabgabevermerkeUtils.ts";
+import { useUserStore } from "@/stores/userStore.ts";
 import { EingenommenerWahlscheinStimmzettelartEnum } from "@/types/stimmabgabevermerke/EingenommenerWahlscheinStimmzettelartEnum.ts";
 import { StimmzettelStimmzettelartEnum } from "@/types/stimmabgabevermerke/StimmzettelStimmzettelartEnum.ts";
 
@@ -16,6 +18,10 @@ export const useStimmabgabevermerkeStore = defineStore(
     const isStimmabgabevermerkeSaving = ref(false);
     const { getStimmabgabevermerke, postStimmabgabevermerke } =
       useStimmabgabevermerkeService();
+    const { createEmptyStimmabgabevermerke } = useStimmabgabevermerkeUtils();
+
+    const { currentUserWahlMetadata } = storeToRefs(useUserStore());
+
     const { logDebug } = useLogging("stimmabgabevermerkeStore");
 
     const lowestNumberOfRowsOverAllWahldaten = computed(() => {
@@ -74,8 +80,11 @@ export const useStimmabgabevermerkeStore = defineStore(
           wahlbezirkID,
           waehlerverzeichnisNummer
         );
+
         if (loadedStimmabgabevermerke) {
           stimmabgabevermerke.value.push(loadedStimmabgabevermerke);
+        } else {
+          _addEmptyStimmabgabevermerke(wahlbezirkID, waehlerverzeichnisNummer);
         }
       } catch {
         throw Error(
@@ -157,6 +166,24 @@ export const useStimmabgabevermerkeStore = defineStore(
         } else if (newRowSize - 1 < lowestNumberOfRowsOverAllWahldaten.value) {
           _decreaseRows(newRowSize);
         }
+      }
+    }
+
+    function _addEmptyStimmabgabevermerke(
+      wahlbezirkID: string,
+      waehlerverzeichnisNummer: number
+    ) {
+      const wahlID = currentUserWahlMetadata.value.find(
+        (m) => m.wahlbezirkID === wahlbezirkID
+      )?.wahlID;
+      if (wahlID !== undefined) {
+        stimmabgabevermerke.value.push(
+          createEmptyStimmabgabevermerke(
+            wahlID,
+            wahlbezirkID,
+            waehlerverzeichnisNummer
+          )
+        );
       }
     }
 

--- a/wls-gui-wahllokalsystem/tests/composables/stimmabgabevermerke/stimmabgabevermerkeUtils.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/stimmabgabevermerke/stimmabgabevermerkeUtils.spec.ts
@@ -1,0 +1,41 @@
+import { useCommonTestDataFactory } from "@tests/utils/common/CommonTestDataFactory.ts";
+import { describe, expect, it } from "vitest";
+
+import { useStimmabgabevermerkeUtils } from "@/composables/stimmabgabevermerke/stimmabgabevermerkeUtils.ts";
+
+const { generateRandomString, generateRandomNumber } =
+  useCommonTestDataFactory();
+
+describe("stimmabgabevermerkeUtils.ts", () => {
+  const { createEmptyStimmabgabevermerke } = useStimmabgabevermerkeUtils();
+
+  describe("createEmptyStimmabgabevermerke", () => {
+    it("should_createAnObjectWithData_when_called", () => {
+      const wahlID = generateRandomString(10);
+      const wahlbezirkID = generateRandomString(10);
+      const waehlerverzeichnisNummer = generateRandomNumber(3);
+
+      const result = createEmptyStimmabgabevermerke(
+        wahlID,
+        wahlbezirkID,
+        waehlerverzeichnisNummer
+      );
+
+      const expectedResult = {
+        waehlerverzeichnisNummer: waehlerverzeichnisNummer,
+        wahlbezirkID: wahlbezirkID,
+        wahldaten: [
+          {
+            wahlbezirkID: wahlbezirkID,
+            waehlerverzeichnisNummer: waehlerverzeichnisNummer,
+            vermerke: [],
+            wahlID: wahlID,
+            eingenommeneWahlscheine: new Map(),
+          },
+        ],
+        anzahlBlaetter: 0,
+      };
+      expect(result).toStrictEqual(expectedResult);
+    });
+  });
+});

--- a/wls-gui-wahllokalsystem/tests/stores/stimmabgabevermerkeStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/stimmabgabevermerkeStore.spec.ts
@@ -79,7 +79,7 @@ describe("stimmabgabevermerkeStore.ts", () => {
       ]);
     });
 
-    it("should_addDefaultStimmabgabevermerkeToState_when_serviceReturnsDataAndUserHasWahlbezirkID", async () => {
+    it("should_addDefaultStimmabgabevermerkeToState_when_serviceReturnsNoDataAndUserHasWahlbezirkID", async () => {
       const wahlbezirkID = generateRandomString(10);
       const waehlerverzeichnisNummer = generateRandomNumber(3);
 
@@ -115,7 +115,7 @@ describe("stimmabgabevermerkeStore.ts", () => {
       ]);
     });
 
-    it("should_notAddDefaultStimmabgabevermerkeToState_when_serviceReturnsDataButUserHasNotThatWahlbezirkID", async () => {
+    it("should_notAddDefaultStimmabgabevermerkeToState_when_serviceReturnsNoDataButUserHasNotThatWahlbezirkID", async () => {
       const wahlbezirkID = generateRandomString(10);
       const waehlerverzeichnisNummer = generateRandomNumber(3);
 

--- a/wls-gui-wahllokalsystem/tests/stores/stimmabgabevermerkeStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/stimmabgabevermerkeStore.spec.ts
@@ -58,7 +58,7 @@ describe("stimmabgabevermerkeStore.ts", () => {
   describe("loadStimmabgabevermerke", () => {
     it("should_addStimmabgabevermerkeToState_when_serviceReturnsData", async () => {
       const wahlbezirkID = generateRandomString(10);
-      const waehlberzeichnisNummer = generateRandomNumber(3);
+      const waehlerverzeichnisNummer = generateRandomNumber(3);
 
       const existingStimmabgabevermerke = createStimmabgabevermerke();
       unitUnderTest.stimmabgabevermerke = [existingStimmabgabevermerke];
@@ -70,7 +70,7 @@ describe("stimmabgabevermerkeStore.ts", () => {
 
       await unitUnderTest.loadStimmabgabevermerke(
         wahlbezirkID,
-        waehlberzeichnisNummer
+        waehlerverzeichnisNummer
       );
 
       expect(unitUnderTest.stimmabgabevermerke).toStrictEqual([
@@ -81,7 +81,7 @@ describe("stimmabgabevermerkeStore.ts", () => {
 
     it("should_addDefaultStimmabgabevermerkeToState_when_serviceReturnsDataAndUserHasWahlbezirkID", async () => {
       const wahlbezirkID = generateRandomString(10);
-      const waehlberzeichnisNummer = generateRandomNumber(3);
+      const waehlerverzeichnisNummer = generateRandomNumber(3);
 
       const existingStimmabgabevermerke = createStimmabgabevermerke();
       unitUnderTest.stimmabgabevermerke = [existingStimmabgabevermerke];
@@ -106,7 +106,7 @@ describe("stimmabgabevermerkeStore.ts", () => {
 
       await unitUnderTest.loadStimmabgabevermerke(
         wahlbezirkID,
-        waehlberzeichnisNummer
+        waehlerverzeichnisNummer
       );
 
       expect(unitUnderTest.stimmabgabevermerke).toStrictEqual([
@@ -117,7 +117,7 @@ describe("stimmabgabevermerkeStore.ts", () => {
 
     it("should_notAddDefaultStimmabgabevermerkeToState_when_serviceReturnsDataButUserHasNotThatWahlbezirkID", async () => {
       const wahlbezirkID = generateRandomString(10);
-      const waehlberzeichnisNummer = generateRandomNumber(3);
+      const waehlerverzeichnisNummer = generateRandomNumber(3);
 
       const existingStimmabgabevermerke = createStimmabgabevermerke();
       unitUnderTest.stimmabgabevermerke = [existingStimmabgabevermerke];
@@ -142,7 +142,7 @@ describe("stimmabgabevermerkeStore.ts", () => {
 
       await unitUnderTest.loadStimmabgabevermerke(
         wahlbezirkID,
-        waehlberzeichnisNummer
+        waehlerverzeichnisNummer
       );
 
       expect(unitUnderTest.stimmabgabevermerke).toStrictEqual([

--- a/wls-gui-wahllokalsystem/tests/stores/stimmabgabevermerkeStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/stimmabgabevermerkeStore.spec.ts
@@ -1,20 +1,35 @@
 import { createTestingPinia } from "@pinia/testing";
+import { useCommonTestDataFactory } from "@tests/utils/common/CommonTestDataFactory.ts";
 import { useStimmabgabevermerkeTestDataFactory } from "@tests/utils/stimmabgabevermerke/StimmabgabevermerkeTestDataFactory.ts";
+import { useUserTestDataFactory } from "@tests/utils/user/UserTestDataFactory.ts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useStimmabgabevermerkeStore } from "@/stores/stimmabgabevermerkeStore.ts";
+import { useUserStore } from "@/stores/userStore.ts";
 import { StimmzettelStimmzettelartEnum } from "@/types/stimmabgabevermerke/StimmzettelStimmzettelartEnum.ts";
 
 const mockDefinitions = vi.hoisted(() => ({
+  getStimmabgabevermerke: vi.fn(),
   postStimmabgabevermerke: vi.fn(),
+  createEmptyStimmabgabevermerke: vi.fn(),
 }));
 
 vi.mock(
   "@/composables/stimmabgabevermerke/stimmabgabevermerkeService.ts",
   () => ({
     useStimmabgabevermerkeService: () => ({
+      getStimmabgabevermerke: mockDefinitions.getStimmabgabevermerke,
       postStimmabgabevermerke: mockDefinitions.postStimmabgabevermerke,
     }),
+  })
+);
+vi.mock(
+  "@/composables/stimmabgabevermerke/stimmabgabevermerkeUtils.ts",
+  () => ({
+    useStimmabgabevermerkeUtils: vi.fn().mockImplementation(() => ({
+      createEmptyStimmabgabevermerke:
+        mockDefinitions.createEmptyStimmabgabevermerke,
+    })),
   })
 );
 
@@ -28,6 +43,9 @@ describe("stimmabgabevermerkeStore.ts", () => {
     prepareVermerk,
     prepareStimmzettel,
   } = useStimmabgabevermerkeTestDataFactory();
+  const { generateRandomString, generateRandomNumber } =
+    useCommonTestDataFactory();
+  const { prepareUser } = useUserTestDataFactory();
 
   beforeEach(() => {
     const testPinia = createTestingPinia({
@@ -35,6 +53,102 @@ describe("stimmabgabevermerkeStore.ts", () => {
       createSpy: vi.fn,
     });
     unitUnderTest = useStimmabgabevermerkeStore(testPinia);
+  });
+
+  describe("loadStimmabgabevermerke", () => {
+    it("should_addStimmabgabevermerkeToState_when_serviceReturnsData", async () => {
+      const wahlbezirkID = generateRandomString(10);
+      const waehlberzeichnisNummer = generateRandomNumber(3);
+
+      const existingStimmabgabevermerke = createStimmabgabevermerke();
+      unitUnderTest.stimmabgabevermerke = [existingStimmabgabevermerke];
+
+      const mockedServiceStimmabgabevermerke = createStimmabgabevermerke();
+      mockDefinitions.getStimmabgabevermerke.mockResolvedValue(
+        mockedServiceStimmabgabevermerke
+      );
+
+      await unitUnderTest.loadStimmabgabevermerke(
+        wahlbezirkID,
+        waehlberzeichnisNummer
+      );
+
+      expect(unitUnderTest.stimmabgabevermerke).toStrictEqual([
+        existingStimmabgabevermerke,
+        mockedServiceStimmabgabevermerke,
+      ]);
+    });
+
+    it("should_addDefaultStimmabgabevermerkeToState_when_serviceReturnsDataAndUserHasWahlbezirkID", async () => {
+      const wahlbezirkID = generateRandomString(10);
+      const waehlberzeichnisNummer = generateRandomNumber(3);
+
+      const existingStimmabgabevermerke = createStimmabgabevermerke();
+      unitUnderTest.stimmabgabevermerke = [existingStimmabgabevermerke];
+
+      mockDefinitions.getStimmabgabevermerke.mockResolvedValue(null);
+      const mockedEmptyStimmabgabevermerke = createStimmabgabevermerke();
+      mockDefinitions.createEmptyStimmabgabevermerke.mockReturnValue(
+        mockedEmptyStimmabgabevermerke
+      );
+
+      useUserStore().setUser(
+        prepareUser()
+          .wahlMetaData([
+            {
+              wahlbezirkID: wahlbezirkID,
+              wahlnummer: generateRandomString(1),
+              wahlID: generateRandomString(10),
+            },
+          ])
+          .build()
+      );
+
+      await unitUnderTest.loadStimmabgabevermerke(
+        wahlbezirkID,
+        waehlberzeichnisNummer
+      );
+
+      expect(unitUnderTest.stimmabgabevermerke).toStrictEqual([
+        existingStimmabgabevermerke,
+        mockedEmptyStimmabgabevermerke,
+      ]);
+    });
+
+    it("should_notAddDefaultStimmabgabevermerkeToState_when_serviceReturnsDataButUserHasNotThatWahlbezirkID", async () => {
+      const wahlbezirkID = generateRandomString(10);
+      const waehlberzeichnisNummer = generateRandomNumber(3);
+
+      const existingStimmabgabevermerke = createStimmabgabevermerke();
+      unitUnderTest.stimmabgabevermerke = [existingStimmabgabevermerke];
+
+      mockDefinitions.postStimmabgabevermerke.mockResolvedValue(null);
+      const mockedEmptyStimmabgabevermerke = createStimmabgabevermerke();
+      mockDefinitions.createEmptyStimmabgabevermerke.mockReturnValue(
+        mockedEmptyStimmabgabevermerke
+      );
+
+      useUserStore().setUser(
+        prepareUser()
+          .wahlMetaData([
+            {
+              wahlbezirkID: wahlbezirkID + wahlbezirkID,
+              wahlnummer: generateRandomString(1),
+              wahlID: generateRandomString(10),
+            },
+          ])
+          .build()
+      );
+
+      await unitUnderTest.loadStimmabgabevermerke(
+        wahlbezirkID,
+        waehlberzeichnisNummer
+      );
+
+      expect(unitUnderTest.stimmabgabevermerke).toStrictEqual([
+        existingStimmabgabevermerke,
+      ]);
+    });
   });
 
   describe("isAnyRowThatShouldBeDeletedFilled", () => {


### PR DESCRIPTION
# Beschreibung:

Fix von Bug dass man keine Stimmabgabevermerke pflegen kann wenn noch keine Daten in der Datenbank sind. Wenn ein 204 vom Backend kommt wird ein Defaultzustand erstellt.

Zum Nachstellen schlage ich vor die DB für den Ergebnismeldungsservice neu aufzusetzen da diverse Tabellen zurückzusetzen sind.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Doku aktualisiert - kein Update erforderlich
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
- [X] Unit-Tests gepflegt
- [x] ~~Komponententests gepflegt~~
- [X] ~~Texte auf Rechtschreibung und Grammatik geprüft~~ keine Texte verfasst

# Referenzen[^1]:

Verwandt mit Issue #1537

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically creates an empty entry when no data is found for the selected election district and register, enabling immediate input instead of showing an empty state.
  - Improves reliability when loading voter remarks by ensuring a consistent default structure.

- Tests
  - Added unit tests covering the creation of empty entries and the store’s loading behavior, including scenarios with and without matching user permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->