### PR TITLE
update vue-component-type-helpers to 3.1.5

### DIFF
--- a/wls-gui-wahllokalsystem/package-lock.json
+++ b/wls-gui-wahllokalsystem/package-lock.json
@@ -11153,8 +11153,8 @@
       "license": "MIT"
     },
     "node_modules/vue-component-type-helpers": {
-      "version": "3.1.4",
-      "integrity": "sha512-Uws7Ew1OzTTqHW8ZVl/qLl/HB+jf08M0NdFONbVWAx0N4gMLK8yfZDgeB77hDnBmaigWWEn5qP8T9BG59jIeyQ==",
+      "version": "3.1.5",
+      "integrity": "sha512-7V3yJuNWW7/1jxCcI1CswnpDsvs02Qcx/N43LkV+ZqhLj2PKj50slUflHAroNkN4UWiYfzMUUUXiNuv9khmSpQ==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
# Beschreibung:

Damit die Frontendbuild wieder durchlaufen in es keine Fehler gibt weil die Version nicht korrekt ist

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

# Referenzen[^1]:

Verwandt mit Issue #

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
