### PR TITLE
Refactor ergebnismeldung testdata factories

### DIFF
--- a/wls-gui-wahllokalsystem/package-lock.json
+++ b/wls-gui-wahllokalsystem/package-lock.json
@@ -121,7 +121,6 @@
       "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1675,7 +1674,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1698,7 +1696,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3941,8 +3938,8 @@
       }
     },
     "node_modules/@storybook/vue3/node_modules/vue-component-type-helpers": {
-      "version": "3.1.0",
-      "integrity": "sha512-cC1pYNRZkSS1iCvdlaMbbg2sjDwxX098FucEjtz9Yig73zYjWzQsnMe5M9H8dRNv55hAIDGUI29hF2BEUA4FMQ==",
+      "version": "3.1.1",
+      "integrity": "sha512-B0kHv7qX6E7+kdc5nsaqjdGZ1KwNKSUQDWGy7XkTYT7wFsOpkEyaJ1Vq79TjwrrtuLRgizrTV7PPuC4rRQo+vw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3972,7 +3969,6 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4095,7 +4091,6 @@
       "integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4182,7 +4177,6 @@
       "integrity": "sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.36.0",
         "@typescript-eslint/types": "8.36.0",
@@ -4653,7 +4647,6 @@
       "version": "3.5.21",
       "integrity": "sha512-SXlyk6I5eUGBd2v8Ie7tF6ADHE9kCR6mBEuPyH1nUZ0h6Xx6nZI29i12sJKQmzbDyr2tUHMhhTt51Z6blbkTTQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.3",
         "@vue/compiler-core": "3.5.21",
@@ -4945,7 +4938,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5325,7 +5317,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -6207,7 +6198,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6280,7 +6270,6 @@
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6341,7 +6330,6 @@
       "integrity": "sha512-4EQQr6wXwS+ZJSzaR5ZCrYgLxqvUjdXctaEtBqHcbkW944B1NQyO4qpdHQbXBONfwxXdkAY81HH4+LUfrg+zPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6401,7 +6389,6 @@
       "integrity": "sha512-174lJKuNsuDIlLpjeXc5E2Tss8P44uIimAfGD0b90k0NoirJqpG7stLuU9Vp/9ioTOrQdWVREc4mRd1BD+CvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "globals": "^13.24.0",
@@ -8322,7 +8309,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bundled-es-modules/cookie": "^2.0.1",
         "@bundled-es-modules/statuses": "^1.0.1",
@@ -8877,7 +8863,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9144,7 +9129,6 @@
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9169,7 +9153,6 @@
       "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.25.0"
       },
@@ -9408,7 +9391,6 @@
       "integrity": "sha512-kg6oI4g+vc41vePJyO6dHt/yl0Rz3Thv0kJeVQ3D1kS3E5XSuKbPc29G4IpT/Kv1KQwgHVcN+HtyS+HYLNSvQg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -9554,7 +9536,6 @@
       "integrity": "sha512-ffmsdbwqb3XeyR8jJR6KelIXARM9bFQe8A6Q3W4Klmwy5Ckd5gz7jgUNHo4UOqutU5Sk1DtKLbpDP0nLCg1xqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -9849,7 +9830,6 @@
       "integrity": "sha512-sVKbCj/OTx67jhmauhxc2dcr1P+yOgz/x3h0krwjyMgdc5Oubvxyg4NYDZmzAw+ym36g/lzH8N0Ccp4dwtdfxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/core": "8.6.14"
       },
@@ -10294,7 +10274,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10531,7 +10510,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10787,7 +10765,6 @@
       "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -10914,7 +10891,6 @@
       "integrity": "sha512-I/wd6QS+DO6lHmuGoi1UTyvvBTQ2KDzQZ9oowJQEJ6OcjWfJnscYXx2ptm6S7fJSASuZT8jGRBL3LV4oS3LpaA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vuetify/loader-shared": "^2.1.1",
         "debug": "^4.3.3",
@@ -10951,7 +10927,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11097,7 +11072,6 @@
       "version": "3.5.21",
       "integrity": "sha512-xxf9rum9KtOdwdRkiApWL+9hZEMWE90FHh8yS1+KJAiWYh+iGWV1FquPjoO9VUHQ+VIhsCXNNyZ5Sf4++RVZBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.21",
         "@vue/compiler-sfc": "3.5.21",
@@ -11313,7 +11287,6 @@
       "version": "3.9.7",
       "integrity": "sha512-Ib8PB3ItcguCol8f0DXLpoGyy7FvoOYW23SEWqXX+in1CSItJZHxUXXGSus94m5JWqYqQrFiwCykbHm7UWPi4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.20 || >=14.13"
       },
@@ -11696,7 +11669,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11789,7 +11761,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/wls-gui-wahllokalsystem/tests/stores/ergebnismeldungStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/ergebnismeldungStore.spec.ts
@@ -1,6 +1,7 @@
 import type { BezirkUndWahlIDStapelArt } from "@/types/ergebnismeldung/BezirkUndWahlIDStapelArt.ts";
 
 import { useCommonTestDataFactory } from "@tests/utils/common/CommonTestDataFactory.ts";
+import { useCommonErgebnismeldungTestDataFactory } from "@tests/utils/ergebnismeldung/commonErgebnismeldungTestDataFactory.ts";
 import { useErgebnisseTestDataFactory } from "@tests/utils/ergebnismeldung/ergebnisseTestDataFactory.ts";
 import { useUserTestDataFactory } from "@tests/utils/user/UserTestDataFactory.ts";
 import { createPinia, setActivePinia } from "pinia";
@@ -24,14 +25,11 @@ vi.mock("@/composables/ergebnismeldung/ergebnisService.ts", () => ({
 
 const { generateRandomString, generateRandomNumber, getRandomItem } =
   useCommonTestDataFactory();
-const {
-  createErgebnis,
-  prepareErgebnis,
-  createErgebnisse,
-  prepareErgebnisse,
-  prepareBezirkUndWahlIDStapelart,
-} = useErgebnisseTestDataFactory();
+const { createErgebnis, prepareErgebnis, createErgebnisse, prepareErgebnisse } =
+  useErgebnisseTestDataFactory();
 const { prepareUser } = useUserTestDataFactory();
+const { prepareBezirkUndWahlIDStapelart } =
+  useCommonErgebnismeldungTestDataFactory();
 
 describe("ergebnismeldungStore.ts", () => {
   let unitUnderTest: ReturnType<typeof useErgebnismeldungStore>;

--- a/wls-gui-wahllokalsystem/tests/utils/ergebnismeldung/commonErgebnismeldungTestDataFactory.ts
+++ b/wls-gui-wahllokalsystem/tests/utils/ergebnismeldung/commonErgebnismeldungTestDataFactory.ts
@@ -1,0 +1,52 @@
+import type { BezirkUndWahlIDStapelartDTO } from "@/api/wls-clients/generated-ergebnismeldung-api";
+import type { BezirkUndWahlIDStapelArt } from "@/types/ergebnismeldung/BezirkUndWahlIDStapelArt.ts";
+import type { Builder } from "@tests/utils/Builder.ts";
+
+import { proxyBuilder } from "@tests/utils/Builder.ts";
+import { useCommonTestDataFactory } from "@tests/utils/common/CommonTestDataFactory.ts";
+
+import { BezirkUndWahlIDStapelartDTOStapelartEnum } from "@/api/wls-clients/generated-ergebnismeldung-api";
+import { StapelArtEnum } from "@/types/ergebnismeldung/StapelArtEnum.ts";
+
+const { generateRandomString, getRandomItem } = useCommonTestDataFactory();
+
+export function useCommonErgebnismeldungTestDataFactory() {
+  function createBezirkUndWahlIDStapelartDTO(
+    stapelArt?: BezirkUndWahlIDStapelartDTOStapelartEnum
+  ): BezirkUndWahlIDStapelartDTO {
+    return {
+      wahlID: generateRandomString(10),
+      wahlbezirkID: generateRandomString(5),
+      stapelart: stapelArt ?? getRandomItem(Object.values(StapelArtEnum)),
+    };
+  }
+
+  function createBezirkUndWahlIDStapelart(
+    stapelArt?: StapelArtEnum
+  ): BezirkUndWahlIDStapelArt {
+    return {
+      wahlID: generateRandomString(10),
+      wahlbezirkID: generateRandomString(5),
+      stapelArt: stapelArt ?? getRandomItem(Object.values(StapelArtEnum)),
+    };
+  }
+
+  function prepareBezirkUndWahlIDStapelart(): Builder<BezirkUndWahlIDStapelArt> {
+    return proxyBuilder<BezirkUndWahlIDStapelArt>(
+      createBezirkUndWahlIDStapelart()
+    );
+  }
+
+  function prepareBezirkUndWahlIDStapelartDTO(): Builder<BezirkUndWahlIDStapelartDTO> {
+    return proxyBuilder<BezirkUndWahlIDStapelartDTO>(
+      createBezirkUndWahlIDStapelartDTO()
+    );
+  }
+
+  return {
+    createBezirkUndWahlIDStapelartDTO,
+    createBezirkUndWahlIDStapelart,
+    prepareBezirkUndWahlIDStapelart,
+    prepareBezirkUndWahlIDStapelartDTO,
+  };
+}

--- a/wls-gui-wahllokalsystem/tests/utils/ergebnismeldung/commonErgebnismeldungTestDataFactory.ts
+++ b/wls-gui-wahllokalsystem/tests/utils/ergebnismeldung/commonErgebnismeldungTestDataFactory.ts
@@ -35,7 +35,9 @@ export function useCommonErgebnismeldungTestDataFactory() {
     return {
       wahlID: generateRandomString(10),
       wahlbezirkID: generateRandomString(5),
-      stapelart: stapelArt ?? getRandomItem(Object.values(StapelArtEnum)),
+      stapelart:
+        stapelArt ??
+        getRandomItem(Object.values(BezirkUndWahlIDStapelartDTOStapelartEnum)),
     };
   }
 

--- a/wls-gui-wahllokalsystem/tests/utils/ergebnismeldung/commonErgebnismeldungTestDataFactory.ts
+++ b/wls-gui-wahllokalsystem/tests/utils/ergebnismeldung/commonErgebnismeldungTestDataFactory.ts
@@ -1,4 +1,8 @@
-import type { BezirkUndWahlIDStapelartDTO } from "@/api/wls-clients/generated-ergebnismeldung-api";
+import type {
+  BezirkUndWahlIDStapelartDTO,
+  BezirkUndWahlID as BezirkUndWahlIDTO,
+} from "@/api/wls-clients/generated-ergebnismeldung-api";
+import type { BezirkUndWahlID } from "@/types/ergebnismeldung/BezirkUndWahlID.ts";
 import type { BezirkUndWahlIDStapelArt } from "@/types/ergebnismeldung/BezirkUndWahlIDStapelArt.ts";
 import type { Builder } from "@tests/utils/Builder.ts";
 
@@ -11,6 +15,20 @@ import { StapelArtEnum } from "@/types/ergebnismeldung/StapelArtEnum.ts";
 const { generateRandomString, getRandomItem } = useCommonTestDataFactory();
 
 export function useCommonErgebnismeldungTestDataFactory() {
+  function createBezirkUndWahlID(): BezirkUndWahlID {
+    return {
+      wahlID: generateRandomString(10),
+      wahlbezirkID: generateRandomString(5),
+    };
+  }
+
+  function createBezirkUndWahlIDDTO(): BezirkUndWahlIDTO {
+    return {
+      wahlID: generateRandomString(10),
+      wahlbezirkID: generateRandomString(5),
+    };
+  }
+
   function createBezirkUndWahlIDStapelartDTO(
     stapelArt?: BezirkUndWahlIDStapelartDTOStapelartEnum
   ): BezirkUndWahlIDStapelartDTO {
@@ -31,6 +49,14 @@ export function useCommonErgebnismeldungTestDataFactory() {
     };
   }
 
+  function prepareBezirkUndWahlID(): Builder<BezirkUndWahlID> {
+    return proxyBuilder<BezirkUndWahlID>(createBezirkUndWahlID());
+  }
+
+  function prepareBezirkUndWahlIDDTO(): Builder<BezirkUndWahlIDTO> {
+    return proxyBuilder<BezirkUndWahlIDTO>(createBezirkUndWahlIDDTO());
+  }
+
   function prepareBezirkUndWahlIDStapelart(): Builder<BezirkUndWahlIDStapelArt> {
     return proxyBuilder<BezirkUndWahlIDStapelArt>(
       createBezirkUndWahlIDStapelart()
@@ -44,8 +70,12 @@ export function useCommonErgebnismeldungTestDataFactory() {
   }
 
   return {
+    createBezirkUndWahlID,
+    createBezirkUndWahlIDDTO,
     createBezirkUndWahlIDStapelartDTO,
     createBezirkUndWahlIDStapelart,
+    prepareBezirkUndWahlID,
+    prepareBezirkUndWahlIDDTO,
     prepareBezirkUndWahlIDStapelart,
     prepareBezirkUndWahlIDStapelartDTO,
   };

--- a/wls-gui-wahllokalsystem/tests/utils/ergebnismeldung/ergebnisseTestDataFactory.ts
+++ b/wls-gui-wahllokalsystem/tests/utils/ergebnismeldung/ergebnisseTestDataFactory.ts
@@ -1,36 +1,26 @@
 import type {
-  BezirkUndWahlIDStapelartDTO,
   ErgebnisDTO,
   ErgebnisseDTO,
 } from "@/api/wls-clients/generated-ergebnismeldung-api";
-import type { BezirkUndWahlIDStapelArt } from "@/types/ergebnismeldung/BezirkUndWahlIDStapelArt.ts";
 import type { Ergebnis } from "@/types/ergebnismeldung/Ergebnis.ts";
 import type { Ergebnisse } from "@/types/ergebnismeldung/Ergebnisse.ts";
 import type { Builder } from "@tests/utils/Builder.ts";
 
 import { proxyBuilder } from "@tests/utils/Builder.ts";
 import { useCommonTestDataFactory } from "@tests/utils/common/CommonTestDataFactory.ts";
+import { useCommonErgebnismeldungTestDataFactory } from "@tests/utils/ergebnismeldung/commonErgebnismeldungTestDataFactory.ts";
 
 import { BezirkUndWahlIDStapelartDTOStapelartEnum } from "@/api/wls-clients/generated-ergebnismeldung-api";
 import { StapelArtEnum } from "@/types/ergebnismeldung/StapelArtEnum.ts";
 
-const { generateRandomString, generateRandomNumber, getRandomItem } =
-  useCommonTestDataFactory();
+const { generateRandomNumber } = useCommonTestDataFactory();
+const { createBezirkUndWahlIDStapelartDTO, createBezirkUndWahlIDStapelart } =
+  useCommonErgebnismeldungTestDataFactory();
 
 export function useErgebnisseTestDataFactory() {
-  function createBezirkUndWahlIDStapelart(
-    stapelArt?: StapelArtEnum
-  ): BezirkUndWahlIDStapelArt {
-    return {
-      wahlID: generateRandomString(10),
-      wahlbezirkID: generateRandomString(5),
-      stapelArt: stapelArt ?? getRandomItem(Object.values(StapelArtEnum)),
-    };
-  }
-
   function createErgebnisseDTO(): ErgebnisseDTO {
     return {
-      bezirkUndWahlIDStapelart: _createBezirkUndWahlIDStapelartDTO(
+      bezirkUndWahlIDStapelart: createBezirkUndWahlIDStapelartDTO(
         BezirkUndWahlIDStapelartDTOStapelartEnum.ObwA
       ),
       ergebnisse: [createErgebnisDTO(), createErgebnisDTO()],
@@ -65,12 +55,6 @@ export function useErgebnisseTestDataFactory() {
     };
   }
 
-  function prepareBezirkUndWahlIDStapelart(): Builder<BezirkUndWahlIDStapelArt> {
-    return proxyBuilder<BezirkUndWahlIDStapelArt>(
-      createBezirkUndWahlIDStapelart()
-    );
-  }
-
   function prepareErgebnisseDTO(): Builder<ErgebnisseDTO> {
     return proxyBuilder<ErgebnisseDTO>(createErgebnisseDTO());
   }
@@ -87,19 +71,7 @@ export function useErgebnisseTestDataFactory() {
     return proxyBuilder<Ergebnis>(createErgebnis());
   }
 
-  function _createBezirkUndWahlIDStapelartDTO(
-    stapelArt: BezirkUndWahlIDStapelartDTOStapelartEnum
-  ): BezirkUndWahlIDStapelartDTO {
-    return {
-      wahlID: generateRandomString(10),
-      wahlbezirkID: generateRandomString(5),
-      stapelart: stapelArt,
-    };
-  }
-
   return {
-    createBezirkUndWahlIDStapelart,
-    prepareBezirkUndWahlIDStapelart,
     createErgebnisseDTO,
     prepareErgebnisseDTO,
     createErgebnisDTO,

--- a/wls-gui-wahllokalsystem/tests/utils/ergebnismeldung/wahlscheineTestDataFactory.ts
+++ b/wls-gui-wahllokalsystem/tests/utils/ergebnismeldung/wahlscheineTestDataFactory.ts
@@ -1,29 +1,20 @@
-import type {
-  BezirkUndWahlID as BezirkUndWahlIDTO,
-  WahlscheineDTO,
-} from "@/api/wls-clients/generated-ergebnismeldung-api";
-import type { BezirkUndWahlID } from "@/types/ergebnismeldung/BezirkUndWahlID.ts";
+import type { WahlscheineDTO } from "@/api/wls-clients/generated-ergebnismeldung-api";
 import type { Wahlscheine } from "@/types/ergebnismeldung/Wahlscheine.ts";
 import type { Builder } from "@tests/utils/Builder.ts";
 
 import { proxyBuilder } from "@tests/utils/Builder.ts";
 import { useCommonTestDataFactory } from "@tests/utils/common/CommonTestDataFactory.ts";
+import { useCommonErgebnismeldungTestDataFactory } from "@tests/utils/ergebnismeldung/commonErgebnismeldungTestDataFactory.ts";
 
-const { generateRandomString, generateRandomNumber } =
-  useCommonTestDataFactory();
+const { generateRandomNumber } = useCommonTestDataFactory();
+const { createBezirkUndWahlID, createBezirkUndWahlIDDTO } =
+  useCommonErgebnismeldungTestDataFactory();
 
 export function useWahlscheineTestDataFactory() {
   function createWahlscheine(): Wahlscheine {
     return {
       bezirkUndWahlID: createBezirkUndWahlID(),
       stimmabgabevermerke: generateRandomNumber(10),
-    };
-  }
-
-  function createBezirkUndWahlID(): BezirkUndWahlID {
-    return {
-      wahlID: generateRandomString(10),
-      wahlbezirkID: generateRandomString(5),
     };
   }
 
@@ -34,37 +25,20 @@ export function useWahlscheineTestDataFactory() {
     };
   }
 
-  function createBezirkUndWahlIDDTO(): BezirkUndWahlIDTO {
-    return {
-      wahlID: generateRandomString(10),
-      wahlbezirkID: generateRandomString(5),
-    };
-  }
-
   function prepareWahlscheine(): Builder<Wahlscheine> {
     return proxyBuilder<Wahlscheine>(createWahlscheine());
-  }
-
-  function prepareBezirkUndWahlID(): Builder<BezirkUndWahlID> {
-    return proxyBuilder<BezirkUndWahlID>(createBezirkUndWahlID());
   }
 
   function prepareWahlscheineDTO(): Builder<WahlscheineDTO> {
     return proxyBuilder<WahlscheineDTO>(createWahlscheineDTO());
   }
 
-  function prepareBezirkUndWahlIDDTO(): Builder<BezirkUndWahlIDTO> {
-    return proxyBuilder<BezirkUndWahlIDTO>(createBezirkUndWahlIDDTO());
-  }
-
   return {
     createWahlscheine,
     prepareWahlscheine,
-    prepareBezirkUndWahlID,
     createBezirkUndWahlID,
     createBezirkUndWahlIDDTO,
     createWahlscheineDTO,
-    prepareBezirkUndWahlIDDTO,
     prepareWahlscheineDTO,
   };
 }


### PR DESCRIPTION
# Beschreibung:

alles bezüglich `BezirkUndWahlID` und `BezirkUndWahlIDStapelart` wurde in eine commonTestDataFactory ausgelagert, weil es nicht nur bei den wahlscheinen und ergebnissen benötigt wird

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] testdata factories refactored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Introduced a shared test data factory for election district and ballot identifiers.
  - Updated existing tests to use the shared helpers, reducing duplication and improving consistency.
  - Simplified test setup across related test suites.

- Refactor
  - Centralized common test data builders and removed local implementations.
  - Streamlined imports and re-exports to use the new shared utilities.

- Chores
  - Minor housekeeping in test utilities with no impact on runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->