### PR TITLE
2414: Reverse Proxy als Startup Dependency für beide Gateways in Docker compose

### DIFF
--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -452,9 +452,6 @@ services:
 
   wls-auth-service-reverse-proxy:
     container_name: wls-auth-service-reverse-proxy
-    depends_on:
-      wls-auth-service:
-        condition: service_healthy
     image: nginx:alpine@sha256:1d13701a5f9f3fb01aaa88cef2344d65b6b5bf6b7d9fa4cf0dca557a8d7702ba
     ports:
       - "58100:443"

--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -276,6 +276,8 @@ services:
     depends_on:
       wls-auth-service:
         condition: service_healthy
+      wls-auth-service-reverse-proxy:
+        condition: service_healthy
     env_file:
       - .env
     ports:
@@ -313,6 +315,8 @@ services:
     image: ghcr.io/it-at-m/wahllokalsystem-wls-api-gateway:latest
     depends_on:
       wls-auth-service:
+        condition: service_healthy
+      wls-auth-service-reverse-proxy:
         condition: service_healthy
     env_file:
       - .env
@@ -448,6 +452,9 @@ services:
 
   wls-auth-service-reverse-proxy:
     container_name: wls-auth-service-reverse-proxy
+    depends_on:
+      wls-auth-service:
+        condition: service_healthy
     image: nginx:alpine@sha256:1d13701a5f9f3fb01aaa88cef2344d65b6b5bf6b7d9fa4cf0dca557a8d7702ba
     ports:
       - "58100:443"
@@ -455,6 +462,12 @@ services:
       - ./reverse-proxy-auth-service/ssl:/etc/nginx/ssl
       - ./reverse-proxy-auth-service/nginx.conf:/etc/nginx/conf.d/default.conf
     restart: always
+    healthcheck:
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider https://127.0.0.1:443/nginx-health --no-check-certificate || exit 1"]
 
 networks:
   internal:

--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -464,7 +464,7 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
-      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider https://127.0.0.1:443/nginx-health --no-check-certificate || exit 1"]
+      test: [ "CMD-SHELL", "curl -f --insecure https://localhost:443/nginx-health" ]
 
 networks:
   internal:

--- a/stack/docker-compose_build-local.yml
+++ b/stack/docker-compose_build-local.yml
@@ -312,6 +312,8 @@ services:
     depends_on:
       wls-auth-service:
         condition: service_healthy
+      wls-auth-service-reverse-proxy:
+        condition: service_healthy
     env_file:
       - .env
     ports:
@@ -352,6 +354,8 @@ services:
       dockerfile: Dockerfile
     depends_on:
       wls-auth-service:
+        condition: service_healthy
+      wls-auth-service-reverse-proxy:
         condition: service_healthy
     env_file:
       - .env

--- a/stack/docker-compose_build-local.yml
+++ b/stack/docker-compose_build-local.yml
@@ -503,6 +503,12 @@ services:
       - ./reverse-proxy-auth-service/ssl:/etc/nginx/ssl
       - ./reverse-proxy-auth-service/nginx.conf:/etc/nginx/conf.d/default.conf
     restart: always
+    healthcheck:
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+      test: [ "CMD-SHELL", "curl -f --insecure https://localhost:443/nginx-health" ]
 
 networks:
   internal:

--- a/stack/docker-compose_latest-dev.yml
+++ b/stack/docker-compose_latest-dev.yml
@@ -276,6 +276,8 @@ services:
     depends_on:
       wls-auth-service:
         condition: service_healthy
+      wls-auth-service-reverse-proxy:
+        condition: service_healthy
     env_file:
       - .env
     ports:
@@ -313,6 +315,8 @@ services:
     image: ghcr.io/it-at-m/wahllokalsystem-wls-api-gateway:latest-dev
     depends_on:
       wls-auth-service:
+        condition: service_healthy
+      wls-auth-service-reverse-proxy:
         condition: service_healthy
     env_file:
       - .env

--- a/stack/docker-compose_latest-dev.yml
+++ b/stack/docker-compose_latest-dev.yml
@@ -455,6 +455,12 @@ services:
       - ./reverse-proxy-auth-service/ssl:/etc/nginx/ssl
       - ./reverse-proxy-auth-service/nginx.conf:/etc/nginx/conf.d/default.conf
     restart: always
+    healthcheck:
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+      test: [ "CMD-SHELL", "curl -f --insecure https://localhost:443/nginx-health" ]
 
 networks:
   internal:

--- a/stack/reverse-proxy-auth-service/nginx.conf
+++ b/stack/reverse-proxy-auth-service/nginx.conf
@@ -14,4 +14,10 @@ server {
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Forwarded-Port 58100;
     }
+
+    location /nginx-health {
+        access_log off;
+        return 200 "healthy\n";
+        add_header Content-Type text/plain;
+    }
 }


### PR DESCRIPTION
# Beschreibung:

- Für wls-auth-service-reverse-proxy wurde ein valider Healthcheck-Endpunkt implementiert (in nginx.config), damit depends_on: condition: service_healthy funktioniert
- beide Gateways setzen einen laufenden/healthy wls-auth-service-reverse-proxy voraus

## Definition of Done (DoD):

<!-- Backend -->
### Backend ###
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [ ] ~Doku aktualisiert~
- [ ] ~Swagger-API vollständig~
- [ ] ~Unit-Tests gepflegt~
- [ ] ~Integrationstests gepflegt~
- [ ] ~Beispiel-Requests gepflegt~
- [x] Texte auf Rechtschreibung und Grammatik geprüft

Closes #2414 

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented inter-service startup dependencies to establish proper initialization sequences and verify all prerequisite services are healthy and ready before dependent services begin their startup processes
  * Added comprehensive health monitoring and status tracking for the authentication reverse proxy service with a dedicated endpoint to continuously track and report service availability and operational readiness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->