### PR TITLE
vue-component-type-helpers update 3.0.7 -> 3.0.8

### DIFF
--- a/wls-gui-wahllokalsystem/package-lock.json
+++ b/wls-gui-wahllokalsystem/package-lock.json
@@ -3938,8 +3938,8 @@
       }
     },
     "node_modules/@storybook/vue3/node_modules/vue-component-type-helpers": {
-      "version": "3.0.7",
-      "integrity": "sha512-TvyUcFXmjZcXUvU+r1MOyn4/vv4iF+tPwg5Ig33l/FJ3myZkxeQpzzQMLMFWcQAjr6Xs7BRwVy/TwbmNZUA/4w==",
+      "version": "3.0.8",
+      "integrity": "sha512-WyR30Eq15Y/+odrUUMax6FmPbZwAp/HnC7qgR1r3lVFAcqwQ4wUoV79Mbh4SxDy3NiqDa+G4TOKD5xXSgBHo5A==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
# Beschreibung:

vue-component-type-helpers update 3.0.7 -> 3.0.8

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

# Referenzen[^1]:

Verwandt mit Issue #

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
