### PR TITLE
215 Initialisierung der Daten zum Beginn der Stimmabgabe - kein Toast bei Initialisierungsfehler

### DIFF
--- a/wls-gui-wahllokalsystem/src/stores/wahlbezirkStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/wahlbezirkStore.ts
@@ -78,7 +78,8 @@ export const useWahlbezirkStore = defineStore(storeID, () => {
     },
     initEroeffnungsuhrzeit: async function initEroeffnungsuhrzeit() {
       const eroeffnungsuhrzeit = await getEroeffnungsuhrzeit(
-        currentUserWahlbezirkID.value
+        currentUserWahlbezirkID.value,
+        false
       );
       eroeffnungsuhrzeitState.value.eroeffnungsuhrzeit = eroeffnungsuhrzeit
         ? new Date(eroeffnungsuhrzeit)

--- a/wls-gui-wahllokalsystem/tests/stores/wahlbezirkStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/wahlbezirkStore.spec.ts
@@ -399,6 +399,11 @@ describe("wahlbezirkStore.ts", () => {
 
   describe("initEroeffnungsuhrzeit", () => {
     it("should_setCurrentAndSavedEroeffnungsuhrzeitWithDate_when_serviceReturnsValue", async () => {
+      const userWahlbezirkID = "wahlbezirkID";
+      useUserStore().setUser(
+        prepareUser().wahlbezirkID(userWahlbezirkID).build()
+      );
+
       unitUnderTest.eroeffnungsuhrzeitState.eroeffnungsuhrzeitSent = undefined;
       unitUnderTest.eroeffnungsuhrzeitState.eroeffnungsuhrzeit = undefined;
 
@@ -425,6 +430,10 @@ describe("wahlbezirkStore.ts", () => {
         unitUnderTest.eroeffnungsuhrzeitState.eroeffnungsuhrzeit,
         "should not be same object cause both data are handled independently"
       ).not.toBe(unitUnderTest.eroeffnungsuhrzeitState.eroeffnungsuhrzeitSent);
+      expect(mockDefinitions.getEroeffnungsuhrzeit).toHaveBeenCalledWith(
+        userWahlbezirkID,
+        false
+      );
     });
 
     it("should_setCurrentAndSavedEroeffnungsuhrzeitWithUndefined_when_serviceReturnsNull", async () => {


### PR DESCRIPTION
# Beschreibung:

- Der ErrorToast, im Falle eines Fehler bei der Initialisierung der Eröffnungsuhrzeit, wurde deaktiviert

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [X] Doku aktualisiert - kein Update erforderlich
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [X] Unit-Tests gepflegt
- [X] Texte auf Rechtschreibung und Grammatik geprüft - keine Texte verfasst

# Referenzen[^1]:

Verwandt mit Issue #

Closes #2125

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tests to verify correct function parameters are passed during initialization.

* **Refactor**
  * Adjusted internal function invocation parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->