### PR TITLE
#2373 kandidaten für wahlvorschlag 1 der mbw ergänzt

### DIFF
--- a/wls-eai-service/src/main/resources/db/dummydata/h2/V16_0__addMoreKandidatenForMBWWahlvorschlag1.sql
+++ b/wls-eai-service/src/main/resources/db/dummydata/h2/V16_0__addMoreKandidatenForMBWWahlvorschlag1.sql
@@ -1,0 +1,123 @@
+-- ====================================
+-- WAHLBEZIRK 1 (UWB)
+-- ====================================
+
+-- Hinzufügen von 27 weiteren Kandidaten zu Wahlvorschlag 1
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('59a10d93-1970-4855-af6d-ad6bba377471', 'Anna Schmidt', 4,false, 1,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('08003d18-3141-492f-b126-2e7ba9083666', 'Max Müller', 5,false, 1,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('ce077fb1-91d5-47b4-8412-8952c2bd4224', 'Emilia Fischer', 6,false, 1,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('9fdd61e7-4c40-4ca5-b0bd-1cbbd0251a14', 'Ben Weber', 7,false, 1,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('5e7430b0-de5b-41e8-9df9-4bbbf7e3d2f3', 'Lena Wagner', 8,false, 1,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('6bf27213-a40d-4ef9-bb80-3f0653aee843', 'Paul Huber', 9,false, 2,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('b52da5fe-2819-4565-88bb-d412f9857c2a', 'Laura Schäfer', 10,false, 2,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('cf32c985-1a54-41b8-820c-480e25d4198d', 'Lukas Becker', 11,false, 2,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('e7b623e5-5d8a-44b7-a832-18ad76b0a825', 'Marie Richter', 12,false, 2,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('e669cd8c-031a-44ba-827d-975048417213', 'David Neumann', 13,false, 2,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('d63a79a3-b89c-4806-86e1-9f194881832f', 'Sophia Bauer', 14,false, 2,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('30f9a17c-a267-45ac-9391-90f6974384d9', 'Leon Wolf', 15,false, 2,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('131b6ce4-d8a6-4b8a-a2b7-ab4e66d969da', 'Hannah König', 16,false, 2,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('1cc9e13d-48de-482f-bae9-8f5fe8f6932c', 'Jonas Keller', 17,false, 3,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('eb29c5bd-e1a3-4260-971f-36959a0e95e4', 'Emily Hofmann', 18,false, 3,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('13036dd1-0972-461d-ace6-c52396c37b49', 'Finn Schäfer', 19,false, 3,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('cb21abe5-5b8d-4306-9068-98cab077e0ac', 'Mia Krause', 20,false, 3,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('6f9a2b57-aaf4-40fc-b5a1-1c7bda2813ac', 'Leonhard Vogel', 21,false, 3,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('06aa779a-c46b-4583-bd58-4f21d9abe039', 'Lina Frank', 22,false, 3,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('724ce133-db1b-4a35-8cbc-157de0aecc4c', 'Marlene Lang', 23,false, 3,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('8e195493-1acc-442c-a48a-0f28fbf39cb2', 'Erik Maier', 24,false, 3,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('b722ecc9-f7a9-401e-ab72-d00b447e5ae6', 'Hannah Brandt', 25,false, 4,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('a214b81f-a916-4132-a848-5a1021220189', 'Mia Schulz', 26,false, 4,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('16e3c6a8-c6e2-4634-a234-0fe91c73960a', 'Oliver Schmitt', 27,false, 4,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('c4c14954-d4a3-4759-9d23-04385e9deaa4', 'Johanna Krüger', 28,false, 4,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('39b19364-5f91-4a01-a504-43bf6674f0a6', 'Niklas Fuchs', 29,false, 4,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('8eac48fa-de84-4257-b6fb-65b375c504c3', 'Clara Busch', 30,false, 4,false, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+
+
+
+-- ====================================
+-- WAHLBEZIRK 2 (BWB)
+-- (verwendet die gleichen Kandidaten wie UWB)
+-- ====================================
+
+-- Hinzufügen von 27 weiteren Kandidaten zu Wahlvorschlag 1
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('fbb4a48e-54a9-4b3f-b2c6-797a1a5787b7', 'Anna Schmidt', 4,false, 1,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('5c0175c5-dabb-44db-9935-d2b058dca4a1', 'Max Müller', 5,false, 1,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('a3fdbc0b-1b51-4f61-af70-1d4cd15c7af8', 'Emilia Fischer', 6,false, 1,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('07242b2d-fc22-4cce-8e00-90b2cbf21285', 'Ben Weber', 7,false, 1,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('52b1796a-d135-4d4a-b24f-df2430d4f335', 'Lena Wagner', 8,false, 1,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('e7b2efe5-ece3-402e-ab7f-f2c84fbf1d89', 'Paul Huber', 9,false, 2,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('7b9837c6-db04-4a93-90db-305bc4af7c82', 'Laura Schäfer', 10,false, 2,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('c783979b-38c4-410e-90de-0ab402aedbfd', 'Lukas Becker', 11,false, 2,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('33473744-7380-4407-8bc4-6016334bb4e6', 'Marie Richter', 12,false, 2,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('781897b5-8363-4bb7-bc14-4ae23da9d1bc', 'David Neumann', 13,false, 2,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('d5f1c4e1-b0bc-4f1a-bc55-279d4fac05b7', 'Sophia Bauer', 14,false, 2,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('60affa58-71af-4768-9730-94cff60e1076', 'Leon Wolf', 15,false, 2,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('88affc81-32b9-4902-be4c-a9d6c8b59815', 'Hannah König', 16,false, 2,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('0428b01d-c068-4ce8-89db-29c155fc5057', 'Jonas Keller', 17,false, 3,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('18380a58-b4bf-4dfd-91c4-a96d6c91a758', 'Emily Hofmann', 18,false, 3,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('296b7e99-56c1-4a87-b62a-b152bef4c7ab', 'Finn Schäfer', 19,false, 3,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('5a3dd138-2a1b-49cf-844a-8d9a60607703', 'Mia Krause', 20,false, 3,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('845da933-fa90-4f13-988d-348ba0c2e228', 'Leonhard Vogel', 21,false, 3,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('c3b79acd-e5cc-499d-bbc7-093305b6f04e', 'Lina Frank', 22,false, 3,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('5d80ddbb-2a1c-4772-b51d-c56c8cee1a6d', 'Marlene Lang', 23,false, 3,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('52b7b6da-dc17-4721-a401-444db0e1c818', 'Erik Maier', 24,false, 3,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('dccdc734-7e16-4846-a3fd-00e15d69d0c1', 'Hannah Brandt', 25,false, 4,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('5c3bab51-2bc6-43f8-a129-1ab6343fc19f', 'Mia Schulz', 26,false, 4,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('10c4a163-6636-40f8-a6f1-1539c3905f94', 'Oliver Schmitt', 27,false, 4,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('ea83cd99-4c32-47b0-83e3-358d8fc09251', 'Johanna Krüger', 28,false, 4,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('6194d458-0076-4fea-a57d-f59838d35c6f', 'Niklas Fuchs', 29,false, 4,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('1c1a5fcc-b33e-45c0-9863-171297cfe09e', 'Clara Busch', 30,false, 4,false, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+

--- a/wls-eai-service/src/main/resources/db/dummydata/oracle/V16_0__addMoreKandidatenForMBWWahlvorschlag1.sql
+++ b/wls-eai-service/src/main/resources/db/dummydata/oracle/V16_0__addMoreKandidatenForMBWWahlvorschlag1.sql
@@ -1,0 +1,123 @@
+-- ====================================
+-- WAHLBEZIRK 1 (UWB)
+-- ====================================
+
+-- Hinzufügen von 27 weiteren Kandidaten zu Wahlvorschlag 1
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('59a10d93-1970-4855-af6d-ad6bba377471', 'Anna Schmidt', 4, 0, 1, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('08003d18-3141-492f-b126-2e7ba9083666', 'Max Müller', 5, 0, 1, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('ce077fb1-91d5-47b4-8412-8952c2bd4224', 'Emilia Fischer', 6, 0, 1, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('9fdd61e7-4c40-4ca5-b0bd-1cbbd0251a14', 'Ben Weber', 7, 0, 1, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('5e7430b0-de5b-41e8-9df9-4bbbf7e3d2f3', 'Lena Wagner', 8, 0, 1, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('6bf27213-a40d-4ef9-bb80-3f0653aee843', 'Paul Huber', 9, 0, 2, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('b52da5fe-2819-4565-88bb-d412f9857c2a', 'Laura Schäfer', 10, 0, 2, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('cf32c985-1a54-41b8-820c-480e25d4198d', 'Lukas Becker', 11, 0, 2, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('e7b623e5-5d8a-44b7-a832-18ad76b0a825', 'Marie Richter', 12, 0, 2, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('e669cd8c-031a-44ba-827d-975048417213', 'David Neumann', 13, 0, 2, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('d63a79a3-b89c-4806-86e1-9f194881832f', 'Sophia Bauer', 14, 0, 2, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('30f9a17c-a267-45ac-9391-90f6974384d9', 'Leon Wolf', 15, 0, 2, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('131b6ce4-d8a6-4b8a-a2b7-ab4e66d969da', 'Hannah König', 16, 0, 2, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('1cc9e13d-48de-482f-bae9-8f5fe8f6932c', 'Jonas Keller', 17, 0, 3, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('eb29c5bd-e1a3-4260-971f-36959a0e95e4', 'Emily Hofmann', 18, 0, 3, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('13036dd1-0972-461d-ace6-c52396c37b49', 'Finn Schäfer', 19, 0, 3, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('cb21abe5-5b8d-4306-9068-98cab077e0ac', 'Mia Krause', 20, 0, 3, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('6f9a2b57-aaf4-40fc-b5a1-1c7bda2813ac', 'Leonhard Vogel', 21, 0, 3, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('06aa779a-c46b-4583-bd58-4f21d9abe039', 'Lina Frank', 22, 0, 3, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('724ce133-db1b-4a35-8cbc-157de0aecc4c', 'Marlene Lang', 23, 0, 3, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('8e195493-1acc-442c-a48a-0f28fbf39cb2', 'Erik Maier', 24, 0, 3, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('b722ecc9-f7a9-401e-ab72-d00b447e5ae6', 'Hannah Brandt', 25, 0, 4, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('a214b81f-a916-4132-a848-5a1021220189', 'Mia Schulz', 26, 0, 4, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('16e3c6a8-c6e2-4634-a234-0fe91c73960a', 'Oliver Schmitt', 27, 0, 4, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('c4c14954-d4a3-4759-9d23-04385e9deaa4', 'Johanna Krüger', 28, 0, 4, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('39b19364-5f91-4a01-a504-43bf6674f0a6', 'Niklas Fuchs', 29, 0, 4, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('8eac48fa-de84-4257-b6fb-65b375c504c3', 'Clara Busch', 30, 0, 4, 0, 'e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b');
+
+
+
+-- ====================================
+-- WAHLBEZIRK 2 (BWB)
+-- (verwendet die gleichen Kandidaten wie UWB)
+-- ====================================
+
+-- Hinzufügen von 27 weiteren Kandidaten zu Wahlvorschlag 1
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('fbb4a48e-54a9-4b3f-b2c6-797a1a5787b7', 'Anna Schmidt', 4, 0, 1, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('5c0175c5-dabb-44db-9935-d2b058dca4a1', 'Max Müller', 5, 0, 1, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('a3fdbc0b-1b51-4f61-af70-1d4cd15c7af8', 'Emilia Fischer', 6, 0, 1, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('07242b2d-fc22-4cce-8e00-90b2cbf21285', 'Ben Weber', 7, 0, 1, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('52b1796a-d135-4d4a-b24f-df2430d4f335', 'Lena Wagner', 8, 0, 1, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('e7b2efe5-ece3-402e-ab7f-f2c84fbf1d89', 'Paul Huber', 9, 0, 2, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('7b9837c6-db04-4a93-90db-305bc4af7c82', 'Laura Schäfer', 10, 0, 2, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('c783979b-38c4-410e-90de-0ab402aedbfd', 'Lukas Becker', 11, 0, 2, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('33473744-7380-4407-8bc4-6016334bb4e6', 'Marie Richter', 12, 0, 2, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('781897b5-8363-4bb7-bc14-4ae23da9d1bc', 'David Neumann', 13, 0, 2, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('d5f1c4e1-b0bc-4f1a-bc55-279d4fac05b7', 'Sophia Bauer', 14, 0, 2, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('60affa58-71af-4768-9730-94cff60e1076', 'Leon Wolf', 15, 0, 2, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('88affc81-32b9-4902-be4c-a9d6c8b59815', 'Hannah König', 16, 0, 2, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('0428b01d-c068-4ce8-89db-29c155fc5057', 'Jonas Keller', 17, 0, 3, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('18380a58-b4bf-4dfd-91c4-a96d6c91a758', 'Emily Hofmann', 18, 0, 3, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('296b7e99-56c1-4a87-b62a-b152bef4c7ab', 'Finn Schäfer', 19, 0, 3, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('5a3dd138-2a1b-49cf-844a-8d9a60607703', 'Mia Krause', 20, 0, 3, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('845da933-fa90-4f13-988d-348ba0c2e228', 'Leonhard Vogel', 21, 0, 3, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('c3b79acd-e5cc-499d-bbc7-093305b6f04e', 'Lina Frank', 22, 0, 3, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('5d80ddbb-2a1c-4772-b51d-c56c8cee1a6d', 'Marlene Lang', 23, 0, 3, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('52b7b6da-dc17-4721-a401-444db0e1c818', 'Erik Maier', 24, 0, 3, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('dccdc734-7e16-4846-a3fd-00e15d69d0c1', 'Hannah Brandt', 25, 0, 4, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('5c3bab51-2bc6-43f8-a129-1ab6343fc19f', 'Mia Schulz', 26, 0, 4, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('10c4a163-6636-40f8-a6f1-1539c3905f94', 'Oliver Schmitt', 27, 0, 4, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('ea83cd99-4c32-47b0-83e3-358d8fc09251', 'Johanna Krüger', 28, 0, 4, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('6194d458-0076-4fea-a57d-f59838d35c6f', 'Niklas Fuchs', 29, 0, 4, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+INSERT INTO Kandidat (id, name, listenposition, direktkandidat, tabellenSpalteInNiederschrift, einzelbewerber, wahlvorschlagId)
+VALUES ('1c1a5fcc-b33e-45c0-9863-171297cfe09e', 'Clara Busch', 30, 0, 4, 0, 'a5b6c7d8-e9f0-4a1b-2c3d-4e5f6a7b8c9e');
+


### PR DESCRIPTION
# Beschreibung:

- wahlvorschlag 1 hat +27 kandidaten erhalten, sodass es insgesamt 30 sind

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] flyway daten ergänzt

# Referenzen[^1]:

Closes #2373 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended test data infrastructure with additional candidate records for electoral voting districts, including updated database migration scripts to ensure consistent test data across H2 and Oracle database environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->