### PR TITLE
Fix 2446 Bug: Wahlscheinewert ist am Anfang vorbelegt

### DIFF
--- a/wls-gui-wahllokalsystem/src/composables/ergebnismeldung/common/wahlscheineMapper.ts
+++ b/wls-gui-wahllokalsystem/src/composables/ergebnismeldung/common/wahlscheineMapper.ts
@@ -14,6 +14,9 @@ export function useWahlscheineMapper() {
   }
 
   function toDto(model: Wahlscheine): WahlscheineDTO {
+    if (model.stimmabgabevermerke === null) {
+      throw new Error("Stimmabgabevermerke ist empty");
+    }
     return {
       bezirkUndWahlID: _toBezirkUndWahlIDDTO(model.bezirkUndWahlID),
       stimmabgabevermerke: model.stimmabgabevermerke,

--- a/wls-gui-wahllokalsystem/src/stores/wahlscheineStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/wahlscheineStore.ts
@@ -26,7 +26,7 @@ export const useWahlscheineStore = defineStore(storeID, () => {
       } else {
         wahlscheine.value.push({
           bezirkUndWahlID: { wahlID, wahlbezirkID },
-          stimmabgabevermerke: 0,
+          stimmabgabevermerke: null,
         });
       }
     } catch {

--- a/wls-gui-wahllokalsystem/src/types/ergebnismeldung/common/DifferenceBegruendung.ts
+++ b/wls-gui-wahllokalsystem/src/types/ergebnismeldung/common/DifferenceBegruendung.ts
@@ -2,6 +2,6 @@ export interface DifferenceBegruendung {
   wahlId: string;
   begruendung: string;
   isBegruendungValid: boolean;
-  anzahlWahlscheineOrStimmabgabevermerke: number | undefined;
+  anzahlWahlscheineOrStimmabgabevermerke: number | null | undefined;
   anzahlStimmzettel: number | undefined | null;
 }

--- a/wls-gui-wahllokalsystem/src/types/ergebnismeldung/common/Wahlscheine.ts
+++ b/wls-gui-wahllokalsystem/src/types/ergebnismeldung/common/Wahlscheine.ts
@@ -2,5 +2,5 @@ import type { BezirkUndWahlID } from "@/types/ergebnismeldung/common/BezirkUndWa
 
 export interface Wahlscheine {
   bezirkUndWahlID: BezirkUndWahlID;
-  stimmabgabevermerke: number;
+  stimmabgabevermerke: number | null;
 }

--- a/wls-gui-wahllokalsystem/tests/composables/ergebnismeldung/common/wahlscheineMapper.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/ergebnismeldung/common/wahlscheineMapper.spec.ts
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { useWahlscheineMapper } from "@/composables/ergebnismeldung/common/wahlscheineMapper.ts";
 
-const { createWahlscheineDTO, createWahlscheine } =
+const { createWahlscheineDTO, createWahlscheine, prepareWahlscheine } =
   useWahlscheineTestDataFactory();
 
 describe("wahlscheineMapper", () => {
@@ -39,10 +39,18 @@ describe("wahlscheineMapper", () => {
 
       const expectedObject: WahlscheineDTO = {
         bezirkUndWahlID: objectToMap.bezirkUndWahlID,
-        stimmabgabevermerke: objectToMap.stimmabgabevermerke,
+        stimmabgabevermerke: objectToMap.stimmabgabevermerke as number,
       };
 
       expect(result).toStrictEqual(expectedObject);
+    });
+
+    it("should_throwError_when_stimmabgabevermerkeIsNull", () => {
+      const objectToMap = prepareWahlscheine()
+        .stimmabgabevermerke(null)
+        .build();
+
+      expect(() => unitUnderTest.toDto(objectToMap)).toThrowError();
     });
   });
 });

--- a/wls-gui-wahllokalsystem/tests/composables/ergebnismeldung/common/wahlscheineService.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/ergebnismeldung/common/wahlscheineService.spec.ts
@@ -135,7 +135,7 @@ describe("wahlscheineService.ts", () => {
       const wahlschein = createWahlscheine();
       const wahlscheinDTO = prepareWahlscheineDTO()
         .bezirkUndWahlID(wahlschein.bezirkUndWahlID)
-        .stimmabgabevermerke(wahlschein.stimmabgabevermerke)
+        .stimmabgabevermerke(wahlschein.stimmabgabevermerke as number)
         .build();
 
       mockDefinitions.postWahlscheine.mockReturnValue(

--- a/wls-gui-wahllokalsystem/tests/stores/wahlscheineStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/wahlscheineStore.spec.ts
@@ -73,7 +73,7 @@ describe("wahlscheineStore.ts", () => {
       expect(unitUnderTest.wahlscheine).toStrictEqual([
         {
           bezirkUndWahlID: { wahlID, wahlbezirkID },
-          stimmabgabevermerke: 0,
+          stimmabgabevermerke: null,
         },
       ]);
     });


### PR DESCRIPTION
# Beschreibung:

Es wird `null` gesetzt wenn es für den Wahlbezirk der Wahl keine Wahlscheine/Stimmabgabevermerke gibt. Beim Speichern kommt ein Error wenn man versucht `null` zu speichern. Das UI ermöglicht aber kein Speichern mit `null`.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] ~[Naming Conventions][naming-conventions-link] beachtet~
- [x] ~Doku aktualisiert~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] Unit-Tests gepflegt
- [x] ~Texte auf Rechtschreibung und Grammatik geprüft~
- [X] ~Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft~

# Referenzen[^1]:

Verwandt mit Issue #

Closes #2446 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for missing data fields to throw errors when required values are not provided, improving error detection and reporting.

* **Tests**
  * Updated test cases to reflect stricter null value handling and added validation coverage for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->