### PR TITLE
Add wahl-worker test

### DIFF
--- a/wls-gui-wahllokalsystem/tests/service-worker/wahl-worker.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/service-worker/wahl-worker.spec.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import "@/service-worker/wahl-worker.ts";
+
+const mockDefinitions = vi.hoisted(() => ({
+  registerRoute: vi.fn(),
+}));
+
+vi.mock("workbox-routing", () => ({
+  registerRoute: mockDefinitions.registerRoute,
+}));
+
+vi.mock("localforage");
+
+describe("wahl-worker.ts", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should_registerRequestHandler_when_serviceWorkerIsInitialised", () => {
+    expect(mockDefinitions.registerRoute).toHaveBeenCalledTimes(2);
+
+    const regex = new RegExp("/api/.+");
+
+    const getCall = mockDefinitions.registerRoute.mock.calls.find(
+      (call) => call[2] === "GET"
+    );
+    expect(getCall).toBeDefined();
+    if (getCall != undefined) {
+      expect(getCall[0]).toEqual(regex);
+      expect(getCall[1].toString()).contains("getRequestHandler");
+    }
+
+    const postCall = mockDefinitions.registerRoute.mock.calls.find(
+      (call) => call[2] === "POST"
+    );
+    expect(postCall).toBeDefined();
+    if (postCall != undefined) {
+      expect(postCall[0]).toEqual(regex);
+      expect(postCall[1].toString()).contains("postRequestHandler");
+    }
+  });
+
+  it("should_coverBasePath_when_regexIsUsed", () => {
+    const basePathRegex = new RegExp("/api/.+");
+
+    const testUrls = new Map<string, boolean>();
+    testUrls.set("/api/test", true);
+    testUrls.set("/api/test/123", true);
+    testUrls.set("/api/", false);
+    testUrls.set("/other/test", false);
+
+    testUrls.forEach((expected, url) => {
+      const matches = basePathRegex.test(url);
+      expect(matches).toBe(expected);
+    });
+  });
+});

--- a/wls-gui-wahllokalsystem/tests/service-worker/wahl-worker.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/service-worker/wahl-worker.spec.ts
@@ -13,6 +13,8 @@ vi.mock("workbox-routing", () => ({
 vi.mock("localforage");
 
 describe("wahl-worker.ts", () => {
+  const API_BASE_PATH_REGEX = new RegExp("/api/.+");
+
   afterEach(() => {
     vi.clearAllMocks();
   });
@@ -20,15 +22,13 @@ describe("wahl-worker.ts", () => {
   it("should_registerRequestHandler_when_serviceWorkerIsInitialised", () => {
     expect(mockDefinitions.registerRoute).toHaveBeenCalledTimes(2);
 
-    const regex = new RegExp("/api/.+");
-
     const getCall = mockDefinitions.registerRoute.mock.calls.find(
       (call) => call[2] === "GET"
     );
     expect(getCall).toBeDefined();
     if (getCall != undefined) {
-      expect(getCall[0]).toEqual(regex);
-      expect(getCall[1].toString()).contains("getRequestHandler");
+      expect(getCall[0]).toEqual(API_BASE_PATH_REGEX);
+      expect(getCall[1].name).equals("getRequestHandler");
     }
 
     const postCall = mockDefinitions.registerRoute.mock.calls.find(
@@ -36,14 +36,12 @@ describe("wahl-worker.ts", () => {
     );
     expect(postCall).toBeDefined();
     if (postCall != undefined) {
-      expect(postCall[0]).toEqual(regex);
-      expect(postCall[1].toString()).contains("postRequestHandler");
+      expect(postCall[0]).toEqual(API_BASE_PATH_REGEX);
+      expect(postCall[1].name).equals("postRequestHandler");
     }
   });
 
   it("should_coverBasePath_when_regexIsUsed", () => {
-    const basePathRegex = new RegExp("/api/.+");
-
     const testUrls = new Map<string, boolean>();
     testUrls.set("/api/test", true);
     testUrls.set("/api/test/123", true);
@@ -51,7 +49,7 @@ describe("wahl-worker.ts", () => {
     testUrls.set("/other/test", false);
 
     testUrls.forEach((expected, url) => {
-      const matches = basePathRegex.test(url);
+      const matches = API_BASE_PATH_REGEX.test(url);
       expect(matches).toBe(expected);
     });
   });


### PR DESCRIPTION
# Beschreibung:

Test für Wahl-Worker

## Definition of Done (DoD):

### Frontend
- [x] Unit-Tests gepflegt

# Referenzen[^1]:

Closes #1730

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the service worker’s API routing, validating initialization, GET/POST handling, and base-path matching across common URLs.
  * Ensures routes are correctly registered and associated handlers are invoked as expected.
  * Improves reliability and confidence in offline and network request behavior.
  * Includes cleanup routines to keep tests isolated and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->