### PR TITLE
add adr link to adr for gender sensitive language to pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@
 ### Dokumentation
 - [ ] Links geprüft
 - [ ] Texte auf Rechtschreibung und Grammatik geprüft
-- [ ] Texte auf [gendergerechte Sprache](gender-sensitive-language) geprüft
+- [ ] Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft
 
 <!-- Frontend -->
 ### Frontend
@@ -29,7 +29,7 @@
   - [UI/UX-Adrs][ui-ux-adrs-link]
 - [ ] Unit-Tests gepflegt
 - [ ] Texte auf Rechtschreibung und Grammatik geprüft
-- [ ] Texte auf [gendergerechte Sprache](gender-sensitive-language) geprüft
+- [ ] Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft
 
 # Referenzen[^1]:
 
@@ -42,4 +42,4 @@ Closes #
 [naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
 [fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
 [ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
-[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language.html
+[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@
 ### Dokumentation
 - [ ] Links geprüft
 - [ ] Texte auf Rechtschreibung und Grammatik geprüft
-- [ ] Texte auf gendergerechte Sprache geprüft
+- [ ] Texte auf [gendergerechte Sprache](gender-sensitive-language) geprüft
 
 <!-- Frontend -->
 ### Frontend
@@ -29,7 +29,7 @@
   - [UI/UX-Adrs][ui-ux-adrs-link]
 - [ ] Unit-Tests gepflegt
 - [ ] Texte auf Rechtschreibung und Grammatik geprüft
-- [ ] Texte auf gendergerechte Sprache geprüft
+- [ ] Texte auf [gendergerechte Sprache](gender-sensitive-language) geprüft
 
 # Referenzen[^1]:
 
@@ -42,3 +42,4 @@ Closes #
 [naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
 [fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
 [ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
+[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language.html


### PR DESCRIPTION
# Beschreibung:

- Link zum Gender-ADR in PR-Template bei den entsprechenden DoDs ergänzt

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

ausprobiert, indem ich das neue PR-Template hier eingefügt hatte

<!-- Dokumentation -->
### Dokumentation
- [x] Links geprüft
- [x] Texte auf Rechtschreibung und Grammatik geprüft
- [x] Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft

<!-- Frontend -->
### Frontend
- [x] Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft
  - zu Testzwecken drin

# Referenzen[^1]:

Verwandt mit Issue #

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language