### PR TITLE
vue-component-type-helpers upgrade 3.1.1 -> 3.1.2

### DIFF
--- a/wls-gui-wahllokalsystem/package-lock.json
+++ b/wls-gui-wahllokalsystem/package-lock.json
@@ -11193,8 +11193,8 @@
       "license": "MIT"
     },
     "node_modules/vue-component-type-helpers": {
-      "version": "3.1.1",
-      "integrity": "sha512-B0kHv7qX6E7+kdc5nsaqjdGZ1KwNKSUQDWGy7XkTYT7wFsOpkEyaJ1Vq79TjwrrtuLRgizrTV7PPuC4rRQo+vw==",
+      "version": "3.1.2",
+      "integrity": "sha512-ch3/SKBtxdZq18vsEntiGCdSszCRNfhX5QaTxjSacCAXLlNQRXfXo+ANjoQEYJMsJOJy1/vHF6Tkc4s85MS+zw==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
# Beschreibung:

- Storybook "latest" dependency verlangt nach einem Upgrade dieser Dependency auf den aktuellsten Stand.
