### PR TITLE
2007 stimmabgabevermerke - nummeriung der blätter angepasst

### DIFF
--- a/stack/http_requests/initOracleDB.http
+++ b/stack/http_requests/initOracleDB.http
@@ -63,7 +63,7 @@ Content-Type: application/json
       ],
       "vermerke": [
         {
-          "blattnummer": 1,
+          "blattnummer": 2,
           "stimmzettel": [
             {
               "anzahl": 1,
@@ -102,7 +102,54 @@ Content-Type: application/json
       ],
       "vermerke": [
         {
-          "blattnummer": 1,
+          "blattnummer": 2,
+          "stimmzettel": [
+            {
+              "anzahl": 1,
+              "stimmzettelart": "GROSS"
+            },
+            {
+              "anzahl": 1,
+              "stimmzettelart": "KLEIN"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+### POST stimmabgabevermerke - 1 Wahldaten | user wls_all_uwb | wahlbezirkID d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a/1
+POST {{ WLS_ERGEBNISMELDUNG_SERVICE_URL }}/businessActions/stimmabgabevermerke/d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a/1
+Authorization: Bearer {{$auth.token("auth-service")}}
+Content-Type: application/json
+
+{
+  "wahlbezirkID": "d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a",
+  "waehlerverzeichnisNummer": 1,
+  "anzahlBlaetter": 2,
+  "wahldaten": [
+    {
+      "waehlerverzeichnisNummer": 1,
+      "wahlbezirkID": "d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a",
+      "wahlID": "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
+      "eingenommeneWahlscheine": [
+        {
+          "anzahl": 2,
+          "stimmzettelart": "KLEIN"
+        },
+        {
+          "anzahl": 4,
+          "stimmzettelart": "BEIDE"
+        },
+        {
+          "anzahl": 12,
+          "stimmzettelart": "GROSS"
+        }
+      ],
+      "vermerke": [
+        {
+          "blattnummer": 2,
           "stimmzettel": [
             {
               "anzahl": 1,

--- a/wls-ergebnismeldung-service/src/main/resources/db/migrations/h2/V9_0__updateBlattnummer.sql
+++ b/wls-ergebnismeldung-service/src/main/resources/db/migrations/h2/V9_0__updateBlattnummer.sql
@@ -1,0 +1,2 @@
+UPDATE Vermerk
+SET blattnummer = blattnummer + 1;

--- a/wls-ergebnismeldung-service/src/main/resources/db/migrations/oracle/V9_0__updateBlattnummer.sql
+++ b/wls-ergebnismeldung-service/src/main/resources/db/migrations/oracle/V9_0__updateBlattnummer.sql
@@ -1,0 +1,2 @@
+UPDATE Vermerk
+SET blattnummer = blattnummer + 1;

--- a/wls-ergebnismeldung-service/src/test/resources/sendErgebnismeldung.http
+++ b/wls-ergebnismeldung-service/src/test/resources/sendErgebnismeldung.http
@@ -144,7 +144,7 @@ Content-Type: application/json
       ],
       "vermerke": [
         {
-          "blattnummer": 1,
+          "blattnummer": 2,
           "stimmzettel": [
             {
               "anzahl": 1,
@@ -263,7 +263,7 @@ Content-Type: application/json
       ],
       "vermerke": [
         {
-          "blattnummer": 1,
+          "blattnummer": 2,
           "stimmzettel": [
             {
               "anzahl": 1,

--- a/wls-ergebnismeldung-service/src/test/resources/stimmabgabevermerke.http
+++ b/wls-ergebnismeldung-service/src/test/resources/stimmabgabevermerke.http
@@ -36,7 +36,7 @@ Content-Type: application/json
       ],
       "vermerke": [
         {
-          "blattnummer": 1,
+          "blattnummer": 2,
           "stimmzettel": [
             {
               "anzahl": 1,
@@ -87,7 +87,7 @@ Content-Type: application/json
       ],
       "vermerke": [
         {
-          "blattnummer": 1,
+          "blattnummer": 2,
           "stimmzettel": [
             {
               "anzahl": 1,

--- a/wls-gui-wahllokalsystem/src/stores/stimmabgabevermerkeStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/stimmabgabevermerkeStore.ts
@@ -235,7 +235,7 @@ export const useStimmabgabevermerkeStore = defineStore(
             ) {
               // @ts-expect-error: noUncheckedIndexedAccess for wahldaten[0] | siehe #2008
               stimmabgabevermerk.wahldaten[0].vermerke.push({
-                blattnummer: rowIndex + 2,
+                blattnummer: rowIndex + 2, //Vermerke starten mit der Blattnummer 2 und von da an weiter, da das erste Blatt die Beurkundung ist
                 stimmzettel: [
                   {
                     anzahl: null,

--- a/wls-gui-wahllokalsystem/src/stores/stimmabgabevermerkeStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/stimmabgabevermerkeStore.ts
@@ -235,8 +235,7 @@ export const useStimmabgabevermerkeStore = defineStore(
             ) {
               // @ts-expect-error: noUncheckedIndexedAccess for wahldaten[0] | siehe #2008
               stimmabgabevermerk.wahldaten[0].vermerke.push({
-                //TODO Die Vergabe der Blattnummer anhand des Indizes könnte im Widerspruch zur Beurkundung als Blatt 1 stehen => Issue 2007
-                blattnummer: rowIndex + 1,
+                blattnummer: rowIndex + 2,
                 stimmzettel: [
                   {
                     anzahl: null,

--- a/wls-gui-wahllokalsystem/tests/stores/stimmabgabevermerkeStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/stimmabgabevermerkeStore.spec.ts
@@ -304,6 +304,14 @@ describe("stimmabgabevermerkeStore.ts", () => {
 
       unitUnderTest.stimmabgabevermerke.forEach((stimmabgabevermerke) => {
         expect(stimmabgabevermerke.wahldaten[0]?.vermerke.length).toBe(4);
+
+        const expectedBlattnummern = [2, 3, 4, 5];
+
+        stimmabgabevermerke.wahldaten[0]?.vermerke?.forEach(
+          (vermerk, index) => {
+            expect(vermerk.blattnummer).toBe(expectedBlattnummern[index]);
+          }
+        );
       });
     });
 


### PR DESCRIPTION
# Beschreibung:

Die Nummerierung der Blätter für die Stimmabgabevermerke startet bei 2.

## Definition of Done (DoD):
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Doku aktualisiert
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] Unit-Tests gepflegt
- [x] Texte auf Rechtschreibung und Grammatik geprüft

# Referenzen[^1]:

Closes #2007

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected off-by-one error in ballot sheet number assignment, ensuring proper sequential numbering for voting records.

* **Tests**
  * Enhanced test coverage to validate ballot sheet number calculations across multiple data loading and row modification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->