### PR TITLE
2085 - Beschlusstext soll sichtbar sein - Vergrößerung der Mindestbreite

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/wahlhandlung/beanstandeteWahlbriefe/TheBeanstandeteWahlbriefeTable.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlhandlung/beanstandeteWahlbriefe/TheBeanstandeteWahlbriefeTable.vue
@@ -324,7 +324,7 @@ td {
 }
 
 .columnStyling {
-  min-width: 230px;
+  min-width: 350px;
 }
 
 .context-category {


### PR DESCRIPTION
# Beschreibung:

Mindestbreite wurde auf 350px erhöht. Lokal waren keine Trennungen in Worten erkennbar. Für 3 Wahlen heißt das, dass ca. 1900px benötigt werden um nicht scrollen zu müssen. Da wir aktuell auf die MBW gehen und die KommWahlen nicht von Relevanz sind, ist das kein Problem.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [X] [Naming Conventions][naming-conventions-link] beachtet
- [X] Doku aktualisiert
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [X] Unit-Tests gepflegt
- [X] Texte auf Rechtschreibung und Grammatik geprüft

# Referenzen[^1]:

Closes #2085

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted column width for improved display visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->