### PR TITLE
1925 fix fehlende Anzeige von Summen zu Zurückweisungsgrunden bei der Wahlbriefzulassung

### DIFF
--- a/wls-gui-wahllokalsystem/src/composables/briefwahl/beanstandeteWahlbriefeGetter.ts
+++ b/wls-gui-wahllokalsystem/src/composables/briefwahl/beanstandeteWahlbriefeGetter.ts
@@ -3,11 +3,15 @@ import type { Ref } from "vue";
 
 import { computed } from "vue";
 
+import { useZurueckweisungsgrundEnumUtils } from "@/composables/briefwahl/zurueckweisungsgrundEnumUtils.ts";
 import { ZurueckweisungsgrundEnum } from "@/types/briefwahl/ZurueckweisungsgrundEnum.ts";
 
 export function useBeanstandeteWahlbriefeGetter(
   wahlenState: Ref<{ wahlen: Wahl[] | null }>
 ) {
+  const { isRejectingZurueckweisungsgrund } =
+    useZurueckweisungsgrundEnumUtils();
+
   const summeGueltigerWahlbriefe = computed(() => {
     if (!wahlenState.value.wahlen) return [];
     return wahlenState.value.wahlen.map(
@@ -40,19 +44,14 @@ export function useBeanstandeteWahlbriefeGetter(
       }));
 
     wahlenState.value.wahlen.forEach((wahl, wahlIndex) => {
-      if (
-        wahl.beanstandeteWahlbriefe &&
-        wahl.beanstandeteWahlbriefe.every((grund) => grund !== null)
-      ) {
-        wahl.beanstandeteWahlbriefe.forEach((beanstandeterWahlbrief) => {
-          if (beanstandeterWahlbrief !== ZurueckweisungsgrundEnum.Zugelassen) {
-            const index = summenZurueckweisungsgruende.findIndex(
-              (item) => item.grund === beanstandeterWahlbrief
-            );
-            summenZurueckweisungsgruende[index].summen[wahlIndex] += 1;
-          }
-        });
-      }
+      wahl.beanstandeteWahlbriefe.forEach((beanstandeterWahlbrief) => {
+        if (isRejectingZurueckweisungsgrund(beanstandeterWahlbrief)) {
+          const index = summenZurueckweisungsgruende.findIndex(
+            (item) => item.grund === beanstandeterWahlbrief
+          );
+          summenZurueckweisungsgruende[index].summen[wahlIndex] += 1;
+        }
+      });
     });
     return summenZurueckweisungsgruende;
   });

--- a/wls-gui-wahllokalsystem/src/composables/briefwahl/zurueckweisungsgrundEnumUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/briefwahl/zurueckweisungsgrundEnumUtils.ts
@@ -1,0 +1,16 @@
+import { ZurueckweisungsgrundEnum } from "@/types/briefwahl/ZurueckweisungsgrundEnum.ts";
+
+export function useZurueckweisungsgrundEnumUtils() {
+  function isRejectingZurueckweisungsgrund(
+    zurueckweisungsgruend: ZurueckweisungsgrundEnum | null
+  ) {
+    return (
+      zurueckweisungsgruend !== null &&
+      zurueckweisungsgruend !== ZurueckweisungsgrundEnum.Zugelassen
+    );
+  }
+
+  return {
+    isRejectingZurueckweisungsgrund,
+  };
+}

--- a/wls-gui-wahllokalsystem/src/composables/briefwahl/zurueckweisungsgrundEnumUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/briefwahl/zurueckweisungsgrundEnumUtils.ts
@@ -2,11 +2,11 @@ import { ZurueckweisungsgrundEnum } from "@/types/briefwahl/Zurueckweisungsgrund
 
 export function useZurueckweisungsgrundEnumUtils() {
   function isRejectingZurueckweisungsgrund(
-    zurueckweisungsgruend: ZurueckweisungsgrundEnum | null
+    zurueckweisungsgrund: ZurueckweisungsgrundEnum | null
   ) {
     return (
-      zurueckweisungsgruend !== null &&
-      zurueckweisungsgruend !== ZurueckweisungsgrundEnum.Zugelassen
+      zurueckweisungsgrund !== null &&
+      zurueckweisungsgrund !== ZurueckweisungsgrundEnum.Zugelassen
     );
   }
 

--- a/wls-gui-wahllokalsystem/tests/composables/briefwahl/zurueckweisungsgrundEnumUtils.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/briefwahl/zurueckweisungsgrundEnumUtils.spec.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useZurueckweisungsgrundEnumUtils } from "@/composables/briefwahl/zurueckweisungsgrundEnumUtils.ts";
+import { ZurueckweisungsgrundEnum } from "@/types/briefwahl/ZurueckweisungsgrundEnum.ts";
+
+describe("zurueckweisungsgrundEnumUtils.ts", () => {
+  let unitUnderTest: ReturnType<typeof useZurueckweisungsgrundEnumUtils>;
+
+  beforeEach(() => {
+    unitUnderTest = useZurueckweisungsgrundEnumUtils();
+  });
+  describe("isRejectingZurueckweisungsgrund", () => {
+    it("should_returnFalse_when_zurueckweisungsGrundIsNull", () => {
+      expect(unitUnderTest.isRejectingZurueckweisungsgrund(null)).toStrictEqual(
+        false
+      );
+    });
+
+    it("should_returnTrue_when_zurueckweisungsGrundIsNotZugelassen", () => {
+      const nonZugelassenGruende = Object.values(
+        ZurueckweisungsgrundEnum
+      ).filter((grund) => grund !== ZurueckweisungsgrundEnum.Zugelassen);
+
+      nonZugelassenGruende.forEach((grund) => {
+        expect(
+          unitUnderTest.isRejectingZurueckweisungsgrund(grund)
+        ).toStrictEqual(true);
+      });
+    });
+
+    it("should_returnFalse_when_zurueckweisungsGrundIsZugelassen", () => {
+      expect(
+        unitUnderTest.isRejectingZurueckweisungsgrund(
+          ZurueckweisungsgrundEnum.Zugelassen
+        )
+      ).toStrictEqual(false);
+    });
+  });
+});

--- a/wls-gui-wahllokalsystem/tests/stores/wahlenStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/wahlenStore.spec.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useUserStore } from "@/stores/userStore.ts";
 import { useWahlenStore } from "@/stores/wahlenStore.ts";
+import { ZurueckweisungsgrundEnum } from "@/types/briefwahl/ZurueckweisungsgrundEnum.ts";
 import { WahlWahlartEnum } from "@/types/wahl/WahlWahlartEnum.ts";
 
 const mockDefinitions = vi.hoisted(() => ({
@@ -540,6 +541,28 @@ describe("wahlenStore.ts", () => {
           expect(row.summen).toStrictEqual([0, 1]);
         }
       });
+    });
+
+    it("should_ignoreBeanstandeWahlbriefeWithoutZurueckweisungsgrund_when_calculatingSum", () => {
+      unitUnderTest.wahlenState.wahlen = [
+        prepareWahl()
+          .beanstandeteWahlbriefe([
+            ZurueckweisungsgrundEnum.LoseStimmzettel,
+            ZurueckweisungsgrundEnum.LoseStimmzettel,
+            null,
+            null,
+            ZurueckweisungsgrundEnum.ScheinUngueltig,
+            ZurueckweisungsgrundEnum.LoseStimmzettel,
+          ])
+          .build(),
+      ];
+
+      const summen =
+        unitUnderTest.beanstandeteWahlbriefeGetter.summenZurueckweisungsgruende;
+      const summeLoseStimmzettel = summen.find(
+        (summe) => summe.grund === ZurueckweisungsgrundEnum.LoseStimmzettel
+      );
+      expect(summeLoseStimmzettel?.summen).toStrictEqual([3]);
     });
   });
 


### PR DESCRIPTION
# Beschreibung:

- Filter entfernt der erforderte das für die Berechnung der Summen bei einer Wahl alle Zurückweissungsgründe gepflegt sind (null-Check)

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->
<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [X] ~~Doku aktualisiert~~ - kein Update erforderlich, da die Doku nicht soweit in das Detail geht
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] Unit-Tests gepflegt
- [x] ~~Texte auf Rechtschreibung und Grammatik geprüft~~ - keine Text verfasst

# Referenzen[^1]:

Verwandt mit Issue #

Closes #1925

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed counting of rejected postal ballots to ignore entries without a rejection reason and those marked as approved, resulting in accurate per-reason totals in brief voting statistics.
- Refactor
  - Consolidated rejection-reason evaluation into a reusable utility for clearer, consistent logic across the app.
- Tests
  - Added unit tests for the new utility.
  - Added store tests verifying summation skips null/approved entries and correctly aggregates counts by rejection reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->