### PR TITLE
PR-2083-anpassung-regeln-für-das-erscheinen-des-löschendialoges-bei-ereignissen

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/vorfaelleundvorkommnisse/TheEreignisseRows.vue
+++ b/wls-gui-wahllokalsystem/src/components/vorfaelleundvorkommnisse/TheEreignisseRows.vue
@@ -57,7 +57,7 @@ function onDeleteIcon(index: number, ereignisPayload: EreignisPayload) {
   dialogDate.value = dateStr ?? "";
   dialogBeschreibung.value = beschreibung ?? "";
 
-  if (!dateStr && !timeStr && !beschreibung) {
+  if (!beschreibung) {
     deleteIndex.value = index;
     onConfirmDelete();
   } else {

--- a/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/TheEreignisseRows.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/TheEreignisseRows.spec.ts
@@ -235,5 +235,40 @@ describe("TheEreignisseRows.vue", () => {
         0
       );
     });
+
+    it("should_notOpenDialogButDelete_when_deleteWasEmittedByARowWithOnlyBeschreibungEmpty", async () => {
+      const ereignisStore = useEreignisStore();
+      const ereigniseintraege = [] as Ereignis[];
+
+      const date = new Date();
+      date.setHours(12, 0);
+      ereigniseintraege.push(
+        EreignisBuilder.createComplete()
+          .withUhrzeit(date)
+          .withBeschreibung(`Beschreibung`)
+      );
+
+      ereignisStore.wahlbezirkEreignisse.ereigniseintraege = ereigniseintraege;
+
+      await nextTick();
+
+      const baseEreignisRow = wrapper.findComponent(BaseEreignisRow);
+      const payload = {
+        dateOnly: date,
+        timeOnly: date,
+        beschreibung: "",
+      };
+      baseEreignisRow.vm.$emit("delete", payload);
+
+      await flushPromises();
+
+      const deleteDialog = wrapper.findComponent(BaseDialog);
+      expect(deleteDialog.exists()).toBe(true);
+      expect(deleteDialog.vm.visible).toBe(false);
+
+      expect(ereignisStore.wahlbezirkEreignisse.ereigniseintraege).toHaveLength(
+        0
+      );
+    });
   });
 });


### PR DESCRIPTION
# Beschreibung:

* Löschregel angepasst
* Test hinzugefügt

<!-- Frontend -->
### Frontend
- [X] [Naming Conventions][naming-conventions-link] beachtet
- [ ] ~Doku aktualisiert~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] Unit-Tests gepflegt
- [x] Texte auf Rechtschreibung und Grammatik geprüft

Closes #2083



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified delete confirmation dialog behavior for event entries: entries without descriptions now auto-delete without prompting, while entries with descriptions display the confirmation dialog.

* **Tests**
  * Added test coverage for delete scenario with missing description field but present date/time values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->