### PR TITLE
#2185 add mbw stapel documentation

### DIFF
--- a/docs/src/about/index.md
+++ b/docs/src/about/index.md
@@ -287,6 +287,15 @@ Stapel für die **Oberbürgermeisterwahl**:
   | `C_Gueltig`          | Bedenkliche Stimmzettel, die für gültig erklärt wurden        |           |
   | `C_Ungueltig`        | Bedenkliche Stimmzettel, die für ungültig erklärt wurden      |           |
 
+Stapel für die **Migrationsbeiratswahl**:
+
+  | Stapel        | Beschreibung                                                    | Anmerkung                 |
+  |---------------|-----------------------------------------------------------------|---------------------------|
+  | `A`           | Zweifelsfrei gültige Stimmen: unverändert                       | mit Listenkreuz           |
+  | `B`           | Zweifelsfrei gültige Stimmen: verändert, nur ein Wahlvorschlag  | mit oder ohne Listenkreuz |
+  | `B_C`         | Zweifelsfrei gültige Stimmen: verändert, mehrere Wahlvorschläge | Kandidatenstimmen         |
+  | `D_Ungueltig` | Leere und ungekennzeichnete Stimmzettel                         |                           |
+
 #### Nach der Auszählung
 
 📃 **UseCase: `Kontrolle, Übermittlung und Druck der Schnellmeldung`**


### PR DESCRIPTION
# Beschreibung:

- stapel der MBW in die doku aufgenommen

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Dokumentation -->
### Dokumentation
- [x] Links geprüft
- [x] Texte auf Rechtschreibung und Grammatik geprüft

# Referenzen[^1]:

Closes #2185 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for Migrationsbeiratswahl (Migration Advisory Council Election) counting stacks, including definitions for stacks A, B, B_C, and D_Ungueltig with descriptions and notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->