### PR TITLE
#1765 add global css for active btn

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -136,6 +136,10 @@ export default withMermaid({
                   text: "Abweichung von Tabreihenfolge in Leserichtung, wenn notwendig",
                   link: `${PATH_ADR_UI}adr003-tab-order.md`,
                 },
+                {
+                  text: "Styling des active Button",
+                  link: `${PATH_ADR_UI}adr004-active-btn-styling.md`,
+                },
               ],
             },
           ],

--- a/docs/src/technik/adr/ui/adr004-active-btn-styling.md
+++ b/docs/src/technik/adr/ui/adr004-active-btn-styling.md
@@ -1,0 +1,21 @@
+# Styling des `active` Buttons
+
+## Status
+
+<adr-status status='accepted'></adr-status>
+
+## Kontext
+
+Ein Button mit dem `active`-Prop wird für den Nutzer hervorgehoben. Wenn dieser disabled ist, oder darüber gehovert
+wird, wird von vuetify ein overlay darüber gelegt, welches den Butten heller und somit schwieriger lesbar macht.
+
+## Entscheidung
+
+- Alle Buttons mit `active`-Prop haben die `primary`-Farbe der Anwendung.
+- Alle Buttons mit `active`-Prop, die disabled sind, haben keine Farbe mehr (--> grau)
+- Alle Buttons mit `active`-Prop, über die entweder gehovert wird, oder die per Tab fokussiert wurden, werden nicht
+  heller, sondern dunkler, um nicht zu viel an Kontrast zu verlieren
+
+## Konsequenzen
+
+Die Einstellungen sind alle zentral definiert und gelten für alle `v-btn`-Tags, die das `active`-Prop erhalten.

--- a/wls-gui-wahllokalsystem/src/styles/custom.css
+++ b/wls-gui-wahllokalsystem/src/styles/custom.css
@@ -11,6 +11,7 @@
   min-width: 300px;
 }
 
-.v-btn.v-btn--active:hover > .v-btn__overlay {
+.v-btn.v-btn--active:hover > .v-btn__overlay,
+.v-btn.v-btn--active:focus > .v-btn__overlay {
   background-color: rgba(44, 58, 64, 0.04);
 }

--- a/wls-gui-wahllokalsystem/src/styles/custom.css
+++ b/wls-gui-wahllokalsystem/src/styles/custom.css
@@ -1,17 +1,17 @@
 .stimmabgabevermerke-table {
-  table-layout: fixed;
-  width: 100%;
+    table-layout: fixed;
+    width: 100%;
 }
 
 .stimmabgabevermerke-table thead th.sav-first-column {
-  min-width: 150px;
+    min-width: 150px;
 }
 
 .stimmabgabevermerke-table .dynamic-column {
-  min-width: 300px;
+    min-width: 300px;
 }
 
 .v-btn.v-btn--active:hover > .v-btn__overlay,
 .v-btn.v-btn--active:focus > .v-btn__overlay {
-  background-color: rgba(44, 58, 64, 0.04);
+    opacity: 0.01;
 }

--- a/wls-gui-wahllokalsystem/src/styles/custom.css
+++ b/wls-gui-wahllokalsystem/src/styles/custom.css
@@ -1,17 +1,17 @@
 .stimmabgabevermerke-table {
-    table-layout: fixed;
-    width: 100%;
+  table-layout: fixed;
+  width: 100%;
 }
 
 .stimmabgabevermerke-table thead th.sav-first-column {
-    min-width: 150px;
+  min-width: 150px;
 }
 
 .stimmabgabevermerke-table .dynamic-column {
-    min-width: 300px;
+  min-width: 300px;
 }
 
 .v-btn.v-btn--active:hover > .v-btn__overlay,
 .v-btn.v-btn--active:focus > .v-btn__overlay {
-    opacity: 0.01;
+  opacity: 0.01;
 }

--- a/wls-gui-wahllokalsystem/src/styles/custom.css
+++ b/wls-gui-wahllokalsystem/src/styles/custom.css
@@ -10,3 +10,7 @@
 .stimmabgabevermerke-table .dynamic-column {
   min-width: 300px;
 }
+
+.v-btn.v-btn--active:hover > .v-btn__overlay {
+  background-color: rgba(44, 58, 64, 0.04);
+}


### PR DESCRIPTION
# Beschreibung:

- active button wird dunkler statt heller beim hovern

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] css config angepasst

# Referenzen[^1]:

Closes #1765

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the hover appearance for active buttons with a subtle overlay tint, enhancing visual feedback during interaction.
  * Improves consistency of button states across the interface, making it clearer when a button is both selected and hovered.
  * Purely a visual update with no impact on functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->