### PR TITLE
1924 Wahlbriefzulassung - Tabellendesign anpassen

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/wahlhandlung/beanstandeteWahlbriefe/TheBeanstandeteWahlbriefeBeschlussergebnis.vue
+++ b/wls-gui-wahllokalsystem/src/components/wahlhandlung/beanstandeteWahlbriefe/TheBeanstandeteWahlbriefeBeschlussergebnis.vue
@@ -54,7 +54,7 @@
             ) in beanstandeteWahlbriefeGetter.summenZurueckweisungsgruende"
             :key="index"
           >
-            <td style="text-indent: 20px">
+            <td style="padding-left: 30px">
               {{ zurueckweisungsgrundEnumToDisplayString(beanstandung.grund) }}
             </td>
             <td

--- a/wls-gui-wahllokalsystem/tests/components/wahlhandlung/beanstandeteWahlbriefe/__snapshots__/TheBeanstandeteWahlbriefeBeschlussergebnis/visual logic/should_renderWahlbriefZulassungBeschlussergebnis_when_componentIsMountedWithBeanstandeteWahlbriefe.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlhandlung/beanstandeteWahlbriefe/__snapshots__/TheBeanstandeteWahlbriefeBeschlussergebnis/visual logic/should_renderWahlbriefZulassungBeschlussergebnis_when_componentIsMountedWithBeanstandeteWahlbriefe.html
@@ -45,57 +45,57 @@
               <td></td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Wahlschein ungültig laut Liste</td>
+              <td style="padding-left: 30px;">Wahlschein ungültig laut Liste</td>
               <td class="text-center">0</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Kein Original-Wahlschein</td>
+              <td style="padding-left: 30px;">Kein Original-Wahlschein</td>
               <td class="text-center">1</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Unterschrift auf Wahlschein fehlt</td>
+              <td style="padding-left: 30px;">Unterschrift auf Wahlschein fehlt</td>
               <td class="text-center">0</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Stimmzettelumschlag fehlt</td>
+              <td style="padding-left: 30px;">Stimmzettelumschlag fehlt</td>
               <td class="text-center">0</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Lose Stimmzettel</td>
+              <td style="padding-left: 30px;">Lose Stimmzettel</td>
               <td class="text-center">0</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Wahlbrief und Stimmzettelumschlag offen</td>
+              <td style="padding-left: 30px;">Wahlbrief und Stimmzettelumschlag offen</td>
               <td class="text-center">0</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Wahlscheine ungleich Stimmzettelumschläge</td>
+              <td style="padding-left: 30px;">Wahlscheine ungleich Stimmzettelumschläge</td>
               <td class="text-center">0</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Nicht-amtlicher Stimmzettelumschlag</td>
+              <td style="padding-left: 30px;">Nicht-amtlicher Stimmzettelumschlag</td>
               <td class="text-center">0</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Stimmzettelumschlag gefährdet Wahlgeheimnis</td>
+              <td style="padding-left: 30px;">Stimmzettelumschlag gefährdet Wahlgeheimnis</td>
               <td class="text-center">0</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Gegenstand im Stimmzettelumschlag</td>
+              <td style="padding-left: 30px;">Gegenstand im Stimmzettelumschlag</td>
               <td class="text-center">0</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Für diese Wahl nicht wahlberechtigt</td>
+              <td style="padding-left: 30px;">Für diese Wahl nicht wahlberechtigt</td>
               <td class="text-center">0</td>
               <td class="text-center">0</td>
             </tr>

--- a/wls-gui-wahllokalsystem/tests/components/wahlhandlung/beanstandeteWahlbriefe/__snapshots__/TheBeanstandeteWahlbriefeBeschlussergebnis/visual logic/should_renderWahlbriefZulassungBeschlussergebnis_when_componentIsMountedWithoutBeanstandeteWahlbriefe.html
+++ b/wls-gui-wahllokalsystem/tests/components/wahlhandlung/beanstandeteWahlbriefe/__snapshots__/TheBeanstandeteWahlbriefeBeschlussergebnis/visual logic/should_renderWahlbriefZulassungBeschlussergebnis_when_componentIsMountedWithoutBeanstandeteWahlbriefe.html
@@ -41,47 +41,47 @@
               <td></td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Wahlschein ungültig laut Liste</td>
+              <td style="padding-left: 30px;">Wahlschein ungültig laut Liste</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Kein Original-Wahlschein</td>
+              <td style="padding-left: 30px;">Kein Original-Wahlschein</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Unterschrift auf Wahlschein fehlt</td>
+              <td style="padding-left: 30px;">Unterschrift auf Wahlschein fehlt</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Stimmzettelumschlag fehlt</td>
+              <td style="padding-left: 30px;">Stimmzettelumschlag fehlt</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Lose Stimmzettel</td>
+              <td style="padding-left: 30px;">Lose Stimmzettel</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Wahlbrief und Stimmzettelumschlag offen</td>
+              <td style="padding-left: 30px;">Wahlbrief und Stimmzettelumschlag offen</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Wahlscheine ungleich Stimmzettelumschläge</td>
+              <td style="padding-left: 30px;">Wahlscheine ungleich Stimmzettelumschläge</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Nicht-amtlicher Stimmzettelumschlag</td>
+              <td style="padding-left: 30px;">Nicht-amtlicher Stimmzettelumschlag</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Stimmzettelumschlag gefährdet Wahlgeheimnis</td>
+              <td style="padding-left: 30px;">Stimmzettelumschlag gefährdet Wahlgeheimnis</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Gegenstand im Stimmzettelumschlag</td>
+              <td style="padding-left: 30px;">Gegenstand im Stimmzettelumschlag</td>
               <td class="text-center">0</td>
             </tr>
             <tr>
-              <td style="text-indent: 20px;">Für diese Wahl nicht wahlberechtigt</td>
+              <td style="padding-left: 30px;">Für diese Wahl nicht wahlberechtigt</td>
               <td class="text-center">0</td>
             </tr>
           </tbody>


### PR DESCRIPTION
# Beschreibung:

Einheitliche Einrückung auch nach Zeilenumbruch

## Definition of Done (DoD):

### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Doku aktualisiert
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] Unit-Tests gepflegt
- [x] Texte auf Rechtschreibung und Grammatik geprüft

# Referenzen[^1]:

Closes #1924 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated table row indentation styling to improve visual alignment and spacing consistency in the interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->