### PR TITLE
1978 rename von ergebnismeldungDruck elementen zu schnellmeldungDruck

### DIFF
--- a/wls-gui-wahllokalsystem/src/composables/ergebnismeldung/MBW/mbwUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/ergebnismeldung/MBW/mbwUtils.ts
@@ -1,7 +1,7 @@
 import type { AWerte } from "@/types/ergebnismeldung/common/AWerte.ts";
 import type { BWerte } from "@/types/ergebnismeldung/common/BWerte.ts";
-import type { ErgebnismeldungDruckInput } from "@/types/ergebnismeldung/common/ErgebnismeldungDruckInput.ts";
 import type { MeldungsartEnum } from "@/types/ergebnismeldung/common/MeldungsartEnum.ts";
+import type { SchnellmeldungDruckInput } from "@/types/ergebnismeldung/common/SchnellmeldungDruckInput.ts";
 import type { Status } from "@/types/ergebnismeldung/common/Status.ts";
 import type { MbwErgebnisseAndWahlvorschlag } from "@/types/ergebnismeldung/MBW/MbwErgebnisseAndWahlvorschlag.ts";
 import type { Wahl } from "@/types/wahl/Wahl.ts";
@@ -227,7 +227,7 @@ export function useMbwUtils(wahlID: string, wahlbezirkID: string) {
     wahl: Wahl,
     status: Status,
     meldungsart: MeldungsartEnum
-  ): Promise<ErgebnismeldungDruckInput> {
+  ): Promise<SchnellmeldungDruckInput> {
     let aWerte = undefined;
     if (currentUserWahlbezirksArt.value == WahlbezirksArtEnum.UWB) {
       aWerte = await getAWerteForWahlbezirkAndWahl();

--- a/wls-gui-wahllokalsystem/src/composables/ergebnismeldung/MBW/mbwUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/ergebnismeldung/MBW/mbwUtils.ts
@@ -223,7 +223,7 @@ export function useMbwUtils(wahlID: string, wahlbezirkID: string) {
     }
   }
 
-  async function prepareDataForErgebnismeldungDruck(
+  async function prepareDataForSchnellmeldungDruck(
     wahl: Wahl,
     status: Status,
     meldungsart: MeldungsartEnum
@@ -367,6 +367,6 @@ export function useMbwUtils(wahlID: string, wahlbezirkID: string) {
     getAWerteForWahlbezirkAndWahl,
     getBWerteForWahlbezirkAndWahl,
     sendSchnellmeldung,
-    prepareDataForErgebnismeldungDruck,
+    prepareDataForSchnellmeldungDruck,
   };
 }

--- a/wls-gui-wahllokalsystem/src/composables/ergebnismeldung/MBW/schnellmeldungDruck.ts
+++ b/wls-gui-wahllokalsystem/src/composables/ergebnismeldung/MBW/schnellmeldungDruck.ts
@@ -13,7 +13,9 @@ const { convertToSixDigitArray } = useNumberFormatter();
 const { toGermanDate } = useDateTimeFormatter();
 
 export function useSchnellmeldungDruck() {
-  function buildTemplateFromData(data: SchnellmeldungDruckInput): string {
+  function buildSchnellmeldungTemplateFromData(
+    data: SchnellmeldungDruckInput
+  ): string {
     return `
         <!DOCTYPE html>
         <html lang="de">
@@ -608,5 +610,5 @@ export function useSchnellmeldungDruck() {
     return convertToSixDigitArray(sum);
   }
 
-  return { buildTemplateFromData };
+  return { buildSchnellmeldungTemplateFromData };
 }

--- a/wls-gui-wahllokalsystem/src/composables/ergebnismeldung/MBW/schnellmeldungDruck.ts
+++ b/wls-gui-wahllokalsystem/src/composables/ergebnismeldung/MBW/schnellmeldungDruck.ts
@@ -1,7 +1,7 @@
 import type { AWerte } from "@/types/ergebnismeldung/common/AWerte.ts";
 import type { BWerte } from "@/types/ergebnismeldung/common/BWerte.ts";
-import type { ErgebnismeldungDruckInput } from "@/types/ergebnismeldung/common/ErgebnismeldungDruckInput.ts";
 import type { MeldungsartEnum } from "@/types/ergebnismeldung/common/MeldungsartEnum.ts";
+import type { SchnellmeldungDruckInput } from "@/types/ergebnismeldung/common/SchnellmeldungDruckInput.ts";
 import type { MbwErgebnisseAndWahlvorschlag } from "@/types/ergebnismeldung/MBW/MbwErgebnisseAndWahlvorschlag.ts";
 
 import { useDateTimeFormatter } from "@/composables/common/dateTimeFormatter.ts";
@@ -12,8 +12,8 @@ import { WahlbezirksArtEnum } from "@/types/wahlbezirksArtEnum.ts";
 const { convertToSixDigitArray } = useNumberFormatter();
 const { toGermanDate } = useDateTimeFormatter();
 
-export function useErgebnismeldungDruck() {
-  function buildTemplateFromData(data: ErgebnismeldungDruckInput): string {
+export function useSchnellmeldungDruck() {
+  function buildTemplateFromData(data: SchnellmeldungDruckInput): string {
     return `
         <!DOCTYPE html>
         <html lang="de">

--- a/wls-gui-wahllokalsystem/src/types/ergebnismeldung/common/SchnellmeldungDruckInput.ts
+++ b/wls-gui-wahllokalsystem/src/types/ergebnismeldung/common/SchnellmeldungDruckInput.ts
@@ -5,7 +5,7 @@ import type { MbwErgebnisseAndWahlvorschlag } from "@/types/ergebnismeldung/MBW/
 import type { Wahl } from "@/types/wahl/Wahl.ts";
 import type { WahlbezirksArtEnum } from "@/types/wahlbezirksArtEnum.ts";
 
-export interface ErgebnismeldungDruckInput {
+export interface SchnellmeldungDruckInput {
   sendOk: boolean;
   barcode: string;
   wahlbezirkNummer: string;

--- a/wls-gui-wahllokalsystem/src/views/ergebnismeldung/MBW/MBWSchnellmeldungView.vue
+++ b/wls-gui-wahllokalsystem/src/views/ergebnismeldung/MBW/MBWSchnellmeldungView.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script setup lang="ts">
-import type { ErgebnismeldungDruckInput } from "@/types/ergebnismeldung/common/ErgebnismeldungDruckInput.ts";
+import type { SchnellmeldungDruckInput } from "@/types/ergebnismeldung/common/SchnellmeldungDruckInput.ts";
 
 import { storeToRefs } from "pinia";
 import { ref } from "vue";
@@ -42,8 +42,8 @@ import TheMBWGueltigeStimmenAnzeigenCard from "@/components/ergebnismeldung/MBW/
 import TheMBWWaehlerAnzeigenCard from "@/components/ergebnismeldung/MBW/stapelAB/TheMBWWaehlerAnzeigenCard.vue";
 import TheMBWWahlberechtigteAnzeigenCard from "@/components/ergebnismeldung/MBW/stapelAB/TheMBWWahlberechtigteAnzeigenCard.vue";
 import TheMBWUngueltigeStimmenAnzeigenCard from "@/components/ergebnismeldung/MBW/stapelC/TheMBWUngueltigeStimmenAnzeigenCard.vue";
-import { useErgebnismeldungDruck } from "@/composables/ergebnismeldung/MBW/ergebnismeldungDruck.ts";
 import { useMbwUtils } from "@/composables/ergebnismeldung/MBW/mbwUtils.ts";
+import { useSchnellmeldungDruck } from "@/composables/ergebnismeldung/MBW/schnellmeldungDruck.ts";
 import { useNavigationUtils } from "@/composables/navigation/navigationUtils.ts";
 import { useUserNotificationService } from "@/composables/userNotification/userNotificationService.ts";
 import { ROUTE_NOTFOUND } from "@/constants.ts";
@@ -68,7 +68,7 @@ const {
   sendSchnellmeldung,
   prepareDataForErgebnismeldungDruck,
 } = useMbwUtils(wahlID, wahlbezirkID);
-const { buildTemplateFromData } = useErgebnismeldungDruck();
+const { buildTemplateFromData } = useSchnellmeldungDruck();
 const { setStepDone } = useWorkflowStore();
 const { getNextRoute } = useNavigationUtils();
 
@@ -102,7 +102,7 @@ async function onDruckenClicked() {
     );
 
     if (wahl && statusForWahlAndWahlbezirk) {
-      const data: ErgebnismeldungDruckInput =
+      const data: SchnellmeldungDruckInput =
         await prepareDataForErgebnismeldungDruck(
           wahl,
           statusForWahlAndWahlbezirk,

--- a/wls-gui-wahllokalsystem/src/views/ergebnismeldung/MBW/MBWSchnellmeldungView.vue
+++ b/wls-gui-wahllokalsystem/src/views/ergebnismeldung/MBW/MBWSchnellmeldungView.vue
@@ -66,9 +66,9 @@ const { status } = storeToRefs(useStatusStore());
 const {
   isSendingSchnellmeldung,
   sendSchnellmeldung,
-  prepareDataForErgebnismeldungDruck,
+  prepareDataForSchnellmeldungDruck,
 } = useMbwUtils(wahlID, wahlbezirkID);
-const { buildTemplateFromData } = useSchnellmeldungDruck();
+const { buildSchnellmeldungTemplateFromData } = useSchnellmeldungDruck();
 const { setStepDone } = useWorkflowStore();
 const { getNextRoute } = useNavigationUtils();
 
@@ -103,7 +103,7 @@ async function onDruckenClicked() {
 
     if (wahl && statusForWahlAndWahlbezirk) {
       const data: SchnellmeldungDruckInput =
-        await prepareDataForErgebnismeldungDruck(
+        await prepareDataForSchnellmeldungDruck(
           wahl,
           statusForWahlAndWahlbezirk,
           MeldungsArtEnum.Schnellmeldung
@@ -116,7 +116,8 @@ async function onDruckenClicked() {
       );
 
       if (printWindow) {
-        printWindow.document.body.innerHTML = buildTemplateFromData(data);
+        printWindow.document.body.innerHTML =
+          buildSchnellmeldungTemplateFromData(data);
         printWindow.print();
         printWindow.close();
         isSendenActive.value = false;

--- a/wls-gui-wahllokalsystem/tests/composables/ergebnismeldung/MBW/mbwUtils.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/ergebnismeldung/MBW/mbwUtils.spec.ts
@@ -120,7 +120,7 @@ const { prepareAWerte } = useAWerteTestDataFactory();
 const { prepareBWerte } = useBWerteTestDataFactory();
 const { prepareMbwErgebnisseAndWahlvorschlag } =
   useMbwErgebnisseAndWahlvorschlagTestDataFactory();
-const { prepareErgebnismeldungDruckInput } =
+const { prepareSchnellmeldungDruckInput } =
   useErgebnismeldungDruckInputTestDataFactory();
 const { convertToSixDigitArray } = useNumberFormatter();
 const { toGermanDate, toHhMm } = useDateTimeFormatter();
@@ -949,7 +949,7 @@ describe("mbwUtils", () => {
         meldungsArt
       );
 
-      const expectedResult = prepareErgebnismeldungDruckInput()
+      const expectedResult = prepareSchnellmeldungDruckInput()
         .meldungsArt(meldungsArt)
         .wahlbezirksArt(WahlbezirksArtEnum.UWB)
         .aktuelleWahl(wahl)

--- a/wls-gui-wahllokalsystem/tests/composables/ergebnismeldung/MBW/mbwUtils.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/ergebnismeldung/MBW/mbwUtils.spec.ts
@@ -710,7 +710,7 @@ describe("mbwUtils", () => {
     });
   });
 
-  describe("prepareDataForErgebnismeldungDruck", () => {
+  describe("prepareDataForSchnellmeldungDruck", () => {
     it("should_returnErgebnismeldungDruckInput_when_givenWahlStatusAndMeldungsart", async () => {
       const userStore = useUserStore(pinia);
       userStore.setUser(
@@ -943,7 +943,7 @@ describe("mbwUtils", () => {
         toHhMm(mockedNow) +
         " O";
 
-      const result = await unitUnderTest.prepareDataForErgebnismeldungDruck(
+      const result = await unitUnderTest.prepareDataForSchnellmeldungDruck(
         wahl,
         status,
         meldungsArt

--- a/wls-gui-wahllokalsystem/tests/utils/ergebnismeldung/common/ergebnismeldungDruckInputTestDataFactory.ts
+++ b/wls-gui-wahllokalsystem/tests/utils/ergebnismeldung/common/ergebnismeldungDruckInputTestDataFactory.ts
@@ -26,7 +26,7 @@ const { createMbwErgebnisseAndWahlvorschlag } =
 const { convertToSixDigitArray } = useNumberFormatter();
 
 export function useErgebnismeldungDruckInputTestDataFactory() {
-  function createErgebnismeldungDruckInput(): SchnellmeldungDruckInput {
+  function createSchnellmeldungDruckInput(): SchnellmeldungDruckInput {
     return {
       meldungsArt: MeldungsArtEnum.Schnellmeldung,
       wahlbezirksArt: WahlbezirksArtEnum.UWB,
@@ -54,11 +54,11 @@ export function useErgebnismeldungDruckInputTestDataFactory() {
     };
   }
 
-  function prepareErgebnismeldungDruckInput(): Builder<SchnellmeldungDruckInput> {
+  function prepareSchnellmeldungDruckInput(): Builder<SchnellmeldungDruckInput> {
     return proxyBuilder<SchnellmeldungDruckInput>(
-      createErgebnismeldungDruckInput()
+      createSchnellmeldungDruckInput()
     );
   }
 
-  return { createErgebnismeldungDruckInput, prepareErgebnismeldungDruckInput };
+  return { createSchnellmeldungDruckInput, prepareSchnellmeldungDruckInput };
 }

--- a/wls-gui-wahllokalsystem/tests/utils/ergebnismeldung/common/ergebnismeldungDruckInputTestDataFactory.ts
+++ b/wls-gui-wahllokalsystem/tests/utils/ergebnismeldung/common/ergebnismeldungDruckInputTestDataFactory.ts
@@ -1,4 +1,4 @@
-import type { ErgebnismeldungDruckInput } from "@/types/ergebnismeldung/common/ErgebnismeldungDruckInput.ts";
+import type { SchnellmeldungDruckInput } from "@/types/ergebnismeldung/common/SchnellmeldungDruckInput.ts";
 import type { Builder } from "@tests/utils/Builder.ts";
 
 import { proxyBuilder } from "@tests/utils/Builder.ts";
@@ -26,7 +26,7 @@ const { createMbwErgebnisseAndWahlvorschlag } =
 const { convertToSixDigitArray } = useNumberFormatter();
 
 export function useErgebnismeldungDruckInputTestDataFactory() {
-  function createErgebnismeldungDruckInput(): ErgebnismeldungDruckInput {
+  function createErgebnismeldungDruckInput(): SchnellmeldungDruckInput {
     return {
       meldungsArt: MeldungsArtEnum.Schnellmeldung,
       wahlbezirksArt: WahlbezirksArtEnum.UWB,
@@ -54,8 +54,8 @@ export function useErgebnismeldungDruckInputTestDataFactory() {
     };
   }
 
-  function prepareErgebnismeldungDruckInput(): Builder<ErgebnismeldungDruckInput> {
-    return proxyBuilder<ErgebnismeldungDruckInput>(
+  function prepareErgebnismeldungDruckInput(): Builder<SchnellmeldungDruckInput> {
+    return proxyBuilder<SchnellmeldungDruckInput>(
       createErgebnismeldungDruckInput()
     );
   }


### PR DESCRIPTION
# Beschreibung:

umbenennung der generischen `ergebnismeldungDruck` elemente zu `schnellmeldungDruck`, da sie nicht für die niederschrift wiederverwendet werden

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [ ] [Naming Conventions][naming-conventions-link] beachtet
- [ ] Doku aktualisiert
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [ ] Unit-Tests gepflegt
- [ ] Texte auf Rechtschreibung und Grammatik geprüft
- [ ] Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft

# Referenzen[^1]:

Verwandt mit Issue #1978 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code reorganization for quick report printing functionality to improve maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->