### PR TITLE
1812 - Refactore Linking in ListItems

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/navigation/TheBWBElectionListGroup.vue
+++ b/wls-gui-wahllokalsystem/src/components/navigation/TheBWBElectionListGroup.vue
@@ -8,28 +8,31 @@
     </template>
     <v-list-item
       title="Beginn Stimmabgabe"
-      :to="ROUTE_BEGINN_STIMMABGABE"
+      :to="routeWithName(ROUTE_BEGINN_STIMMABGABE)"
     />
     <v-list-item
       title="Wahlumgebung"
-      :to="ROUTE_WAHLUMGEBUNG"
+      :to="routeWithName(ROUTE_WAHLUMGEBUNG)"
     />
     <v-list-item
       title="Wahlbriefe erfassen"
-      :to="ROUTE_ERFASSUNG_WAHLBRIEFE"
+      :to="routeWithName(ROUTE_ERFASSUNG_WAHLBRIEFE)"
     />
     <v-list-item
       title="Wahlbriefe zulassen"
-      :to="ROUTE_WAHLBRIEFE_ZULASSEN"
+      :to="routeWithName(ROUTE_WAHLBRIEFE_ZULASSEN)"
     />
   </v-list-group>
 </template>
 
 <script setup lang="ts">
+import { useNavigationUtils } from "@/composables/navigation/navigationUtils.ts";
 import {
   ROUTE_BEGINN_STIMMABGABE,
   ROUTE_ERFASSUNG_WAHLBRIEFE,
   ROUTE_WAHLBRIEFE_ZULASSEN,
   ROUTE_WAHLUMGEBUNG,
 } from "@/constants.ts";
+
+const { routeWithName } = useNavigationUtils();
 </script>

--- a/wls-gui-wahllokalsystem/src/components/navigation/TheKommunalwahlenScoresListGroup.vue
+++ b/wls-gui-wahllokalsystem/src/components/navigation/TheKommunalwahlenScoresListGroup.vue
@@ -7,8 +7,14 @@
       />
     </template>
     <v-list-item
-      :title="title"
-      :to="route"
+      v-if="isBWB"
+      title="Wahlscheine"
+      to="/Wahlscheine"
+    />
+    <v-list-item
+      v-if="isUWB"
+      title="Stimmabgabevermerke"
+      :to="'/' + ROUTE_STIMMABGABEVERMERKE"
     />
     <the-o-b-w-scores-list-group :title-stimmen-zaehlen="titleStimmenZaehlen" />
     <the-s-r-w-scores-list-group :title-stimmen-zaehlen="titleStimmenZaehlen" />
@@ -26,15 +32,8 @@ import TheSRWScoresListGroup from "@/components/navigation/auszaehlung_wahlarten
 import { ROUTE_STIMMABGABEVERMERKE } from "@/constants.ts";
 import { useUserStore } from "@/stores/userStore.ts";
 
-const { isBWB } = storeToRefs(useUserStore());
+const { isBWB, isUWB } = storeToRefs(useUserStore());
 
-const title = computed(() =>
-  isBWB.value ? "Wahlscheine" : "Stimmabgabevermerke"
-);
-
-const route = computed(() =>
-  isBWB.value ? "Wahlscheine" : ROUTE_STIMMABGABEVERMERKE
-);
 const titleStimmenZaehlen = computed(() => {
   return isBWB.value
     ? "Zählen der Stimmzettelumschläge"

--- a/wls-gui-wahllokalsystem/src/components/navigation/TheKommunalwahlenScoresListGroup.vue
+++ b/wls-gui-wahllokalsystem/src/components/navigation/TheKommunalwahlenScoresListGroup.vue
@@ -14,7 +14,7 @@
     <v-list-item
       v-if="isUWB"
       title="Stimmabgabevermerke"
-      :to="'/' + ROUTE_STIMMABGABEVERMERKE"
+      :to="routeWithName(ROUTE_STIMMABGABEVERMERKE)"
     />
     <the-o-b-w-scores-list-group :title-stimmen-zaehlen="titleStimmenZaehlen" />
     <the-s-r-w-scores-list-group :title-stimmen-zaehlen="titleStimmenZaehlen" />
@@ -29,10 +29,12 @@ import { computed } from "vue";
 import TheBAWScoresListGroup from "@/components/navigation/auszaehlung_wahlarten/TheBAWScoresListGroup.vue";
 import TheOBWScoresListGroup from "@/components/navigation/auszaehlung_wahlarten/TheOBWScoresListGroup.vue";
 import TheSRWScoresListGroup from "@/components/navigation/auszaehlung_wahlarten/TheSRWScoresListGroup.vue";
+import { useNavigationUtils } from "@/composables/navigation/navigationUtils.ts";
 import { ROUTE_STIMMABGABEVERMERKE } from "@/constants.ts";
 import { useUserStore } from "@/stores/userStore.ts";
 
 const { isBWB, isUWB } = storeToRefs(useUserStore());
+const { routeWithName } = useNavigationUtils();
 
 const titleStimmenZaehlen = computed(() => {
   return isBWB.value

--- a/wls-gui-wahllokalsystem/src/components/navigation/TheUWBElectionListGroup.vue
+++ b/wls-gui-wahllokalsystem/src/components/navigation/TheUWBElectionListGroup.vue
@@ -8,28 +8,31 @@
     </template>
     <v-list-item
       title="Wahlumgebung"
-      :to="ROUTE_WAHLUMGEBUNG"
+      :to="routeWithName(ROUTE_WAHLUMGEBUNG)"
     />
     <v-list-item
       title="Wählerverzeichnis"
-      :to="ROUTE_WAHLVORBEREITUNG_WAEHLERVERZEICHNIS"
+      :to="routeWithName(ROUTE_WAHLVORBEREITUNG_WAEHLERVERZEICHNIS)"
     />
     <v-list-item
       title="Beginn Stimmabgabe"
-      :to="ROUTE_BEGINN_STIMMABGABE"
+      :to="routeWithName(ROUTE_BEGINN_STIMMABGABE)"
     />
     <v-list-item
       title="Stimmabgabe"
-      :to="ROUTE_STIMMABGABE"
+      :to="routeWithName(ROUTE_STIMMABGABE)"
     />
   </v-list-group>
 </template>
 
 <script setup lang="ts">
+import { useNavigationUtils } from "@/composables/navigation/navigationUtils.ts";
 import {
   ROUTE_BEGINN_STIMMABGABE,
   ROUTE_STIMMABGABE,
   ROUTE_WAHLUMGEBUNG,
   ROUTE_WAHLVORBEREITUNG_WAEHLERVERZEICHNIS,
 } from "@/constants.ts";
+
+const { routeWithName } = useNavigationUtils();
 </script>

--- a/wls-gui-wahllokalsystem/src/components/navigation/auszaehlung_wahlarten/TheBAWScoresListGroup.vue
+++ b/wls-gui-wahllokalsystem/src/components/navigation/auszaehlung_wahlarten/TheBAWScoresListGroup.vue
@@ -11,10 +11,11 @@
     https://github.com/vuetifyjs/vuetify/issues/20516 -->
     <v-list-item
       :title="titleStimmenZaehlen"
-      :to="{
-        name: ROUTE_AUSZAEHLUNG_STIMMZETTEL,
-        params: { wahlId: String(bawWahlID) },
-      }"
+      :to="
+        routeWithNameAndParams(ROUTE_AUSZAEHLUNG_STIMMZETTEL, {
+          wahlId: String(bawWahlID),
+        })
+      "
     />
     <v-list-item title="Ungültige Stimmzettel" />
     <v-list-item title="Gültige Stimmzettel" />
@@ -27,11 +28,13 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
+import { useNavigationUtils } from "@/composables/navigation/navigationUtils.ts";
 import { ROUTE_AUSZAEHLUNG_STIMMZETTEL } from "@/constants.ts";
 import { useWahlenStore } from "@/stores/wahlenStore.ts";
 import { WahlWahlartEnum } from "@/types/wahl/WahlWahlartEnum.ts";
 
 const { getWahlIdOrUndefinedByWahlart } = useWahlenStore();
+const { routeWithNameAndParams } = useNavigationUtils();
 
 defineProps<{
   titleStimmenZaehlen: string;

--- a/wls-gui-wahllokalsystem/src/components/navigation/auszaehlung_wahlarten/TheOBWScoresListGroup.vue
+++ b/wls-gui-wahllokalsystem/src/components/navigation/auszaehlung_wahlarten/TheOBWScoresListGroup.vue
@@ -11,10 +11,11 @@
     https://github.com/vuetifyjs/vuetify/issues/20516 -->
     <v-list-item
       :title="titleStimmenZaehlen"
-      :to="{
-        name: ROUTE_AUSZAEHLUNG_STIMMZETTEL,
-        params: { wahlId: String(obwWahlID) },
-      }"
+      :to="
+        routeWithNameAndParams(ROUTE_AUSZAEHLUNG_STIMMZETTEL, {
+          wahlId: String(obwWahlID),
+        })
+      "
     />
     <v-list-item title="Stapel c" />
     <v-list-item title="Stapel b" />
@@ -27,11 +28,13 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
+import { useNavigationUtils } from "@/composables/navigation/navigationUtils.ts";
 import { ROUTE_AUSZAEHLUNG_STIMMZETTEL } from "@/constants.ts";
 import { useWahlenStore } from "@/stores/wahlenStore.ts";
 import { WahlWahlartEnum } from "@/types/wahl/WahlWahlartEnum.ts";
 
 const { getWahlIdOrUndefinedByWahlart } = useWahlenStore();
+const { routeWithNameAndParams } = useNavigationUtils();
 
 defineProps<{
   titleStimmenZaehlen: string;

--- a/wls-gui-wahllokalsystem/src/components/navigation/auszaehlung_wahlarten/TheSRWScoresListGroup.vue
+++ b/wls-gui-wahllokalsystem/src/components/navigation/auszaehlung_wahlarten/TheSRWScoresListGroup.vue
@@ -11,10 +11,11 @@
     https://github.com/vuetifyjs/vuetify/issues/20516 -->
     <v-list-item
       :title="titleStimmenZaehlen"
-      :to="{
-        name: ROUTE_AUSZAEHLUNG_STIMMZETTEL,
-        params: { wahlId: String(srwWahlID) },
-      }"
+      :to="
+        routeWithNameAndParams(ROUTE_AUSZAEHLUNG_STIMMZETTEL, {
+          wahlId: String(srwWahlID),
+        })
+      "
     />
     <v-list-item title="Ungültige Stimmzettel" />
     <v-list-item title="Gültige Stimmzettel" />
@@ -27,11 +28,13 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
+import { useNavigationUtils } from "@/composables/navigation/navigationUtils.ts";
 import { ROUTE_AUSZAEHLUNG_STIMMZETTEL } from "@/constants.ts";
 import { useWahlenStore } from "@/stores/wahlenStore.ts";
 import { WahlWahlartEnum } from "@/types/wahl/WahlWahlartEnum.ts";
 
 const { getWahlIdOrUndefinedByWahlart } = useWahlenStore();
+const { routeWithNameAndParams } = useNavigationUtils();
 
 defineProps<{
   titleStimmenZaehlen: string;

--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/TheWlsAppBar.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/TheWlsAppBar.vue
@@ -54,17 +54,17 @@
           </template>
           <v-list-item
             title="Home"
-            :to="'/'"
+            :to="routeWithName(ROUTES_HOME)"
           />
           <v-list-item
             title="Wahlvorstand"
-            :to="ROUTE_WAHLVORSTAND"
+            :to="routeWithName(ROUTE_WAHLVORSTAND)"
           />
           <the-b-w-b-election-list-group v-if="isBWB" />
           <the-u-w-b-election-list-group v-if="isUWB" />
           <v-list-item
             title="Ereignisse"
-            :to="ROUTE_EREIGNISSE"
+            :to="routeWithName(ROUTE_EREIGNISSE)"
           />
         </v-list-group>
         <the-kommunalwahlen-scores-list-group />
@@ -86,7 +86,12 @@ import TheUWBElectionListGroup from "@/components/navigation/TheUWBElectionListG
 import TheWlsOnlineOfflineMenu from "@/components/wlsComponents/TheWlsOnlineOfflineMenu.vue";
 import WlsClock from "@/components/wlsComponents/WlsClock.vue";
 import { useDateTimeFormatter } from "@/composables/common/dateTimeFormatter.ts";
-import { ROUTE_EREIGNISSE, ROUTE_WAHLVORSTAND } from "@/constants.ts";
+import { useNavigationUtils } from "@/composables/navigation/navigationUtils.ts";
+import {
+  ROUTE_EREIGNISSE,
+  ROUTE_WAHLVORSTAND,
+  ROUTES_HOME,
+} from "@/constants.ts";
 import { useTaskManagerStore } from "@/stores/taskManagerStore.ts";
 import { useUserStore } from "@/stores/userStore.ts";
 import { useWahlbezirkStore } from "@/stores/wahlbezirkStore.ts";
@@ -100,6 +105,8 @@ const { user, currentUserWahltag, currentUserWahlbezirkNummer, isUWB, isBWB } =
 const { hasInitializationOfTasksCompletelyRun } = storeToRefs(
   useTaskManagerStore()
 );
+const { routeWithName } = useNavigationUtils();
+
 const [drawer, toggleDrawer] = useToggle();
 const wahltermin = computed(() =>
   user ? toGermanDate(currentUserWahltag.value ?? "") : ""

--- a/wls-gui-wahllokalsystem/src/composables/navigation/navigationUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/navigation/navigationUtils.ts
@@ -1,0 +1,24 @@
+import type { RouteLocationAsRelativeGeneric } from "vue-router";
+
+export function useNavigationUtils() {
+  function routeWithName(routeName: string): RouteLocationAsRelativeGeneric {
+    return {
+      name: routeName,
+    };
+  }
+
+  function routeWithNameAndParams(
+    routeName: string,
+    params: Record<string, string>
+  ): RouteLocationAsRelativeGeneric {
+    return {
+      name: routeName,
+      params,
+    };
+  }
+
+  return {
+    routeWithName,
+    routeWithNameAndParams,
+  };
+}

--- a/wls-gui-wahllokalsystem/src/views/ExampleError404View.vue
+++ b/wls-gui-wahllokalsystem/src/views/ExampleError404View.vue
@@ -7,12 +7,15 @@
     <v-col class="text-center">
       <p>
         Back
-        <router-link :to="{ name: ROUTES_HOME }"> Home</router-link>
+        <router-link :to="routeWithName(ROUTES_HOME)"> Home</router-link>
       </p>
     </v-col>
   </v-container>
 </template>
 
 <script setup lang="ts">
+import { useNavigationUtils } from "@/composables/navigation/navigationUtils.ts";
 import { ROUTES_HOME } from "@/constants";
+
+const { routeWithName } = useNavigationUtils();
 </script>

--- a/wls-gui-wahllokalsystem/tests/components/wlsComponents/__snapshots__/TheWlsAppBar.vue/visual logic/should_notRenderNavigationDrawerIcon_when_initializationOfTaskHasNotCompletelyRun.html
+++ b/wls-gui-wahllokalsystem/tests/components/wlsComponents/__snapshots__/TheWlsAppBar.vue/visual logic/should_notRenderNavigationDrawerIcon_when_initializationOfTaskHasNotCompletelyRun.html
@@ -151,7 +151,8 @@
                 </div>
               </div>
               <transition-stub name="" appear="false" persisted="false" css="false">
-                <div class="v-list-group__items" role="group" aria-labelledby="v-list-group--id-Ergebnisse" style="display: none;"><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                <div class="v-list-group__items" role="group" aria-labelledby="v-list-group--id-Ergebnisse" style="display: none;">
+                  <!--v-if--><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
                     <!---->
                     <div class="v-list-item__content" data-no-activator="">
                       <div class="v-list-item-title">Stimmabgabevermerke</div>

--- a/wls-gui-wahllokalsystem/tests/components/wlsComponents/__snapshots__/TheWlsAppBar.vue/visual logic/should_renderNavigationDrawerIcon_when_initializationOfTaskHasCompletelyRun.html
+++ b/wls-gui-wahllokalsystem/tests/components/wlsComponents/__snapshots__/TheWlsAppBar.vue/visual logic/should_renderNavigationDrawerIcon_when_initializationOfTaskHasCompletelyRun.html
@@ -153,7 +153,8 @@
                 </div>
               </div>
               <transition-stub name="" appear="false" persisted="false" css="false">
-                <div class="v-list-group__items" role="group" aria-labelledby="v-list-group--id-Ergebnisse" style="display: none;"><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
+                <div class="v-list-group__items" role="group" aria-labelledby="v-list-group--id-Ergebnisse" style="display: none;">
+                  <!--v-if--><a class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--one-line rounded-0 v-list-item--variant-text" tabindex="-2"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
                     <!---->
                     <div class="v-list-item__content" data-no-activator="">
                       <div class="v-list-item-title">Stimmabgabevermerke</div>

--- a/wls-gui-wahllokalsystem/tests/composables/navigation/navigationUtils.ts.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/navigation/navigationUtils.ts.spec.ts
@@ -1,0 +1,63 @@
+import { useCommonTestDataFactory } from "@tests/utils/common/CommonTestDataFactory.ts";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useNavigationUtils } from "@/composables/navigation/navigationUtils.ts";
+
+const { generateRandomString } = useCommonTestDataFactory();
+
+describe("navigationUtils.ts", () => {
+  let unitUnderTest: ReturnType<typeof useNavigationUtils>;
+
+  beforeEach(() => {
+    unitUnderTest = useNavigationUtils();
+  });
+
+  describe("routeWithName", () => {
+    it("should_setNameInObject_when_routeNameIsGiven", () => {
+      const routeName = generateRandomString(20);
+
+      const result = unitUnderTest.routeWithName(routeName);
+
+      const expectedResult = {
+        name: routeName,
+      };
+      expect(result).toStrictEqual(expectedResult);
+    });
+  });
+
+  describe("routeWithNameAndParams", () => {
+    it.each([
+      {
+        params: {},
+        additionalTestCaseDescription: "AndParameterisEmptyObject",
+      },
+      {
+        params: { [generateRandomString(4)]: generateRandomString(10) },
+        additionalTestCaseDescription: "AndParameterisHasOneProperty",
+      },
+      {
+        params: {
+          [generateRandomString(4)]: generateRandomString(10),
+          [generateRandomString(5)]: generateRandomString(10),
+        },
+        additionalTestCaseDescription: "AndParameterisHasTwoProperties",
+      },
+    ])(
+      "should_setNameAndParamsInObject_when_routeNameAndParamsAreGiven$additionalTestCaseDescription",
+      (args) => {
+        const routeName = generateRandomString(20);
+
+        const result = unitUnderTest.routeWithNameAndParams(
+          routeName,
+          args.params
+        );
+
+        const expectedResult = {
+          name: routeName,
+          params: args.params,
+        };
+        expect(result).toStrictEqual(expectedResult);
+      }
+    );
+  });
+});


### PR DESCRIPTION
# Beschreibung:

Der Link war relativ definiert weshalb es zu dem Problem kam.

Zur besseren Lesbarkeit habe ich zwei List-Items definiert. Eins führt bei einem `BWB` zu den Wahlscheinen. Das andere bei einem `UWB` zu den Stimmabgabevermerken. Ich halte es für lesbarer da man auf diese Weise ohne das Skript versteht wofür die Navigationspunkte sind. Zuvor war es zu generisch.

---

Alle Stellen die eine Navigation durchgeführt haben wurden überarbeitet und verwenden ein Composable dass sich darum kümmert dass über den Namen navigiert wird.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [X] [Naming Conventions][naming-conventions-link] beachtet
- [X] ~~Doku aktualisiert~~ - nicht notwendig
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
- [X] ~~Unit-Tests gepflegt~~ kein Update erforderlich
- [X] Komponententests gepflegt - Snapshots wurden aktualisiert
- [X] ~~Texte auf Rechtschreibung und Grammatik geprüft~~ keine Texte verfasst

# Referenzen[^1]:

Closes #1812

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation now shows context-specific entries: “Wahlscheine” for BWB and “Stimmabgabevermerke” for UWB, improving clarity and discoverability.
* **Bug Fixes**
  * Corrected navigation routing for “Wahlscheine” using an absolute path to ensure reliable navigation.
* **Tests**
  * Updated visual snapshots to reflect conditional rendering in the navigation, aligning tests with the new menu behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->