### PR TITLE
1953 - Fixing fehlende Reaktivität für den Titel zur Zählung der Stimmzettel

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/navigation/auszaehlung_wahlarten/TheOBWScoresListGroup.vue
+++ b/wls-gui-wahllokalsystem/src/components/navigation/auszaehlung_wahlarten/TheOBWScoresListGroup.vue
@@ -52,7 +52,7 @@ const obwWahlID = computed<string | undefined>(() => {
   return wahlenActions.getWahlIdOrUndefinedByWahlart(WahlWahlartEnum.Obw);
 });
 
-const items = [
+const items = computed(() => [
   {
     title: properties.titleStimmenZaehlen,
     routeName: ROUTE_AUSZAEHLUNG_STIMMZETTEL,
@@ -60,5 +60,5 @@ const items = [
   { title: "Stapel c", routeName: ROUTE_STAPEL_C },
   { title: "Stapel b", routeName: ROUTE_STAPEL_B },
   { title: "Stapel a", routeName: ROUTE_STAPEL_A },
-];
+]);
 </script>


### PR DESCRIPTION
# Beschreibung:

- Reaktivität wurde ergänzt
- ist nur bei der OBW notwendig gewesen da bei den anderen Navigation der anderen Wahlen direkt die Property verwendet wurde

# Benötigt
- #1964

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Doku aktualisiert - keine Funktionalität geändert
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [X] Unit-Tests gepflegt - nur Änderung an Komponente, daher keine Tests
- [X] Texte auf Rechtschreibung und Grammatik geprüft, keinen Text verfasst

# Referenzen[^1]:

Verwandt mit Issue #

Closes #1953

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Score lists now update automatically when underlying data changes, preventing stale or static entries in the UI.

* **Refactor**
  * Improved reactivity of list generation to ensure consistent, real-time updates without manual refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->