### PR TITLE
2161 204 als antwort bei get urnenwahlschliessungsuhrzeit festhalten und im fe ausimplementieren

### DIFF
--- a/wls-gui-wahllokalsystem/src/composables/wahlhandlung/wahlvorbereitungService.ts
+++ b/wls-gui-wahllokalsystem/src/composables/wahlhandlung/wahlvorbereitungService.ts
@@ -51,11 +51,19 @@ export function useWahlvorbereitungService() {
   async function getUrnenwahlSchliessungsUhrzeit(
     wahlbezirkID: string,
     sendNotification = true
-  ): Promise<UrnenwahlSchliessungsuhrzeit> {
+  ): Promise<UrnenwahlSchliessungsuhrzeit | null> {
     try {
-      return await urnenwahlSchliessungsUhrzeitControllerAPI
-        .getUrnenwahlSchliessungsUhrzeit(wahlbezirkID)
-        .then((response) => toUrnenwahlSchliessungsuhrzeitModel(response.data));
+      const response =
+        await urnenwahlSchliessungsUhrzeitControllerAPI.getUrnenwahlSchliessungsUhrzeit(
+          wahlbezirkID
+        );
+      const responseData = getNullOn204OrElseResponseData(response);
+
+      if (!responseData) {
+        return null;
+      }
+
+      return toUrnenwahlSchliessungsuhrzeitModel(responseData);
     } catch (error) {
       if (sendNotification) {
         userNotificationService.addNotification(

--- a/wls-gui-wahllokalsystem/src/stores/wahlbezirkStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/wahlbezirkStore.ts
@@ -135,12 +135,14 @@ export const useWahlbezirkStore = defineStore(storeID, () => {
           currentUserWahlbezirkID.value,
           false
         );
-      schliessungsuhrzeitState.value.schliessungsuhrzeit = new Date(
-        urnenwahlSchliessungsuhrzeit.schliessungsuhrzeit
-      );
-      schliessungsuhrzeitState.value.schliessungsuhrzeitSent = new Date(
-        urnenwahlSchliessungsuhrzeit.schliessungsuhrzeit
-      );
+      schliessungsuhrzeitState.value.schliessungsuhrzeit =
+        urnenwahlSchliessungsuhrzeit
+          ? new Date(urnenwahlSchliessungsuhrzeit.schliessungsuhrzeit)
+          : undefined;
+      schliessungsuhrzeitState.value.schliessungsuhrzeitSent =
+        urnenwahlSchliessungsuhrzeit
+          ? new Date(urnenwahlSchliessungsuhrzeit.schliessungsuhrzeit)
+          : undefined;
     },
   };
 

--- a/wls-gui-wahllokalsystem/tests/composables/wahlhandlung/wahlvorbereitungService.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/wahlhandlung/wahlvorbereitungService.spec.ts
@@ -131,6 +131,17 @@ describe("wahlvorbereitungService", () => {
       ).toHaveBeenCalledWith(mockedApiResponseData);
     });
 
+    it("should_returnNull_when_apiReturns204", async () => {
+      const wahlbezirkID = "wahlbezirkID";
+
+      mockDefinitions.getUrnenwahlSchliessungsUhrzeit.mockResolvedValue(
+        createAxiosResponse({ status: 204, data: {} })
+      );
+
+      const result = await getUrnenwahlSchliessungsUhrzeit(wahlbezirkID);
+      expect(result).toBeNull();
+    });
+
     it.each([true, false])(
       "should_throwErrorAndSendNotification=%b_when_apiCallFailedAndSendNotification",
       async (sendNotificationParameter) => {

--- a/wls-gui-wahllokalsystem/tests/stores/wahlbezirkStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/wahlbezirkStore.spec.ts
@@ -674,6 +674,27 @@ describe("wahlbezirkStore.ts", () => {
         mockDefinitions.getUrnenwahlSchliessungsUhrzeit
       ).toHaveBeenCalledWith(userWahlbezirkID, false);
     });
+
+    it("should_setUndefinedForSchliessungsuhrzeitAndSchliessungsuhrzeitSend_when_noSchliessungsuhrzeitIsGiven", async () => {
+      const userWahlbezirkID = "wahlbezirkID";
+      useUserStore().setUser(
+        prepareUser().wahlbezirkID(userWahlbezirkID).build()
+      );
+      unitUnderTest.schliessungsuhrzeitState.schliessungsuhrzeit = new Date();
+      unitUnderTest.schliessungsuhrzeitState.schliessungsuhrzeitSent =
+        new Date();
+
+      mockDefinitions.getUrnenwahlSchliessungsUhrzeit.mockReturnValue(null);
+
+      await unitUnderTest.schliessungsuhrzeitActions.initSchliessungsuhrzeit();
+
+      expect(
+        unitUnderTest.schliessungsuhrzeitState.schliessungsuhrzeit?.getTime()
+      ).toBeUndefined();
+      expect(
+        unitUnderTest.schliessungsuhrzeitState.schliessungsuhrzeitSent?.getTime()
+      ).toBeUndefined();
+    });
   });
 
   describe("sendSchliessungsuhrzeit", () => {

--- a/wls-wahlvorbereitung-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/rest/eroeffnungsuhrzeit/EroeffnungsUhrzeitController.java
+++ b/wls-wahlvorbereitung-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/rest/eroeffnungsuhrzeit/EroeffnungsUhrzeitController.java
@@ -3,6 +3,8 @@ package de.muenchen.oss.wahllokalsystem.wahlvorbereitungservice.rest.eroeffnungs
 import de.muenchen.oss.wahllokalsystem.wahlvorbereitungservice.rest.AbstractController;
 import de.muenchen.oss.wahllokalsystem.wahlvorbereitungservice.service.eroeffnungsuhrzeit.EroeffnungsUhrzeitService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
@@ -29,6 +31,10 @@ public class EroeffnungsUhrzeitController extends AbstractController {
             responses = {
                     @ApiResponse(
                             responseCode = "200", description = "Eroeffnungsuhrzeit erfolgreich gespeichert."
+                    ),
+                    @ApiResponse(
+                            responseCode = "204", description = "Keine Daten vorhanden",
+                            content = @Content(schema = @Schema())
                     ) }
     )
     @GetMapping("{wahlbezirkID}")

--- a/wls-wahlvorbereitung-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/rest/urnenwahlschliessungsuhrzeit/UrnenwahlSchliessungsUhrzeitController.java
+++ b/wls-wahlvorbereitung-service/src/main/java/de/muenchen/oss/wahllokalsystem/wahlvorbereitungservice/rest/urnenwahlschliessungsuhrzeit/UrnenwahlSchliessungsUhrzeitController.java
@@ -3,6 +3,8 @@ package de.muenchen.oss.wahllokalsystem.wahlvorbereitungservice.rest.urnenwahlsc
 import de.muenchen.oss.wahllokalsystem.wahlvorbereitungservice.rest.AbstractController;
 import de.muenchen.oss.wahllokalsystem.wahlvorbereitungservice.service.urnenwahlschliessungsuhrzeit.UrnenwahlSchliessungsUhrzeitService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
@@ -29,6 +31,10 @@ public class UrnenwahlSchliessungsUhrzeitController extends AbstractController {
             responses = {
                     @ApiResponse(
                             responseCode = "200", description = "Urnenwahlschliessungsuhrzeit erfolgreich zurückgegeben."
+                    ),
+                    @ApiResponse(
+                            responseCode = "204", description = "Keine Daten vorhanden",
+                            content = @Content(schema = @Schema())
                     ) }
     )
     @GetMapping("{wahlbezirkID}")


### PR DESCRIPTION
# Beschreibung:

- für die Schliessungsuhrzeit fehlte noch das 204 Handling. Das wurde ergänzt

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Doku aktualisiert - kein Update notwendig
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] Unit-Tests gepflegt
- [X] Texte auf Rechtschreibung und Grammatik geprüft - keine Texte verfasst

# Referenzen[^1]:

Verwandt mit Issue #

Closes #2161

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing closing time information. The system now properly clears time values when data is unavailable instead of retaining previous values.

* **Documentation**
  * Updated API documentation to accurately reflect all possible response types including empty data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->