### PR TITLE
Ordnungszahl in Anzeige vorangestellt

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/ergebnisermittlung/OBW/stapelC/BaseRowStapelC.vue
+++ b/wls-gui-wahllokalsystem/src/components/ergebnisermittlung/OBW/stapelC/BaseRowStapelC.vue
@@ -37,7 +37,7 @@ import { StapelArtEnum } from "@/types/ergebnismeldung/StapelArtEnum.ts";
 const STAPELART_FOR_INVALID = StapelArtEnum.ObwCUngueltig;
 const REF_AUTOCOMPLETE_WAHLVORSCHLAG = "wahlvorschlagSelection";
 
-const { getFirstKandidatNameOrEmptyString } = useWahlvorschlagUtils();
+const { getWahlvorschlagTitle } = useWahlvorschlagUtils();
 
 const modelValue = defineModel({
   type: Object as PropType<Ergebnis>,
@@ -78,10 +78,6 @@ const isSelected = computed(() => props.stapelArt === STAPELART_FOR_INVALID);
 const isWahlvorschlagSelectionDisabled = computed(
   () => props.stapelArt === STAPELART_FOR_INVALID
 );
-
-function getWahlvorschlagTitle(wahlvorschlag: Wahlvorschlag) {
-  return `${wahlvorschlag.ordnungszahl} - ${wahlvorschlag.kurzname}, ${getFirstKandidatNameOrEmptyString(wahlvorschlag)}`;
-}
 
 function onUngueltigCheckboxChanged(newValue: boolean) {
   emit("selectionChanged", newValue);

--- a/wls-gui-wahllokalsystem/src/components/ergebnisermittlung/OBW/stapelC/TheOBWStapelCSummaryCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/ergebnisermittlung/OBW/stapelC/TheOBWStapelCSummaryCard.vue
@@ -19,9 +19,7 @@
             :key="wahlvorschlagAndSum.wahlvorschlag.identifikator"
           >
             <td>
-              {{
-                `${wahlvorschlagAndSum.wahlvorschlag.ordnungszahl} - ${wahlvorschlagAndSum.wahlvorschlag.kurzname}, ${getFirstKandidatNameOrEmptyString(wahlvorschlagAndSum.wahlvorschlag)}`
-              }}
+              {{ getWahlvorschlagTitle(wahlvorschlagAndSum.wahlvorschlag) }}
             </td>
             <td>{{ wahlvorschlagAndSum.sum }}</td>
           </tr>
@@ -45,7 +43,7 @@ import { computed } from "vue";
 import { useOBWStapelCUtils } from "@/composables/ergebnisermittlung/obwStapelCUtils.ts";
 import { useWahlvorschlagUtils } from "@/composables/wahlvorschlaege/wahlvorschlagUtils.ts";
 
-const { getFirstKandidatNameOrEmptyString } = useWahlvorschlagUtils();
+const { getWahlvorschlagTitle } = useWahlvorschlagUtils();
 
 const props = defineProps({
   wahlId: {

--- a/wls-gui-wahllokalsystem/src/components/ergebnisermittlung/OBW/stapelC/TheOBWStapelCSummaryCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/ergebnisermittlung/OBW/stapelC/TheOBWStapelCSummaryCard.vue
@@ -20,7 +20,7 @@
           >
             <td>
               {{
-                `${wahlvorschlagAndSum.wahlvorschlag.kurzname}, ${getFirstKandidatNameOrEmptyString(wahlvorschlagAndSum.wahlvorschlag)}`
+                `${wahlvorschlagAndSum.wahlvorschlag.ordnungszahl} - ${wahlvorschlagAndSum.wahlvorschlag.kurzname}, ${getFirstKandidatNameOrEmptyString(wahlvorschlagAndSum.wahlvorschlag)}`
               }}
             </td>
             <td>{{ wahlvorschlagAndSum.sum }}</td>

--- a/wls-gui-wahllokalsystem/src/composables/wahlvorschlaege/wahlvorschlagUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/wahlvorschlaege/wahlvorschlagUtils.ts
@@ -1,6 +1,10 @@
 import type { Wahlvorschlag } from "@/types/wahlvorschlaege/Wahlvorschlag.ts";
 
 export function useWahlvorschlagUtils() {
+  function getWahlvorschlagTitle(wahlvorschlag: Wahlvorschlag) {
+    return `${wahlvorschlag.ordnungszahl} - ${wahlvorschlag.kurzname}, ${getFirstKandidatNameOrEmptyString(wahlvorschlag)}`;
+  }
+
   function getFirstKandidatNameOrEmptyString(wahlvorschlag: Wahlvorschlag) {
     if (wahlvorschlag.kandidaten && wahlvorschlag.kandidaten.size > 0) {
       const kandidatWithLowedListenPosition = [
@@ -14,6 +18,7 @@ export function useWahlvorschlagUtils() {
     }
   }
   return {
+    getWahlvorschlagTitle,
     getFirstKandidatNameOrEmptyString,
   };
 }


### PR DESCRIPTION
# Beschreibung:

*Beschreben Sie hier die wesentlichen Aufgaben, die damit erledigt wurden und geben sie Hinweise zum Review.*

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [ ] ~Doku aktualisiert~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [ ] ~Unit-Tests gepflegt~
- [x] Texte auf Rechtschreibung und Grammatik geprüft

# Referenzen[^1]:

Verwandt mit Issue #

Closes #1958

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the Wahlvorschlag label in the OBW Stapel C summary card to display “ordnungszahl – kurzname” instead of just the kurzname.
  - Improves readability and disambiguation when multiple proposals have similar short names.
  - No changes to candidate name display or sum/total values; all other visuals remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->