### PR TITLE
Add toasty feedback after saving stimmabgabevermerke

### DIFF
--- a/wls-gui-wahllokalsystem/src/composables/stimmabgabevermerke/stimmabgabevermerkeService.ts
+++ b/wls-gui-wahllokalsystem/src/composables/stimmabgabevermerke/stimmabgabevermerkeService.ts
@@ -59,6 +59,10 @@ export function useStimmabgabevermerkeService() {
         waehlerverzeichnisNummer,
         toDto(stimmabgabevermerke)
       );
+      addNotification(
+        `Stimmabgabevermerke erfolgreich gespeichert`,
+        UserNotificationCategoryEnum.SUCCESS
+      );
     } catch (e) {
       const errorMessage = "Fehler beim Speichern der Stimmabgabevermerke.";
       logDebug(errorMessage, e);

--- a/wls-gui-wahllokalsystem/src/composables/stimmabgabevermerke/stimmabgabevermerkeService.ts
+++ b/wls-gui-wahllokalsystem/src/composables/stimmabgabevermerke/stimmabgabevermerkeService.ts
@@ -9,6 +9,7 @@ import { useLogging } from "@/composables/common/logging.ts";
 import { useStimmabgabevermerkeMapper } from "@/composables/stimmabgabevermerke/stimmabgabevermerkeMapper.ts";
 import { useUserNotificationService } from "@/composables/userNotification/userNotificationService.ts";
 import { ERGEBNISMELDUNG_SERVICE_API_URL } from "@/constants.ts";
+import { useWahlenStore } from "@/stores/wahlenStore.ts";
 import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
 
 const { addNotification } = useUserNotificationService();
@@ -53,18 +54,24 @@ export function useStimmabgabevermerkeService() {
     waehlerverzeichnisNummer: number,
     stimmabgabevermerke: Stimmabgabevermerke
   ) {
+    const { getWahlNameOrBlankStringById } = useWahlenStore();
+    const wahlname = getWahlNameOrBlankStringById(
+      stimmabgabevermerke.wahldaten[0].wahlID
+    );
     try {
       await stimmabgabevermerkeControllerApi.postStimmabgabevermerke(
         wahlbezirkID,
         waehlerverzeichnisNummer,
         toDto(stimmabgabevermerke)
       );
+
       addNotification(
-        `Stimmabgabevermerke erfolgreich gespeichert`,
+        `Stimmabgabevermerke für ${wahlname} erfolgreich gespeichert`,
         UserNotificationCategoryEnum.SUCCESS
       );
     } catch (e) {
-      const errorMessage = "Fehler beim Speichern der Stimmabgabevermerke.";
+      const errorMessage =
+        "Fehler beim Speichern der Stimmabgabevermerke für " + wahlname;
       logDebug(errorMessage, e);
       addNotification(errorMessage, UserNotificationCategoryEnum.ERROR);
       throw new Error("Post Stimmabgabevermerke Failed");

--- a/wls-gui-wahllokalsystem/src/composables/stimmabgabevermerke/stimmabgabevermerkeService.ts
+++ b/wls-gui-wahllokalsystem/src/composables/stimmabgabevermerke/stimmabgabevermerkeService.ts
@@ -55,9 +55,9 @@ export function useStimmabgabevermerkeService() {
     stimmabgabevermerke: Stimmabgabevermerke
   ) {
     const { getWahlNameOrBlankStringById } = useWahlenStore();
-    const wahlname = getWahlNameOrBlankStringById(
-      stimmabgabevermerke.wahldaten[0].wahlID
-    );
+    const wahlname =
+      getWahlNameOrBlankStringById(stimmabgabevermerke.wahldaten?.[0].wahlID) ||
+      "";
     try {
       await stimmabgabevermerkeControllerApi.postStimmabgabevermerke(
         wahlbezirkID,

--- a/wls-gui-wahllokalsystem/tests/composables/stimmabgabevermerke/stimmabgabevermerkeService.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/stimmabgabevermerke/stimmabgabevermerkeService.spec.ts
@@ -1,8 +1,10 @@
 import { useCommonTestDataFactory } from "@tests/utils/common/CommonTestDataFactory.ts";
 import { useStimmabgabevermerkeTestDataFactory } from "@tests/utils/stimmabgabevermerke/StimmabgabevermerkeTestDataFactory.ts";
+import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useStimmabgabevermerkeService } from "@/composables/stimmabgabevermerke/stimmabgabevermerkeService.ts";
+import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
 
 const mockDefinitions = vi.hoisted(() => ({
   getStimmabgabevermerke: vi.fn(),
@@ -13,6 +15,7 @@ const mockDefinitions = vi.hoisted(() => ({
 }));
 
 vi.mock("@/api/wls-clients/generated-ergebnismeldung-api", () => ({
+  StimmzettelumschlaegeControllerApi: vi.fn(),
   StimmabgabevermerkeControllerApi: vi.fn().mockImplementation(() => ({
     getStimmabgabevermerke: mockDefinitions.getStimmabgabevermerke,
     postStimmabgabevermerke: mockDefinitions.postStimmabgabevermerke,
@@ -49,9 +52,11 @@ describe("stimmabgabevermekerService.ts", () => {
     useStimmabgabevermerkeService();
 
   beforeEach(() => {
+    setActivePinia(createPinia());
     vi.resetAllMocks();
     vi.clearAllMocks();
   });
+
   describe("getStimmabgabevermerke", () => {
     it("should_returnStimmabgabevermerke_when_parameterAreGiven", async () => {
       const waehlerverzeichnisNummer = generateRandomNumber(2);
@@ -107,7 +112,7 @@ describe("stimmabgabevermekerService.ts", () => {
   });
 
   describe("postStimmabgabevermerke", () => {
-    it("should_sendStimmabgabevermerke_when_noErrorAppear", () => {
+    it("should_sendStimmabgabevermerke_when_noErrorAppear", async () => {
       const stimmabgabevermerk = createStimmabgabevermerke();
       const stimmabgabevermerkeDTO = prepareStimmabgabevermerkeDTO()
         .wahlbezirkID(stimmabgabevermerk.wahlbezirkID)
@@ -120,7 +125,7 @@ describe("stimmabgabevermekerService.ts", () => {
 
       mockDefinitions.toDto.mockReturnValue(stimmabgabevermerkeDTO);
 
-      postStimmabgabevermerke(
+      await postStimmabgabevermerke(
         stimmabgabevermerk.wahlbezirkID,
         stimmabgabevermerk.waehlerverzeichnisNummer,
         stimmabgabevermerk
@@ -131,6 +136,9 @@ describe("stimmabgabevermekerService.ts", () => {
         stimmabgabevermerk.waehlerverzeichnisNummer,
         stimmabgabevermerkeDTO
       );
+      expect(mockDefinitions.addNotification.mock.calls).toEqual([
+        [expect.any(String), UserNotificationCategoryEnum.SUCCESS],
+      ]);
     });
 
     it("should_throwError_when_postStimmabgabevermerkeFailed", async () => {


### PR DESCRIPTION
# Beschreibung:

- user feedback beim speichern der stimmabgabevermerke ergänzt

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] tests angepasst


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Notifications when saving voting records now include the specific election name for clearer context.
  - Error messages on save failures also reference the relevant election.
- Tests
  - Expanded test coverage to validate success and error notifications.
  - Improved test setup with isolated stores and async handling for service calls.
  - Added assertions ensuring no notifications are shown when not applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->