### PR TITLE
vue-component-type-helpers upgraded to version 3.1.3

### DIFF
--- a/wls-gui-wahllokalsystem/package-lock.json
+++ b/wls-gui-wahllokalsystem/package-lock.json
@@ -11132,8 +11132,8 @@
       "license": "MIT"
     },
     "node_modules/vue-component-type-helpers": {
-      "version": "3.1.2",
-      "integrity": "sha512-ch3/SKBtxdZq18vsEntiGCdSszCRNfhX5QaTxjSacCAXLlNQRXfXo+ANjoQEYJMsJOJy1/vHF6Tkc4s85MS+zw==",
+      "version": "3.1.3",
+      "integrity": "sha512-V1dOD8XYfstOKCnXbWyEJIrhTBMwSyNjv271L1Jlx9ExpNlCSuqOs3OdWrGJ0V544zXufKbcYabi/o+gK8lyfQ==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
# Beschreibung:

* vue-component-type-helpers upgraded to version 3.1.3 in package-lock.json
