### PR TITLE
2106 - Clearable bei Wahlbriefzulassung funktioniert nicht

### DIFF
--- a/docs/src/technik/adr/ui/adr006-delete-button-visibility-on-form-elements.md
+++ b/docs/src/technik/adr/ui/adr006-delete-button-visibility-on-form-elements.md
@@ -34,6 +34,6 @@ bei Bedarf weiterhin eine individuelle Konfiguration erfolgen kann.
 ## Ausnahmen
 
 Bei der Zulassung der Wahlbriefe gibt es verschiedene Querbezüge zwischen den Feldern. Ein Löschbutton in jedem
-einzelnen Feld würde eine komplexe Löschlogik erfordern. Zusätzlich wurde die Tabelle mit den vielen Löschbuttons als 
-unübersichtlich empfunden.   
+einzelnen Feld würde eine komplexe Löschlogik erfordern. Zusätzlich wurde die Tabelle mit den vielen Löschbuttons als
+unübersichtlich empfunden.
 Nach fachlicher Abstimmung wird hier deshalb auf die Löschbuttons verzichtet.  

--- a/docs/src/technik/adr/ui/adr006-delete-button-visibility-on-form-elements.md
+++ b/docs/src/technik/adr/ui/adr006-delete-button-visibility-on-form-elements.md
@@ -30,3 +30,10 @@ Weniger individuelle Konfiguration.
 
 Den Benutzern werden mehr Steuerelemente angezeigt. In Bezug auf die Konfiguration gibt es keine negativen Folgen, da
 bei Bedarf weiterhin eine individuelle Konfiguration erfolgen kann.
+
+## Ausnahmen
+
+Bei der Zulassung der Wahlbriefe gibt es verschiedene Querbezüge zwischen den Feldern. Ein Löschbutton in jedem
+einzelnen Feld würde eine komplexe Löschlogik erfordern. Zusätzlich wurde die Tabelle mit den vielen Löschbuttons als 
+unübersichtlich empfunden.   
+Nach fachlicher Abstimmung wird hier deshalb auf die Löschbuttons verzichtet.  

--- a/wls-gui-wahllokalsystem/src/components/wahlhandlung/beanstandeteWahlbriefe/TheBeanstandeteWahlbriefeTable.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlhandlung/beanstandeteWahlbriefe/TheBeanstandeteWahlbriefeTable.vue
@@ -32,6 +32,7 @@
                 class="ml-5 fill-height"
                 :items="gruendeWahlscheine"
                 auto-select-first
+                :clearable="false"
                 :rules="[required]"
                 :data-test="`wahlscheingruende-input-${index - 1}`"
                 @update:model-value="
@@ -56,6 +57,7 @@
               label="Beschlussergebnis"
               :items="gruendeStimmzettel"
               auto-select-first
+              :clearable="false"
               :rules="[required]"
               :disabled="_isInputDisabled(index - 1)"
               :data-test="`stimmzettelgruende-input-${wahl.wahlID}-${index - 1}`"

--- a/wls-gui-wahllokalsystem/tests/components/wahlhandlung/beanstandeteWahlbriefe/__snapshots__/TheBeanstandeteWahlbriefeErfassenCard/visual logic/should_renderWithDisabledSaveButton_when_rowsAreInvalid.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlhandlung/beanstandeteWahlbriefe/__snapshots__/TheBeanstandeteWahlbriefeErfassenCard/visual logic/should_renderWithDisabledSaveButton_when_rowsAreInvalid.html
@@ -68,11 +68,7 @@
                               </div>
                               <!---->
                             </div>
-                            <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
-                              <div class="v-field__clearable"><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-label="Clear Beschlussergebnis"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                                    <path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path>
-                                  </svg></i></div>
-                            </transition-stub>
+                            <!---->
                             <div class="v-field__append-inner">
                               <!----><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable v-autocomplete__menu-icon" role="button" aria-hidden="false" tabindex="-1" aria-label="Open" title="Open"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                                   <path d="M7,10L12,15L17,10H7Z"></path>

--- a/wls-gui-wahllokalsystem/tests/components/wahlhandlung/beanstandeteWahlbriefe/__snapshots__/TheBeanstandeteWahlbriefeErfassenCard/visual logic/should_renderWithEnabledSaveButton_when_rowsAreValid.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlhandlung/beanstandeteWahlbriefe/__snapshots__/TheBeanstandeteWahlbriefeErfassenCard/visual logic/should_renderWithEnabledSaveButton_when_rowsAreValid.html
@@ -68,11 +68,7 @@
                               </div>
                               <!---->
                             </div>
-                            <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
-                              <div class="v-field__clearable"><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-label="Clear Beschlussergebnis"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                                    <path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path>
-                                  </svg></i></div>
-                            </transition-stub>
+                            <!---->
                             <div class="v-field__append-inner">
                               <!----><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable v-autocomplete__menu-icon" role="button" aria-hidden="false" tabindex="-1" aria-label="Open" title="Open"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                                   <path d="M7,10L12,15L17,10H7Z"></path>

--- a/wls-gui-wahllokalsystem/tests/components/wahlhandlung/beanstandeteWahlbriefe/__snapshots__/TheBeanstandeteWahlbriefeTable/visual logic/should_showMultipleRows_when_multipleZurueckweisungsgruendeGiven.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlhandlung/beanstandeteWahlbriefe/__snapshots__/TheBeanstandeteWahlbriefeTable/visual logic/should_showMultipleRows_when_multipleZurueckweisungsgruendeGiven.html
@@ -48,11 +48,7 @@
                         </div>
                         <!---->
                       </div>
-                      <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
-                        <div class="v-field__clearable"><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-label="Clear Beschlussergebnis"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                              <path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path>
-                            </svg></i></div>
-                      </transition-stub>
+                      <!---->
                       <div class="v-field__append-inner">
                         <!----><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable v-autocomplete__menu-icon" role="button" aria-hidden="false" tabindex="-1" aria-label="Open" title="Open"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                             <path d="M7,10L12,15L17,10H7Z"></path>
@@ -109,11 +105,7 @@
                       </div>
                       <!---->
                     </div>
-                    <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
-                      <div class="v-field__clearable"><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-label="Clear Beschlussergebnis"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                            <path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path>
-                          </svg></i></div>
-                    </transition-stub>
+                    <!---->
                     <div class="v-field__append-inner">
                       <!----><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable v-autocomplete__menu-icon" role="button" aria-hidden="false" tabindex="-1" aria-label="Open" title="Open"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                           <path d="M7,10L12,15L17,10H7Z"></path>
@@ -169,11 +161,7 @@
                       </div>
                       <!---->
                     </div>
-                    <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
-                      <div class="v-field__clearable"><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-label="Clear Beschlussergebnis"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                            <path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path>
-                          </svg></i></div>
-                    </transition-stub>
+                    <!---->
                     <div class="v-field__append-inner">
                       <!----><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable v-autocomplete__menu-icon" role="button" aria-hidden="false" tabindex="-1" aria-label="Open" title="Open"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                           <path d="M7,10L12,15L17,10H7Z"></path>
@@ -242,11 +230,7 @@
                         </div>
                         <!---->
                       </div>
-                      <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
-                        <div class="v-field__clearable"><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-label="Clear Beschlussergebnis"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                              <path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path>
-                            </svg></i></div>
-                      </transition-stub>
+                      <!---->
                       <div class="v-field__append-inner">
                         <!----><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable v-autocomplete__menu-icon" role="button" aria-hidden="false" tabindex="-1" aria-label="Open" title="Open"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                             <path d="M7,10L12,15L17,10H7Z"></path>
@@ -303,11 +287,7 @@
                       </div>
                       <!---->
                     </div>
-                    <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
-                      <div class="v-field__clearable"><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-label="Clear Beschlussergebnis"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                            <path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path>
-                          </svg></i></div>
-                    </transition-stub>
+                    <!---->
                     <div class="v-field__append-inner">
                       <!----><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable v-autocomplete__menu-icon" role="button" aria-hidden="false" tabindex="-1" aria-label="Open" title="Open"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                           <path d="M7,10L12,15L17,10H7Z"></path>
@@ -363,11 +343,7 @@
                       </div>
                       <!---->
                     </div>
-                    <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
-                      <div class="v-field__clearable"><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-label="Clear Beschlussergebnis"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                            <path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path>
-                          </svg></i></div>
-                    </transition-stub>
+                    <!---->
                     <div class="v-field__append-inner">
                       <!----><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable v-autocomplete__menu-icon" role="button" aria-hidden="false" tabindex="-1" aria-label="Open" title="Open"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                           <path d="M7,10L12,15L17,10H7Z"></path>
@@ -436,11 +412,7 @@
                         </div>
                         <!---->
                       </div>
-                      <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
-                        <div class="v-field__clearable"><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-label="Clear Beschlussergebnis"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                              <path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path>
-                            </svg></i></div>
-                      </transition-stub>
+                      <!---->
                       <div class="v-field__append-inner">
                         <!----><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable v-autocomplete__menu-icon" role="button" aria-hidden="false" tabindex="-1" aria-label="Open" title="Open"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                             <path d="M7,10L12,15L17,10H7Z"></path>

--- a/wls-gui-wahllokalsystem/tests/components/wahlhandlung/beanstandeteWahlbriefe/__snapshots__/TheBeanstandeteWahlbriefeTable/visual logic/should_showOneRow_when_oneZurueckweisungsgrundGiven.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlhandlung/beanstandeteWahlbriefe/__snapshots__/TheBeanstandeteWahlbriefeTable/visual logic/should_showOneRow_when_oneZurueckweisungsgrundGiven.html
@@ -48,11 +48,7 @@
                         </div>
                         <!---->
                       </div>
-                      <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
-                        <div class="v-field__clearable"><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-label="Clear Beschlussergebnis"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                              <path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path>
-                            </svg></i></div>
-                      </transition-stub>
+                      <!---->
                       <div class="v-field__append-inner">
                         <!----><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable v-autocomplete__menu-icon" role="button" aria-hidden="false" tabindex="-1" aria-label="Open" title="Open"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                             <path d="M7,10L12,15L17,10H7Z"></path>
@@ -109,11 +105,7 @@
                       </div>
                       <!---->
                     </div>
-                    <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
-                      <div class="v-field__clearable"><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-label="Clear Beschlussergebnis"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                            <path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path>
-                          </svg></i></div>
-                    </transition-stub>
+                    <!---->
                     <div class="v-field__append-inner">
                       <!----><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable v-autocomplete__menu-icon" role="button" aria-hidden="false" tabindex="-1" aria-label="Open" title="Open"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                           <path d="M7,10L12,15L17,10H7Z"></path>
@@ -169,11 +161,7 @@
                       </div>
                       <!---->
                     </div>
-                    <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
-                      <div class="v-field__clearable"><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-label="Clear Beschlussergebnis"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                            <path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path>
-                          </svg></i></div>
-                    </transition-stub>
+                    <!---->
                     <div class="v-field__append-inner">
                       <!----><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable v-autocomplete__menu-icon" role="button" aria-hidden="false" tabindex="-1" aria-label="Open" title="Open"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                           <path d="M7,10L12,15L17,10H7Z"></path>

--- a/wls-gui-wahllokalsystem/tests/views/wahlhandlung/__snapshots__/BWBWahlbriefZulassungView/visual logic/should_renderWithEditIcon_when_beanstandeteWahlbriefeTableNotValid.html
+++ b/wls-gui-wahllokalsystem/tests/views/wahlhandlung/__snapshots__/BWBWahlbriefZulassungView/visual logic/should_renderWithEditIcon_when_beanstandeteWahlbriefeTableNotValid.html
@@ -88,11 +88,7 @@
                                         </div>
                                         <!---->
                                       </div>
-                                      <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
-                                        <div class="v-field__clearable"><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-label="Clear Beschlussergebnis"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                                              <path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path>
-                                            </svg></i></div>
-                                      </transition-stub>
+                                      <!---->
                                       <div class="v-field__append-inner">
                                         <!----><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable v-autocomplete__menu-icon" role="button" aria-hidden="false" tabindex="-1" aria-label="Open" title="Open"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                                             <path d="M7,10L12,15L17,10H7Z"></path>

--- a/wls-gui-wahllokalsystem/tests/views/wahlhandlung/__snapshots__/BWBWahlbriefZulassungView/visual logic/should_renderWithValidIcon_when_beanstandeteWahlbriefeTableHasValidRows.html
+++ b/wls-gui-wahllokalsystem/tests/views/wahlhandlung/__snapshots__/BWBWahlbriefZulassungView/visual logic/should_renderWithValidIcon_when_beanstandeteWahlbriefeTableHasValidRows.html
@@ -88,11 +88,7 @@
                                         </div>
                                         <!---->
                                       </div>
-                                      <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
-                                        <div class="v-field__clearable"><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-label="Clear Beschlussergebnis"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                                              <path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path>
-                                            </svg></i></div>
-                                      </transition-stub>
+                                      <!---->
                                       <div class="v-field__append-inner">
                                         <!----><i class="v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable v-autocomplete__menu-icon" role="button" aria-hidden="false" tabindex="-1" aria-label="Open" title="Open"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                                             <path d="M7,10L12,15L17,10H7Z"></path>


### PR DESCRIPTION
# Beschreibung:

* `clearable` bei autocompletes disabled nach fachlicher Abstimmung

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Doku aktualisiert
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] Unit-Tests gepflegt
- [x] Texte auf Rechtschreibung und Grammatik geprüft

# Referenzen[^1]:

Closes #2106

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Autocomplete input fields within the ballot objection management interface are now locked after selection, preventing users from accidentally or unintentionally clearing their entries through the user interface. This ensures consistent data integrity and reduces the risk of incomplete submissions during the objection processing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->