### PR TITLE
update vue-component-type-helpers to 3.1.0

### DIFF
--- a/wls-gui-wahllokalsystem/package-lock.json
+++ b/wls-gui-wahllokalsystem/package-lock.json
@@ -3938,8 +3938,8 @@
       }
     },
     "node_modules/@storybook/vue3/node_modules/vue-component-type-helpers": {
-      "version": "3.0.8",
-      "integrity": "sha512-WyR30Eq15Y/+odrUUMax6FmPbZwAp/HnC7qgR1r3lVFAcqwQ4wUoV79Mbh4SxDy3NiqDa+G4TOKD5xXSgBHo5A==",
+      "version": "3.1.0",
+      "integrity": "sha512-cC1pYNRZkSS1iCvdlaMbbg2sjDwxX098FucEjtz9Yig73zYjWzQsnMe5M9H8dRNv55hAIDGUI29hF2BEUA4FMQ==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
# Beschreibung:

- update einer Dependency von Storybook die dort als `latest` definiert ist

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
