### PR TITLE
Create generate ldif file script

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -216,6 +216,10 @@ export default withMermaid({
               text: "Aktualisierung von Images",
               link: `${PATH_GUIDES}update-images.md`,
             },
+            {
+              text: "Update embedded LDAP User",
+              link: `${PATH_GUIDES}update-ldif-file-data.md`,
+            },
           ],
         },
         {

--- a/docs/src/technik/guides/update-ldif-file-data.md
+++ b/docs/src/technik/guides/update-ldif-file-data.md
@@ -4,14 +4,14 @@
 
 Der [Auth-Service](/services/backend-services/auth-service) verwendet einen embedded LDAP-Server,
 wenn keine LDAP-Verbindung konfiguriert ist. Die Daten dieses Servers werden über ein ldif-File
-definiert. Ergeben sich dem Anlegen von Wahltermindaten, und damit verbunden die Erstellung von Usern, neue User
-müssen diese im ldif-File nachgetragen werden.
+definiert. Ergibt sich beim Anlegen von Wahltermindaten und damit verbunden bei der Erstellung von Usern, dass neue
+User hinzukommen, müssen diese im LDIF-File nachgetragen werden.
 
 ## Kurzbeschreibung des Vorgehens
 
-Über das Skript `generateLdif.sh` im Ordner `stack/ldap` des Repositories kann ein ldif-File erstellt werden. Als
-Input benötigt das Skript eine Datei, welche zeilenweise die Benutzer enthält. Nach dem Ausführen des Skriptes sind
-die neuen Benutzer und die Zuordnung der Nutzer zu einer Gruppe aus dem erzeugten File zu kopieren und in das
+Über das Skript `generateLdif.sh` im Ordner `stack/ldap` des Repositories kann eine ldif-Datei erstellt werden. Als
+Input benötigt das Skript eine Datei, die zeilenweise die Benutzer enthält. Nach dem Ausführen des Skriptes sind
+die neuen Benutzer und die Zuordnung der Nutzer zu einer Gruppe aus der erzeugten Datei zu kopieren und in das
 bestehende Skript zu integrieren. Danach kann man sich zusätzlich mit den generierten Usern einloggen.
 
 ## Beschreibung im Detail
@@ -65,7 +65,7 @@ Login möglich.
 ### Generierung eines neuen Wahltermins
 
 Wenn ein neuer Wahltermin durch das Wahllokalsystem unterstützt werden soll, muss dieser Wahltermin initialisiert werden.
-Das erfolgt über die Admin-Gui. Im Rahmen des Initialisierungsprozess werden auch Benutzer generiert.
+Das erfolgt über die Admin-GUI. Im Rahmen des Initialisierungsprozesses werden auch Benutzer generiert.
 Für das Beispiel gehen wir davon aus, dass folgende Benutzer generiert wurden:
 
 ```
@@ -76,7 +76,7 @@ ujt9a-wahlbezirk0002
 
 ### Erzeugung des neuen ldif-Files
 
-Die Benutzer sollten in einer Datei vorliegen. Im Beispiel gehen wird davon aus die Datei den namen `exportusers.csv`
+Die Benutzer sollten in einer Datei vorliegen. Im Beispiel gehen wir davon aus, dass die Datei den Namen `exportusers.csv`
 hat und im selben Ordner wie das Skript liegt.
 
 ```bash
@@ -84,7 +84,7 @@ hat und im selben Ordner wie das Skript liegt.
 ```
 *Befehl zum Ausführen des Bash-Skriptes zur Erzeugung des ldif-Files*
 
-Nach erfolgreicher Beendigung des Skripts mit der Datei `ouput.ldif` das generierte ldif-File vor.
+Nach erfolgreicher Beendigung des Skripts liegt die Datei `output.ldif` mit dem generierten ldif-File vor.
 
 ### Zusammenführen der LDIF
 
@@ -138,10 +138,10 @@ member: uid=ujt9a-wahlbezirk0002,ou=people,dc=springframework,dc=org
 member: uid=78nmr-wahlbezirk0003,ou=people,dc=springframework,dc=org
 ```
 
-Aus dem erzeugten File müssen die erzeugten User und die Zuordnung zur Gruppe (siehe der hervorgehobene Bereich)
+Aus dem erzeugten File müssen die erzeugten User und die Zuordnung zur Gruppe (siehe den hervorgehobenen Bereich)
 in das bestehende ldif-File übertragen werden.
 
-Nach einem Neustart des Auth-Service ist, kann zusätzlich ein Login mit den neuen Usern erfolgen.
+Nach einem Neustart des Auth-Service kann zusätzlich ein Login mit den neuen Usern erfolgen.
 
 ### Das finale ldif-File
 

--- a/docs/src/technik/guides/update-ldif-file-data.md
+++ b/docs/src/technik/guides/update-ldif-file-data.md
@@ -3,7 +3,8 @@
 ## Kontext
 
 Der [Auth-Service](/services/backend-services/auth-service/index.md) verwendet einen embedded LDAP-Server,
-wenn keine LDAP-Verbindung konfiguriert ist. Die Daten dieses Servers werden über ein ldif-File
+wenn keine LDAP-Verbindung konfiguriert ist. Die Daten dieses Servers werden über ein
+[LDIF](https://de.wikipedia.org/wiki/LDAP_Data_Interchange_Format)-File
 definiert. Ergibt sich beim Anlegen von Wahltermindaten und damit verbunden bei der Erstellung von Usern, dass neue
 User hinzukommen, müssen diese im LDIF-File nachgetragen werden.
 

--- a/docs/src/technik/guides/update-ldif-file-data.md
+++ b/docs/src/technik/guides/update-ldif-file-data.md
@@ -2,7 +2,7 @@
 
 ## Kontext
 
-Der [Auth-Service](/services/backend-services/auth-service) verwendet einen embedded LDAP-Server,
+Der [Auth-Service](/services/backend-services/auth-service/index.md) verwendet einen embedded LDAP-Server,
 wenn keine LDAP-Verbindung konfiguriert ist. Die Daten dieses Servers werden über ein ldif-File
 definiert. Ergibt sich beim Anlegen von Wahltermindaten und damit verbunden bei der Erstellung von Usern, dass neue
 User hinzukommen, müssen diese im LDIF-File nachgetragen werden.
@@ -20,7 +20,7 @@ bestehende Skript zu integrieren. Danach kann man sich zusätzlich mit den gener
 
 Gehen wir davon aus, es gibt folgendes ldif-File:
 
-```ldif
+```text
 dn: ou=groups,dc=springframework,dc=org
 objectclass: top
 objectclass: organizationalUnit
@@ -68,7 +68,7 @@ Wenn ein neuer Wahltermin durch das Wahllokalsystem unterstützt werden soll, mu
 Das erfolgt über die Admin-GUI. Im Rahmen des Initialisierungsprozesses werden auch Benutzer generiert.
 Für das Beispiel gehen wir davon aus, dass folgende Benutzer generiert wurden:
 
-```
+```text
 fzh56-wahlbezirk0001
 ujt9a-wahlbezirk0002
 78nmr-wahlbezirk0003
@@ -82,13 +82,14 @@ hat und im selben Ordner wie das Skript liegt.
 ```bash
 ./generateLdif.sh exportusers.csv
 ```
-*Befehl zum Ausführen des Bash-Skriptes zur Erzeugung des ldif-Files*
+
+<em>Befehl zum Ausführen des Bash-Skriptes zur Erzeugung des ldif-Files</em>
 
 Nach erfolgreicher Beendigung des Skripts liegt die Datei `output.ldif` mit dem generierten ldif-File vor.
 
 ### Zusammenführen der LDIF
 
-```ldif:line-numbers {11-19,21-29,31-39,45-47}
+```text:line-numbers {11-19,21-29,31-39,45-47}
 dn: ou=groups,dc=springframework,dc=org
 objectclass: top
 objectclass: organizationalUnit
@@ -145,7 +146,7 @@ Nach einem Neustart des Auth-Service kann zusätzlich ein Login mit den neuen Us
 
 ### Das finale ldif-File
 
-```ldif
+```text
 dn: ou=groups,dc=springframework,dc=org
 objectclass: top
 objectclass: organizationalUnit

--- a/docs/src/technik/guides/update-ldif-file-data.md
+++ b/docs/src/technik/guides/update-ldif-file-data.md
@@ -1,0 +1,218 @@
+# Aktualisieren der embedded-LDAP User
+
+## Kontext
+
+Der [Auth-Service](/services/backend-services/auth-service) verwendet einen embedded LDAP-Server,
+wenn keine LDAP-Verbindung konfiguriert ist. Die Daten dieses Servers werden über ein ldif-File
+definiert. Ergeben sich dem Anlegen von Wahltermindaten, und damit verbunden die Erstellung von Usern, neue User
+müssen diese im ldif-File nachgetragen werden.
+
+## Kurzbeschreibung des Vorgehens
+
+Über das Skript `generateLdif.sh` im Ordner `stack/ldap` des Repositories kann ein ldif-File erstellt werden. Als
+Input benötigt das Skript eine Datei, welche zeilenweise die Benutzer enthält. Nach dem Ausführen des Skriptes sind
+die neuen Benutzer und die Zuordnung der Nutzer zu einer Gruppe aus dem erzeugten File zu kopieren und in das
+bestehende Skript zu integrieren. Danach kann man sich zusätzlich mit den generierten Usern einloggen.
+
+## Beschreibung im Detail
+
+### Ausgangslage
+
+Gehen wir davon aus, es gibt folgendes ldif-File:
+
+```ldif
+dn: ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: groups
+
+dn: ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: people
+
+dn: uid=wls_all_uwb,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: wls_all_uwb
+sn: uwb
+uid: wls_all_uwb
+userPassword: test
+
+dn: uid=wls_all_bwb,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: wls_all_bwb
+sn: bwb
+uid: wls_all_bwb
+userPassword: test
+
+dn: cn=user,ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: user
+member: uid=wls_all_uwb,ou=people,dc=springframework,dc=org
+member: uid=wls_all_bwb,ou=people,dc=springframework,dc=org
+```
+
+Über dieses File werden zwei User (`wls_all_uwb` und `wls_all_bwb`) definiert. Nur mit diesen beiden Usern ist ein
+Login möglich.
+
+### Generierung eines neuen Wahltermins
+
+Wenn ein neuer Wahltermin durch das Wahllokalsystem unterstützt werden soll, muss dieser Wahltermin initialisiert werden.
+Das erfolgt über die Admin-Gui. Im Rahmen des Initialisierungsprozess werden auch Benutzer generiert.
+Für das Beispiel gehen wir davon aus, dass folgende Benutzer generiert wurden:
+
+```
+fzh56-wahlbezirk0001
+ujt9a-wahlbezirk0002
+78nmr-wahlbezirk0003
+```
+
+### Erzeugung des neuen ldif-Files
+
+Die Benutzer sollten in einer Datei vorliegen. Im Beispiel gehen wird davon aus die Datei den namen `exportusers.csv`
+hat und im selben Ordner wie das Skript liegt.
+
+```bash
+./generateLdif.sh exportusers.csv
+```
+*Befehl zum Ausführen des Bash-Skriptes zur Erzeugung des ldif-Files*
+
+Nach erfolgreicher Beendigung des Skripts mit der Datei `ouput.ldif` das generierte ldif-File vor.
+
+### Zusammenführen der LDIF
+
+```ldif:line-numbers {11-19,21-29,31-39,45-47}
+dn: ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: groups
+
+dn: ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: people
+
+dn: uid=fzh56-wahlbezirk0001,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: fzh56-wahlbezirk0001
+sn: fzh56-wahlbezirk0001
+uid: fzh56-wahlbezirk0001
+userPassword: test
+
+dn: uid=ujt9a-wahlbezirk0002,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: ujt9a-wahlbezirk0002
+sn: ujt9a-wahlbezirk0002
+uid: ujt9a-wahlbezirk0002
+userPassword: test
+
+dn: uid=78nmr-wahlbezirk0003,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: 78nmr-wahlbezirk0003
+sn: 78nmr-wahlbezirk0003
+uid: 78nmr-wahlbezirk0003
+userPassword: test
+
+dn: cn=user,ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: user
+member: uid=fzh56-wahlbezirk0001,ou=people,dc=springframework,dc=org
+member: uid=ujt9a-wahlbezirk0002,ou=people,dc=springframework,dc=org
+member: uid=78nmr-wahlbezirk0003,ou=people,dc=springframework,dc=org
+```
+
+Aus dem erzeugten File müssen die erzeugten User und die Zuordnung zur Gruppe (siehe der hervorgehobene Bereich)
+in das bestehende ldif-File übertragen werden.
+
+Nach einem Neustart des Auth-Service ist, kann zusätzlich ein Login mit den neuen Usern erfolgen.
+
+### Das finale ldif-File
+
+```ldif
+dn: ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: groups
+
+dn: ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: people
+
+dn: uid=wls_all_uwb,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: wls_all_uwb
+sn: uwb
+uid: wls_all_uwb
+userPassword: test
+
+dn: uid=wls_all_bwb,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: wls_all_bwb
+sn: bwb
+uid: wls_all_bwb
+userPassword: test
+
+dn: uid=fzh56-wahlbezirk0001,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: fzh56-wahlbezirk0001
+sn: fzh56-wahlbezirk0001
+uid: fzh56-wahlbezirk0001
+userPassword: test
+
+dn: uid=ujt9a-wahlbezirk0002,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: ujt9a-wahlbezirk0002
+sn: ujt9a-wahlbezirk0002
+uid: ujt9a-wahlbezirk0002
+userPassword: test
+
+dn: uid=78nmr-wahlbezirk0003,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: 78nmr-wahlbezirk0003
+sn: 78nmr-wahlbezirk0003
+uid: 78nmr-wahlbezirk0003
+userPassword: test
+
+dn: cn=user,ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: user
+member: uid=wls_all_uwb,ou=people,dc=springframework,dc=org
+member: uid=wls_all_bwb,ou=people,dc=springframework,dc=org
+member: uid=fzh56-wahlbezirk0001,ou=people,dc=springframework,dc=org
+member: uid=ujt9a-wahlbezirk0002,ou=people,dc=springframework,dc=org
+member: uid=78nmr-wahlbezirk0003,ou=people,dc=springframework,dc=org
+```

--- a/docs/src/technik/guides/update-ldif-file-data.md
+++ b/docs/src/technik/guides/update-ldif-file-data.md
@@ -5,8 +5,7 @@
 Der [Auth-Service](/services/backend-services/auth-service/index.md) verwendet einen embedded LDAP-Server,
 wenn keine LDAP-Verbindung konfiguriert ist. Die Daten dieses Servers werden über ein
 [LDIF](https://de.wikipedia.org/wiki/LDAP_Data_Interchange_Format)-File
-definiert. Ergibt sich beim Anlegen von Wahltermindaten und damit verbunden bei der Erstellung von Usern, dass neue
-User hinzukommen, müssen diese im LDIF-File nachgetragen werden.
+definiert. Wenn bei der Eingabe von Wahltermindaten neue Benutzer erstellt werden, müssen diese im LDIF-File ergänzt werden.
 
 ## Kurzbeschreibung des Vorgehens
 

--- a/docs/src/technik/guides/update-ldif-file-data.md
+++ b/docs/src/technik/guides/update-ldif-file-data.md
@@ -10,7 +10,7 @@ User hinzukommen, müssen diese im LDIF-File nachgetragen werden.
 
 ## Kurzbeschreibung des Vorgehens
 
-Über das Skript `generateLdif.sh` im Ordner `stack/ldap` des Repositories kann eine ldif-Datei erstellt werden. Als
+Über das Skript `generateLdif.sh` im Ordner `stack/ldap` des Repositories kann eine LDIF-Datei erstellt werden. Als
 Input benötigt das Skript eine Datei, die zeilenweise die Benutzer enthält. Nach dem Ausführen des Skriptes sind
 die neuen Benutzer und die Zuordnung der Nutzer zu einer Gruppe aus der erzeugten Datei zu kopieren und in das
 bestehende Skript zu integrieren. Danach kann man sich zusätzlich mit den generierten Usern einloggen.
@@ -19,7 +19,7 @@ bestehende Skript zu integrieren. Danach kann man sich zusätzlich mit den gener
 
 ### Ausgangslage
 
-Gehen wir davon aus, es gibt folgendes ldif-File:
+Gehen wir davon aus, es gibt folgendes LDIF-File:
 
 ```text
 dn: ou=groups,dc=springframework,dc=org
@@ -75,7 +75,7 @@ ujt9a-wahlbezirk0002
 78nmr-wahlbezirk0003
 ```
 
-### Erzeugung des neuen ldif-Files
+### Erzeugung des neuen LDIF-Files
 
 Die Benutzer sollten in einer Datei vorliegen. Im Beispiel gehen wir davon aus, dass die Datei den Namen `exportusers.csv`
 hat und im selben Ordner wie das Skript liegt.
@@ -84,9 +84,9 @@ hat und im selben Ordner wie das Skript liegt.
 ./generateLdif.sh exportusers.csv
 ```
 
-<em>Befehl zum Ausführen des Bash-Skriptes zur Erzeugung des ldif-Files</em>
+<em>Befehl zum Ausführen des Bash-Skriptes zur Erzeugung des LDIF-Files</em>
 
-Nach erfolgreicher Beendigung des Skripts liegt die Datei `output.ldif` mit dem generierten ldif-File vor.
+Nach erfolgreicher Beendigung des Skripts liegt die Datei `output.ldif` mit dem generierten LDIF-File vor.
 
 ### Zusammenführen der LDIF
 
@@ -141,11 +141,11 @@ member: uid=78nmr-wahlbezirk0003,ou=people,dc=springframework,dc=org
 ```
 
 Aus dem erzeugten File müssen die erzeugten User und die Zuordnung zur Gruppe (siehe den hervorgehobenen Bereich)
-in das bestehende ldif-File übertragen werden.
+in das bestehende LDIF-File übertragen werden.
 
 Nach einem Neustart des Auth-Service kann zusätzlich ein Login mit den neuen Usern erfolgen.
 
-### Das finale ldif-File
+### Das finale LDIF-File
 
 ```text
 dn: ou=groups,dc=springframework,dc=org

--- a/stack/ldap/generateLdif.sh
+++ b/stack/ldap/generateLdif.sh
@@ -9,6 +9,18 @@ fi
 input_file="$1"
 output_file="output.ldif"
 
+# Array für Benutzernamen initialisieren
+usernames=()
+
+# Benutzer aus der Eingabedatei lesen und in das Array einfügen
+while IFS= read -r username || [[ -n "$username" ]]; do
+    # Entfernen von führenden und nachfolgenden Leerzeichen
+    username=$(echo "$username" | xargs)
+    if [ -n "$username" ]; then  # Nur wenn der Benutzername nicht leer ist
+        usernames+=("$username")
+    fi
+done < "$input_file"
+
 # Erstellen einer neuen LDIF-Datei
 {
     # Gruppen definieren
@@ -24,37 +36,29 @@ output_file="output.ldif"
     echo ""
 
     # Benutzer erstellen
-    while IFS= read -r username || [[ -n "$username" ]]; do # Jede Zeile lesen auch wenn sie nicht mit \n enden
-        # Entfernen von führenden und nachfolgenden Leerzeichen
-        username=$(echo "$username" | xargs)
-        if [ -n "$username" ]; then  # Nur wenn der Benutzername nicht leer ist
-            echo "dn: uid=${username},ou=people,dc=springframework,dc=org"
-            echo "objectclass: top"
-            echo "objectclass: person"
-            echo "objectclass: organizationalPerson"
-            echo "objectclass: inetOrgPerson"
-            echo "cn: ${username}"
-            echo "sn: ${username}"
-            echo "uid: ${username}"
-            echo "userPassword: test"
-            echo ""
-        fi
-    done < "$input_file"
+    for username in "${usernames[@]}"; do
+        echo "dn: uid=${username},ou=people,dc=springframework,dc=org"
+        echo "objectclass: top"
+        echo "objectclass: person"
+        echo "objectclass: organizationalPerson"
+        echo "objectclass: inetOrgPerson"
+        echo "cn: ${username}"
+        echo "sn: ${username}"
+        echo "uid: ${username}"
+        echo "userPassword: test"
+        echo ""
+    done
 
-    # User der Gruppe zuordnen
+    # Userzuordnung erstellen
     echo "dn: cn=user,ou=groups,dc=springframework,dc=org"
     echo "objectclass: top"
     echo "objectclass: groupOfNames"
     echo "cn: user"
 
-    # Mitglieder hinzufügen
-    while IFS= read -r username || [[ -n "$username" ]]; do # Jede Zeile lesen auch wenn sie nicht mit \n enden
-        # Entfernen von führenden und nachfolgenden Leerzeichen
-        username=$(echo "$username" | xargs)
-        if [ -n "$username" ]; then  # Nur wenn der Benutzername nicht leer ist
-            echo "member: uid=${username},ou=people,dc=springframework,dc=org"
-        fi
-    done < "$input_file"
+    # Mitglieder der Userzuordnung hinzufügen
+    for username in "${usernames[@]}"; do
+        echo "member: uid=${username},ou=people,dc=springframework,dc=org"
+    done
 
 } > "$output_file"
 

--- a/stack/ldap/generateLdif.sh
+++ b/stack/ldap/generateLdif.sh
@@ -15,7 +15,8 @@ usernames=()
 # Benutzer aus der Eingabedatei lesen und in das Array einfügen
 while IFS= read -r username || [[ -n "$username" ]]; do
     # Entfernen von führenden und nachfolgenden Leerzeichen
-    username=$(echo "$username" | xargs)
+    username="${username#"${username%%[![:space:]]*}"}" # leading whitespace
+    username="${username%"${username##*[![:space:]]}"}" # trailing whitespace
     if [ -n "$username" ]; then  # Nur wenn der Benutzername nicht leer ist
         usernames+=("$username")
     fi

--- a/stack/ldap/generateLdif.sh
+++ b/stack/ldap/generateLdif.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Überprüfen, ob die Eingabedatei angegeben wurde
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <input_file>"
+    exit 1
+fi
+
+input_file="$1"
+output_file="output.ldif"
+
+# Erstellen einer neuen LDIF-Datei
+{
+    # Fester Teil
+    echo "dn: ou=groups,dc=springframework,dc=org"
+    echo "objectclass: top"
+    echo "objectclass: organizationalUnit"
+    echo "ou: groups"
+    echo ""
+    echo "dn: ou=people,dc=springframework,dc=org"
+    echo "objectclass: top"
+    echo "objectclass: organizationalUnit"
+    echo "ou: people"
+    echo ""
+
+    # Benutzer hinzufügen
+    while IFS= read -r username; do
+        echo "dn: uid=${username},ou=people,dc=springframework,dc=org"
+        echo "objectclass: top"
+        echo "objectclass: person"
+        echo "objectclass: organizationalPerson"
+        echo "objectclass: inetOrgPerson"
+        echo "cn: ${username}"
+        echo "sn: ${username}"
+        echo "uid: ${username}"
+        echo "userPassword: test"
+        echo ""
+    done < "$input_file"
+
+    # Letzter Teil
+    echo "dn: cn=user,ou=groups,dc=springframework,dc=org"
+    echo "objectclass: top"
+    echo "objectclass: groupOfNames"
+    echo "cn: user"
+
+    # Mitglieder hinzufügen
+    while IFS= read -r username; do
+        echo "member: uid=${username},ou=people,dc=springframework,dc=org"
+    done < "$input_file"
+
+} > "$output_file"
+
+echo "LDIF file '$output_file' has been generated."

--- a/stack/ldap/generateLdif.sh
+++ b/stack/ldap/generateLdif.sh
@@ -11,7 +11,7 @@ output_file="output.ldif"
 
 # Erstellen einer neuen LDIF-Datei
 {
-    # Fester Teil
+    # Gruppen definieren
     echo "dn: ou=groups,dc=springframework,dc=org"
     echo "objectclass: top"
     echo "objectclass: organizationalUnit"
@@ -23,29 +23,37 @@ output_file="output.ldif"
     echo "ou: people"
     echo ""
 
-    # Benutzer hinzufügen
-    while IFS= read -r username; do
-        echo "dn: uid=${username},ou=people,dc=springframework,dc=org"
-        echo "objectclass: top"
-        echo "objectclass: person"
-        echo "objectclass: organizationalPerson"
-        echo "objectclass: inetOrgPerson"
-        echo "cn: ${username}"
-        echo "sn: ${username}"
-        echo "uid: ${username}"
-        echo "userPassword: test"
-        echo ""
+    # Benutzer erstellen
+    while IFS= read -r username || [[ -n "$username" ]]; do # Jede Zeile lesen auch wenn sie nicht mit \n enden
+        # Entfernen von führenden und nachfolgenden Leerzeichen
+        username=$(echo "$username" | xargs)
+        if [ -n "$username" ]; then  # Nur wenn der Benutzername nicht leer ist
+            echo "dn: uid=${username},ou=people,dc=springframework,dc=org"
+            echo "objectclass: top"
+            echo "objectclass: person"
+            echo "objectclass: organizationalPerson"
+            echo "objectclass: inetOrgPerson"
+            echo "cn: ${username}"
+            echo "sn: ${username}"
+            echo "uid: ${username}"
+            echo "userPassword: test"
+            echo ""
+        fi
     done < "$input_file"
 
-    # Letzter Teil
+    # User der Gruppe zuordnen
     echo "dn: cn=user,ou=groups,dc=springframework,dc=org"
     echo "objectclass: top"
     echo "objectclass: groupOfNames"
     echo "cn: user"
 
     # Mitglieder hinzufügen
-    while IFS= read -r username; do
-        echo "member: uid=${username},ou=people,dc=springframework,dc=org"
+    while IFS= read -r username || [[ -n "$username" ]]; do # Jede Zeile lesen auch wenn sie nicht mit \n enden
+        # Entfernen von führenden und nachfolgenden Leerzeichen
+        username=$(echo "$username" | xargs)
+        if [ -n "$username" ]; then  # Nur wenn der Benutzername nicht leer ist
+            echo "member: uid=${username},ou=people,dc=springframework,dc=org"
+        fi
     done < "$input_file"
 
 } > "$output_file"


### PR DESCRIPTION
# Beschreibung:

- PR für interne Aufgabe um wahlspezifische User auf den Umgebungen hinterlegen zu können oder den Weg über den zentralen LDAP-Service gehen zu müssen
  - management#65
- Bereitstellung eines Skriptes um das ldif-File zu erzeugen um die Daten dann manuell zu mergen
- Guide zum Vorgehen erstellt

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Dokumentation -->
### Dokumentation
- [x] Links geprüft
- [x] Texte auf Rechtschreibung und Grammatik geprüft

# Referenzen[^1]:

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new guide for updating embedded LDAP user data with step-by-step instructions and examples
  * Guide includes detailed commands and LDIF file examples for reference

* **New Features**
  * Added a command-line utility script for generating LDIF configuration files for LDAP servers from a usernames input file

<!-- end of auto-generated comment: release notes by coderabbit.ai -->