### PR TITLE
Skip Instabiler Snapshot-Test

### DIFF
--- a/wls-gui-wahllokalsystem/tests/components/wahlhandlung/BaseWahlumgebungWahlurnenDiv.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/components/wahlhandlung/BaseWahlumgebungWahlurnenDiv.spec.ts
@@ -187,7 +187,8 @@ describe("BaseWahlumgebungWahlurnenDiv.vue", () => {
       expect(wrapper.html()).toContain(errorMessage);
     });
 
-    it("should_renderErrorMessage_when_ruleRequiredIsViolated", async (context) => {
+    //runs unstable. Sometimes "style" attribute is set with no property set
+    it.skip("should_renderErrorMessage_when_ruleRequiredIsViolated", async (context) => {
       const twoWahlenWahlVorbereitungAnzahlNull = {
         wahlbezirkID: "wahlbezirkID1",
         urneVersiegelt: false,


### PR DESCRIPTION
# Beschreibung:

Der Test läuft in den Workflows instabil. Wenn er fehlschlägt und man die Pipeline erneut startet geht der Test durch. Da wir uns aber entscheiden haben bis auf weiteres keine Komponententest zu erstellen, denke ich dass wir den Test deaktivieren können.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

# Referenzen[^1]:

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Marked an unstable validation error rendering test as skipped to stabilize CI runs and prevent intermittent failures. Added context comment describing flaky style attribute behavior to aid future investigation. No user-facing changes; functionality remains unchanged. Release contains only test adjustments, improving reliability of the build pipeline and signal for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->