### PR TITLE
remove unused constants

### DIFF
--- a/wls-gui-wahllokalsystem/src/constants.ts
+++ b/wls-gui-wahllokalsystem/src/constants.ts
@@ -15,11 +15,6 @@ export const ROUTE_AUSZAEHLUNG_STIMMZETTEL = "auszaehlungStimmzettel";
 export const ROUTE_STAPEL_A = "stapelA";
 export const ROUTE_STAPEL_B = "stapelB";
 export const ROUTE_STAPEL_C = "stapelC";
-export const ROUTE_STAPEL_A_AND_B = "stapelAandB";
-export const ROUTE_STAPEL_D = "stapelD";
-export const ROUTE_SCHNELLMELDUNG = "schnellmeldung";
-export const ROUTE_STAPEL_BC = "stapelBC";
-export const ROUTE_NIEDERSCHRIFT = "niederschrift";
 
 export const MIN_WAHLVORSTAND_ANWESEND_VOR_SCHLIESSUNG = 3;
 export const MIN_WAHLVORSTAND_ANWESEND_NACH_SCHLIESSUNG = 5;


### PR DESCRIPTION
# Beschreibung:

ungenutzte konstanten entfernt




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed five navigation routes: Stapel A/B, Stapel D, Schnellmeldung, Stapel BC, and Niederschrift. These application sections are no longer accessible through the user interface. The removal of these routes has changed the application's overall navigation structure and the complete set of features available to users within the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->