### PR TITLE
1934 default label base number input

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/common/inputs/BaseNumberInput.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/inputs/BaseNumberInput.vue
@@ -17,7 +17,7 @@ const props = defineProps({
   label: {
     type: String,
     required: false,
-    default: "Zahl eingeben",
+    default: "Anzahl",
   },
   rules: {
     type: Array<(value: number) => string | boolean>,

--- a/wls-gui-wahllokalsystem/src/components/ergebnisermittlung/OBW/stapelB/TheOBWStapelBCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/ergebnisermittlung/OBW/stapelB/TheOBWStapelBCard.vue
@@ -9,7 +9,6 @@
               :model-value="ergebnisseStapelBLeer"
               :rules="[required, minNumber(0), maxNumber(9999)]"
               min-width="20rem"
-              label="Anzahl"
               @update:model-value="
                 onModelValueStapelBChanged(StapelArtEnum.ObwBLeer, $event)
               "
@@ -22,7 +21,6 @@
             :model-value="ergebnisseStapelBUngekennzeichnet"
             :rules="[required, minNumber(0), maxNumber(9999)]"
             min-width="20rem"
-            label="Anzahl"
             @update:model-value="
               onModelValueStapelBChanged(
                 StapelArtEnum.ObwBUngekennzeichnet,

--- a/wls-gui-wahllokalsystem/src/components/ergebnisermittlung/OBW/stapelC/TheOBWStapelCErfassungCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/ergebnisermittlung/OBW/stapelC/TheOBWStapelCErfassungCard.vue
@@ -10,7 +10,6 @@
             <base-number-input
               v-model="countRows"
               :rules="[minNumber(0), maxNumber(9999), required]"
-              label="Anzahl"
               max-width="15rem"
             />
             <v-btn

--- a/wls-gui-wahllokalsystem/src/components/stimmabgabevermerke/TheUWBStimmabgabevermerkeEingenommeneWahlscheineTable.vue
+++ b/wls-gui-wahllokalsystem/src/components/stimmabgabevermerke/TheUWBStimmabgabevermerkeEingenommeneWahlscheineTable.vue
@@ -28,7 +28,6 @@
           >
             <base-number-input
               max-width="15rem"
-              label="Anzahl"
               :rules="[required, minNumber(0)]"
               :model-value="
                 getMapValue(

--- a/wls-gui-wahllokalsystem/src/components/stimmabgabevermerke/TheUWBStimmabgabevermerkeErfassenTable.vue
+++ b/wls-gui-wahllokalsystem/src/components/stimmabgabevermerke/TheUWBStimmabgabevermerkeErfassenTable.vue
@@ -85,7 +85,6 @@
                 v-model="stimmzettel.anzahl"
                 max-width="15rem"
                 :rules="[required, minNumber(0), maxNumber(50)]"
-                label="Anzahl"
               />
             </template>
           </td>

--- a/wls-gui-wahllokalsystem/stories/components/common/inputs/BaseNumberInput.stories.ts
+++ b/wls-gui-wahllokalsystem/stories/components/common/inputs/BaseNumberInput.stories.ts
@@ -51,7 +51,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    label: "Zahl eingeben",
     "onUpdate:modelValue": fn(),
   },
 };


### PR DESCRIPTION
# Beschreibung:

`Anzahl` als Default-Label für den BaseNumberInput

## Definition of Done (DoD):

### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [ ] ~~Doku aktualisiert~~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] Unit-Tests gepflegt
- [x] Texte auf Rechtschreibung und Grammatik geprüft

# Referenzen[^1]:

Closes #1934

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the default label text for the numeric input to “Anzahl.”
  - Removed explicit “Anzahl” labels from number inputs in OBW Stapel B (ObwBLeer, ObwBUngekennzeichnet), OBW Stapel C Erfassung, and UWB Stimmabgabevermerke tables to streamline the UI.
  - Visual-only adjustments; no changes to validation, data handling, or interaction behavior.
  - Ensures consistent labeling where needed while reducing redundant labels in specific views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->