### PR TITLE
BWB Wahlvorbereitung: Fix fehlendes Handling von 204 Response und fehlendes Setzen von WorkflowState

### DIFF
--- a/wls-gui-wahllokalsystem/src/composables/wahlhandlung/wahlvorbereitungMapper.ts
+++ b/wls-gui-wahllokalsystem/src/composables/wahlhandlung/wahlvorbereitungMapper.ts
@@ -82,7 +82,7 @@ export function useWahlvorbereitungMapper() {
     briefwahlvorbereitungDTO: BriefwahlvorbereitungDTO
   ): Wahlvorbereitung {
     const urnenAnzahlModel =
-      briefwahlvorbereitungDTO.urnenAnzahl?.map((wahlurneDTO) =>
+      briefwahlvorbereitungDTO?.urnenAnzahl?.map((wahlurneDTO) =>
         _toWahlurneModel(wahlurneDTO)
       ) ?? [];
     return {

--- a/wls-gui-wahllokalsystem/src/composables/wahlhandlung/wahlvorbereitungMapper.ts
+++ b/wls-gui-wahllokalsystem/src/composables/wahlhandlung/wahlvorbereitungMapper.ts
@@ -82,7 +82,7 @@ export function useWahlvorbereitungMapper() {
     briefwahlvorbereitungDTO: BriefwahlvorbereitungDTO
   ): Wahlvorbereitung {
     const urnenAnzahlModel =
-      briefwahlvorbereitungDTO?.urnenAnzahl?.map((wahlurneDTO) =>
+      briefwahlvorbereitungDTO.urnenAnzahl?.map((wahlurneDTO) =>
         _toWahlurneModel(wahlurneDTO)
       ) ?? [];
     return {

--- a/wls-gui-wahllokalsystem/src/composables/wahlhandlung/wahlvorbereitungService.ts
+++ b/wls-gui-wahllokalsystem/src/composables/wahlhandlung/wahlvorbereitungService.ts
@@ -211,9 +211,21 @@ export function useWahlvorbereitungService() {
     sendNotification = true
   ): Promise<Wahlvorbereitung> {
     try {
-      return await briefwahlvorbereitungControllerAPI
-        .getBriefwahlvorbereitung(wahlbezirkID)
-        .then((response) => toBriefwahlvorbereitungModel(response.data));
+      const response =
+        await briefwahlvorbereitungControllerAPI.getBriefwahlvorbereitung(
+          wahlbezirkID
+        );
+      const responseData = getNullOn204OrElseResponseData(response);
+      if (responseData) {
+        useWorkflowStore().isWahlumgebungErfasst = true;
+        return toBriefwahlvorbereitungModel(responseData);
+      } else {
+        return {
+          urnenAnzahl: [],
+          wahlbezirkID: wahlbezirkID,
+          urneVersiegelt: false,
+        };
+      }
     } catch (error) {
       if (sendNotification) {
         userNotificationService.addNotification(
@@ -242,6 +254,7 @@ export function useWahlvorbereitungService() {
         "Briefwahlvorbereitung erfolgreich gespeichert.",
         UserNotificationCategoryEnum.SUCCESS
       );
+      useWorkflowStore().isWahlumgebungErfasst = true;
     } catch (error) {
       userNotificationService.addNotification(
         "Speichern der Briefwahlvorbereitung fehlgeschlagen.",

--- a/wls-gui-wahllokalsystem/tests/composables/wahlhandlung/wahlvorbereitungService.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/wahlhandlung/wahlvorbereitungService.spec.ts
@@ -2,6 +2,7 @@ import type {
   UrnenwahlSchliessungsUhrzeitDTO,
   UrnenwahlSchliessungsUhrzeitWriteDTO,
 } from "@/api/wls-clients/generated-wahlvorbereitung-api";
+import type { Wahlvorbereitung } from "@/types/wahlhandlung/Wahlvorbereitung.ts";
 
 import { useAxiosTestDataFactory } from "@tests/utils/common/AxiosTestDataFactory.ts";
 import { useCommonTestDataFactory } from "@tests/utils/common/CommonTestDataFactory.ts";
@@ -465,7 +466,10 @@ describe("wahlvorbereitungService", () => {
         expectedBriefwahlvorbereitung
       );
       mockDefinitions.getBriefwahlvorbereitung.mockResolvedValue(
-        createBriefwahlvorbereitungDTO()
+        createAxiosResponse({
+          status: 200,
+          data: createBriefwahlvorbereitungDTO(),
+        })
       );
 
       const result = await getBriefwahlvorbereitung(wahlbezirkID);
@@ -491,6 +495,22 @@ describe("wahlvorbereitungService", () => {
           UserNotificationCategoryEnum.ERROR,
         ],
       ]);
+    });
+
+    it("should_returnDefaultWahlvorbereitung_when_apiReturns204", async () => {
+      const wahlbezirkID = "wahlbezirkID1";
+      mockDefinitions.getBriefwahlvorbereitung.mockReturnValue(
+        createAxiosResponse({ status: 204, data: "" })
+      );
+
+      const result = await getBriefwahlvorbereitung(wahlbezirkID);
+
+      const expectedResult: Wahlvorbereitung = {
+        wahlbezirkID,
+        urneVersiegelt: false,
+        urnenAnzahl: [],
+      };
+      expect(result).toStrictEqual(expectedResult);
     });
 
     it("should_notCallNotificationServiceAfterFailure_when_sendNotificationParameterIsFalse", async () => {


### PR DESCRIPTION
# Beschreibung:

- es wurde nicht beachtet dass 204 vom Service kommen kann womit dann eine Default-Antwort erzeugt werden muss. Der aktuelle Stand führte dazu dass bei Wahlvorebereitung die WahlbezirkID `undefined` war.
- Der Workflow-State für WahlvorbereitungErfasst wird jetzt immer beim Speichern gesetzt, und beim Lesen wenn die Antwort nicht 204 ist. Das Objekt wird nicht weiter untersucht weil nur valide Daten gespeichert und damit auch nur valide Daten gelesen werden können.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [X] ~Doku aktualisiert~ - kein Update erforderlich
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [X] Unit-Tests gepflegt
- [X] ~Texte auf Rechtschreibung und Grammatik geprüft~ - keine Texte verfasst
- [X] ~Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft~ - keine Texte verfasst

# Referenzen[^1]:

Closes #2415

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null safety for data handling to prevent undefined reference errors
  * API responses now return default values instead of null for better reliability
  * Enhanced handling of empty API responses (204 status code)

* **Refactor**
  * Simplified asynchronous logic using async/await syntax

<!-- end of auto-generated comment: release notes by coderabbit.ai -->