### PR TITLE
2428 - Test ergänzt: null wenn das Datum invalide ist

### DIFF
--- a/wls-gui-wahllokalsystem/tests/composables/wahlhandlung/wahlvorbereitungService.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/wahlhandlung/wahlvorbereitungService.spec.ts
@@ -249,7 +249,7 @@ describe("wahlvorbereitungService", () => {
       expect(result).toBeNull();
     });
 
-    it("should_returnNull_when_apiReturnsInvalideDate", async () => {
+    it("should_returnNull_when_apiReturnsInvalidDate", async () => {
       const wahlbezirkID = generateRandomString(10);
 
       const mockedApiResponseData = prepareEroeffnungsuhrzeitDTO()

--- a/wls-gui-wahllokalsystem/tests/composables/wahlhandlung/wahlvorbereitungService.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/wahlhandlung/wahlvorbereitungService.spec.ts
@@ -96,6 +96,7 @@ const {
   createUrnenwahlvorbereitungDTO,
   createWahlvorbereitung,
   createBriefwahlvorbereitungDTO,
+  prepareEroeffnungsuhrzeitDTO,
 } = useWahlvorbereitungTestDataFactory();
 const { generateRandomString, generateRandomDateTimeAsString } =
   useCommonTestDataFactory();
@@ -246,6 +247,24 @@ describe("wahlvorbereitungService", () => {
 
       expect(useWorkflowStore().isWahleroeffnungErfasst).toBe(false);
       expect(result).toBeNull();
+    });
+
+    it("should_returnNull_when_apiReturnsInvalideDate", async () => {
+      const wahlbezirkID = generateRandomString(10);
+
+      const mockedApiResponseData = prepareEroeffnungsuhrzeitDTO()
+        .eroeffnungsuhrzeit("invalid date")
+        .build();
+      mockDefinitions.getEroeffnungsuhrzeit.mockReturnValue(
+        createAxiosResponse({ status: 200, data: mockedApiResponseData })
+      );
+
+      const result = await getEroeffnungsuhrzeit(wahlbezirkID);
+
+      expect(result).toBeNull();
+      expect(mockDefinitions.getEroeffnungsuhrzeit.mock.calls).toStrictEqual([
+        [wahlbezirkID],
+      ]);
     });
 
     it("should_throwErrorAndSendNotification_when_apiFailed", async () => {

--- a/wls-gui-wahllokalsystem/tests/utils/wahlhandlung/WahlvorbereitungTestDataFactory.ts
+++ b/wls-gui-wahllokalsystem/tests/utils/wahlhandlung/WahlvorbereitungTestDataFactory.ts
@@ -87,6 +87,10 @@ export function useWahlvorbereitungTestDataFactory() {
     };
   }
 
+  function prepareEroeffnungsuhrzeitDTO(): Builder<EroeffnungsUhrzeitDTO> {
+    return proxyBuilder<EroeffnungsUhrzeitDTO>(createEroeffnungsUhrzeitDTO());
+  }
+
   function prepareUrnenwahlvorbereitung(): Builder<Urnenwahlvorbereitung> {
     return proxyBuilder<Urnenwahlvorbereitung>(createUrnenwahlvorbereitung());
   }
@@ -123,6 +127,7 @@ export function useWahlvorbereitungTestDataFactory() {
     createUrnenwahlvorbereitungDTO,
     createWahlvorbereitung,
     createBriefwahlvorbereitungDTO,
+    prepareEroeffnungsuhrzeitDTO,
     prepareUrnenwahlvorbereitung,
     prepareWahlvorbereitung,
   };


### PR DESCRIPTION
# Beschreibung:

Test erstellt um zu zeigen dass es gewollt ist dass bei einem ungültigen Datum null geliefert wird

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [X] ~Doku aktualisiert~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [X] Unit-Tests gepflegt
- [X] ~Texte auf Rechtschreibung und Grammatik geprüft~
- [X] ~Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft~

# Referenzen[^1]:

Closes #2428

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test utilities with new data factory helper for constructing test data.
  * Added test case to verify API behavior when receiving invalid date responses, ensuring proper error handling and fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->