### PR TITLE
Version für vue-component-helpers definieren

### DIFF
--- a/wls-gui-admintool/package-lock.json
+++ b/wls-gui-admintool/package-lock.json
@@ -8629,8 +8629,8 @@
       "license": "MIT"
     },
     "node_modules/vue-component-type-helpers": {
-      "version": "3.2.4",
-      "integrity": "sha512-05lR16HeZDcDpB23ku5b5f1fBOoHqFnMiKRr2CiEvbG5Ux4Yi0McmQBOET0dR0nxDXosxyVqv67q6CzS3AK8rw==",
+      "version": "3.2.5",
+      "integrity": "sha512-tkvNr+bU8+xD/onAThIe7CHFvOJ/BO6XCOrxMzeytJq40nTfpGDJuVjyCM8ccGZKfAbGk2YfuZyDMXM56qheZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/wls-gui-admintool/package.json
+++ b/wls-gui-admintool/package.json
@@ -76,5 +76,10 @@
     "workerDirectory": [
       ".msw/public"
     ]
+  },
+  "overrides": {
+    "@storybook/vue3": {
+      "vue-component-type-helpers": "3.2.5"
+    }
   }
 }

--- a/wls-gui-wahllokalsystem/package-lock.json
+++ b/wls-gui-wahllokalsystem/package-lock.json
@@ -11163,8 +11163,8 @@
       "license": "MIT"
     },
     "node_modules/vue-component-type-helpers": {
-      "version": "3.2.4",
-      "integrity": "sha512-05lR16HeZDcDpB23ku5b5f1fBOoHqFnMiKRr2CiEvbG5Ux4Yi0McmQBOET0dR0nxDXosxyVqv67q6CzS3AK8rw==",
+      "version": "3.2.5",
+      "integrity": "sha512-tkvNr+bU8+xD/onAThIe7CHFvOJ/BO6XCOrxMzeytJq40nTfpGDJuVjyCM8ccGZKfAbGk2YfuZyDMXM56qheZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/wls-gui-wahllokalsystem/package.json
+++ b/wls-gui-wahllokalsystem/package.json
@@ -88,5 +88,10 @@
     "workerDirectory": [
       ".msw/public"
     ]
+  },
+  "overrides": {
+    "@storybook/vue3": {
+      "vue-component-type-helpers": "3.2.5"
+    }
   }
 }


### PR DESCRIPTION
# Beschreibung:

Dadurch sollte `latest` in `@storybook/vue3` nicht mehr greifen und renovate neue Versionen vorschlagen.Die sporadischen Build-Failure wegen einer neuen Version sollten damit verschwinden.

Das es gibt wurde lokal geprüft. Entsprechend der eingetragenen Version hat sich in der package-lock.json auch die Version geändert.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] ~[Naming Conventions][naming-conventions-link] beachtet~
- [x] ~Doku aktualisiert~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] ~Unit-Tests gepflegt~
- [X] ~Texte auf Rechtschreibung und Grammatik geprüft~
- [X] ~Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft~

# Referenzen[^1]:

Verwandt mit Issue #

Closes #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling configuration to ensure stable Storybook Vue 3 integration across development environments and projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->