### PR TITLE
2515 - Anpassung Werte für default empty Ereignisse

### DIFF
--- a/wls-gui-wahllokalsystem/src/types/vorfaelleundvorkommnisse/WahlbezirkEreignisse.ts
+++ b/wls-gui-wahllokalsystem/src/types/vorfaelleundvorkommnisse/WahlbezirkEreignisse.ts
@@ -16,6 +16,6 @@ export class WahlbezirkEreignisseBuilder implements WahlbezirkEreignisse {
   ) {}
 
   static createEmptyWahlbezirkEreignisse(): WahlbezirkEreignisseBuilder {
-    return new WahlbezirkEreignisseBuilder("", [], true, true);
+    return new WahlbezirkEreignisseBuilder("", [], undefined, undefined);
   }
 }

--- a/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/TheEreignisseNoEventsCheckboxes.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/TheEreignisseNoEventsCheckboxes.spec.ts
@@ -31,6 +31,7 @@ describe("TheEreignisseNoEventsCheckboxes.vue", () => {
       global: {
         plugins: [
           createTestingPinia({
+            stubActions: false,
             createSpy: vi.fn,
           }),
           vuetify,

--- a/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/__snapshots__/TheEreignisseNoEventsCheckboxes.vue/visual logic/databinding/should_renderCheckboxesSelected_when_keineEreignisseFlagsInStoreAreTrueForUWB.html
+++ b/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/__snapshots__/TheEreignisseNoEventsCheckboxes.vue/visual logic/databinding/should_renderCheckboxesSelected_when_keineEreignisseFlagsInStoreAreTrueForUWB.html
@@ -7,7 +7,7 @@
           <!---->
           <div class="v-selection-control__input"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                 <path d="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3Z"></path>
-              </svg></i><input checked="" id="checkbox-v-0" aria-disabled="false" aria-label="Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
+              </svg></i><input id="checkbox-v-0" aria-disabled="false" aria-label="Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen." type="checkbox" value="true" checked=""></div>
         </div><label class="v-label v-label--clickable" for="checkbox-v-0">
           <!---->Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen.
         </label>
@@ -24,7 +24,7 @@
           <!---->
           <div class="v-selection-control__input"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                 <path d="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3Z"></path>
-              </svg></i><input checked="" disabled="" id="checkbox-v-3" aria-disabled="true" aria-label="Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
+              </svg></i><input disabled="" id="checkbox-v-3" aria-disabled="true" aria-label="Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen." type="checkbox" value="true" checked=""></div>
         </div><label class="v-label v-label--clickable" for="checkbox-v-3">
           <!---->Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen.
         </label>

--- a/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/__snapshots__/TheEreignisseNoEventsCheckboxes.vue/visual logic/keineVorfaelle/should_renderKeineVorfaelleDisabled_when_vorfaelleAreGivenInStoreForUWB.html
+++ b/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/__snapshots__/TheEreignisseNoEventsCheckboxes.vue/visual logic/keineVorfaelle/should_renderKeineVorfaelleDisabled_when_vorfaelleAreGivenInStoreForUWB.html
@@ -1,13 +1,13 @@
 <div>
-  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-input--disabled v-checkbox" data-test="checkboxKeineVorfaelle">
+  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--disabled v-checkbox" data-test="checkboxKeineVorfaelle">
     <!---->
     <div class="v-input__control">
-      <div class="v-selection-control v-selection-control--dirty v-selection-control--disabled v-selection-control--density-default v-checkbox-btn">
+      <div class="v-selection-control v-selection-control--disabled v-selection-control--density-default v-checkbox-btn">
         <div class="v-selection-control__wrapper">
           <!---->
           <div class="v-selection-control__input"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                <path d="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3Z"></path>
-              </svg></i><input checked="" id="checkbox-v-0" aria-disabled="true" aria-label="Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen." type="checkbox" value="true" disabled=""></div>
+                <path d="M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3M19,5V19H5V5H19Z"></path>
+              </svg></i><input id="checkbox-v-0" aria-disabled="true" aria-label="Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen." type="checkbox" value="true" disabled=""></div>
         </div><label class="v-label v-label--clickable" for="checkbox-v-0">
           <!---->Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen.
         </label>
@@ -16,15 +16,15 @@
     <!---->
     <!---->
   </div>
-  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-input--disabled v-checkbox" data-test="checkboxKeineVorkommnisse">
+  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--disabled v-checkbox" data-test="checkboxKeineVorkommnisse">
     <!---->
     <div class="v-input__control">
-      <div class="v-selection-control v-selection-control--dirty v-selection-control--disabled v-selection-control--density-default v-checkbox-btn">
+      <div class="v-selection-control v-selection-control--disabled v-selection-control--density-default v-checkbox-btn">
         <div class="v-selection-control__wrapper">
           <!---->
           <div class="v-selection-control__input"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                <path d="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3Z"></path>
-              </svg></i><input checked="" disabled="" id="checkbox-v-3" aria-disabled="true" aria-label="Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
+                <path d="M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3M19,5V19H5V5H19Z"></path>
+              </svg></i><input disabled="" id="checkbox-v-3" aria-disabled="true" aria-label="Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
         </div><label class="v-label v-label--clickable" for="checkbox-v-3">
           <!---->Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen.
         </label>

--- a/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/__snapshots__/TheEreignisseNoEventsCheckboxes.vue/visual logic/keineVorfaelle/should_renderKeineVorfaelleEnabled_when_noVorfaelleAreGivenInStoreForUWB.html
+++ b/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/__snapshots__/TheEreignisseNoEventsCheckboxes.vue/visual logic/keineVorfaelle/should_renderKeineVorfaelleEnabled_when_noVorfaelleAreGivenInStoreForUWB.html
@@ -1,13 +1,13 @@
 <div>
-  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-checkbox" data-test="checkboxKeineVorfaelle">
+  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-checkbox" data-test="checkboxKeineVorfaelle">
     <!---->
     <div class="v-input__control">
-      <div class="v-selection-control v-selection-control--dirty v-selection-control--density-default v-checkbox-btn">
+      <div class="v-selection-control v-selection-control--density-default v-checkbox-btn">
         <div class="v-selection-control__wrapper">
           <!---->
           <div class="v-selection-control__input"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                <path d="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3Z"></path>
-              </svg></i><input checked="" id="checkbox-v-0" aria-disabled="false" aria-label="Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
+                <path d="M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3M19,5V19H5V5H19Z"></path>
+              </svg></i><input id="checkbox-v-0" aria-disabled="false" aria-label="Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
         </div><label class="v-label v-label--clickable" for="checkbox-v-0">
           <!---->Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen.
         </label>
@@ -16,15 +16,15 @@
     <!---->
     <!---->
   </div>
-  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-input--disabled v-checkbox" data-test="checkboxKeineVorkommnisse">
+  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--disabled v-checkbox" data-test="checkboxKeineVorkommnisse">
     <!---->
     <div class="v-input__control">
-      <div class="v-selection-control v-selection-control--dirty v-selection-control--disabled v-selection-control--density-default v-checkbox-btn">
+      <div class="v-selection-control v-selection-control--disabled v-selection-control--density-default v-checkbox-btn">
         <div class="v-selection-control__wrapper">
           <!---->
           <div class="v-selection-control__input"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                <path d="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3Z"></path>
-              </svg></i><input checked="" disabled="" id="checkbox-v-3" aria-disabled="true" aria-label="Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
+                <path d="M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3M19,5V19H5V5H19Z"></path>
+              </svg></i><input disabled="" id="checkbox-v-3" aria-disabled="true" aria-label="Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
         </div><label class="v-label v-label--clickable" for="checkbox-v-3">
           <!---->Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen.
         </label>

--- a/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/__snapshots__/TheEreignisseNoEventsCheckboxes.vue/visual logic/keineVorkommnisse/should_renderKeineVorkommnisseDisabled_when_noVorkommnisseAreGivenInStoreButSchliessungsuhrzeitIsNotSetForUWB.html
+++ b/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/__snapshots__/TheEreignisseNoEventsCheckboxes.vue/visual logic/keineVorkommnisse/should_renderKeineVorkommnisseDisabled_when_noVorkommnisseAreGivenInStoreButSchliessungsuhrzeitIsNotSetForUWB.html
@@ -1,13 +1,13 @@
 <div>
-  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-checkbox" data-test="checkboxKeineVorfaelle">
+  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-checkbox" data-test="checkboxKeineVorfaelle">
     <!---->
     <div class="v-input__control">
-      <div class="v-selection-control v-selection-control--dirty v-selection-control--density-default v-checkbox-btn">
+      <div class="v-selection-control v-selection-control--density-default v-checkbox-btn">
         <div class="v-selection-control__wrapper">
           <!---->
           <div class="v-selection-control__input"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                <path d="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3Z"></path>
-              </svg></i><input checked="" id="checkbox-v-0" aria-disabled="false" aria-label="Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
+                <path d="M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3M19,5V19H5V5H19Z"></path>
+              </svg></i><input id="checkbox-v-0" aria-disabled="false" aria-label="Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
         </div><label class="v-label v-label--clickable" for="checkbox-v-0">
           <!---->Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen.
         </label>
@@ -16,15 +16,15 @@
     <!---->
     <!---->
   </div>
-  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-input--disabled v-checkbox" data-test="checkboxKeineVorkommnisse">
+  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--disabled v-checkbox" data-test="checkboxKeineVorkommnisse">
     <!---->
     <div class="v-input__control">
-      <div class="v-selection-control v-selection-control--dirty v-selection-control--disabled v-selection-control--density-default v-checkbox-btn">
+      <div class="v-selection-control v-selection-control--disabled v-selection-control--density-default v-checkbox-btn">
         <div class="v-selection-control__wrapper">
           <!---->
           <div class="v-selection-control__input"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                <path d="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3Z"></path>
-              </svg></i><input checked="" disabled="" id="checkbox-v-3" aria-disabled="true" aria-label="Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
+                <path d="M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3M19,5V19H5V5H19Z"></path>
+              </svg></i><input disabled="" id="checkbox-v-3" aria-disabled="true" aria-label="Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
         </div><label class="v-label v-label--clickable" for="checkbox-v-3">
           <!---->Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen.
         </label>

--- a/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/__snapshots__/TheEreignisseNoEventsCheckboxes.vue/visual logic/keineVorkommnisse/should_renderKeineVorkommnisseDisabled_when_vorkommnisseAreGivenInStoreForUWB.html
+++ b/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/__snapshots__/TheEreignisseNoEventsCheckboxes.vue/visual logic/keineVorkommnisse/should_renderKeineVorkommnisseDisabled_when_vorkommnisseAreGivenInStoreForUWB.html
@@ -1,13 +1,13 @@
 <div>
-  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-checkbox" data-test="checkboxKeineVorfaelle">
+  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-checkbox" data-test="checkboxKeineVorfaelle">
     <!---->
     <div class="v-input__control">
-      <div class="v-selection-control v-selection-control--dirty v-selection-control--density-default v-checkbox-btn">
+      <div class="v-selection-control v-selection-control--density-default v-checkbox-btn">
         <div class="v-selection-control__wrapper">
           <!---->
           <div class="v-selection-control__input"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                <path d="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3Z"></path>
-              </svg></i><input checked="" id="checkbox-v-0" aria-disabled="false" aria-label="Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
+                <path d="M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3M19,5V19H5V5H19Z"></path>
+              </svg></i><input id="checkbox-v-0" aria-disabled="false" aria-label="Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
         </div><label class="v-label v-label--clickable" for="checkbox-v-0">
           <!---->Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen.
         </label>
@@ -16,15 +16,15 @@
     <!---->
     <!---->
   </div>
-  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-input--disabled v-checkbox" data-test="checkboxKeineVorkommnisse">
+  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--disabled v-checkbox" data-test="checkboxKeineVorkommnisse">
     <!---->
     <div class="v-input__control">
-      <div class="v-selection-control v-selection-control--dirty v-selection-control--disabled v-selection-control--density-default v-checkbox-btn">
+      <div class="v-selection-control v-selection-control--disabled v-selection-control--density-default v-checkbox-btn">
         <div class="v-selection-control__wrapper">
           <!---->
           <div class="v-selection-control__input"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                <path d="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3Z"></path>
-              </svg></i><input checked="" disabled="" id="checkbox-v-3" aria-disabled="true" aria-label="Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
+                <path d="M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3M19,5V19H5V5H19Z"></path>
+              </svg></i><input disabled="" id="checkbox-v-3" aria-disabled="true" aria-label="Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
         </div><label class="v-label v-label--clickable" for="checkbox-v-3">
           <!---->Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen.
         </label>

--- a/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/__snapshots__/TheEreignisseNoEventsCheckboxes.vue/visual logic/keineVorkommnisse/should_renderKeineVorkommnisseEnabled_when_noVorkommnisseAreGivenInStoreAndSchliessungsuhrzeitIsNotSetForBWB.html
+++ b/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/__snapshots__/TheEreignisseNoEventsCheckboxes.vue/visual logic/keineVorkommnisse/should_renderKeineVorkommnisseEnabled_when_noVorkommnisseAreGivenInStoreAndSchliessungsuhrzeitIsNotSetForBWB.html
@@ -1,5 +1,6 @@
 <div>
-  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-checkbox" data-test="checkboxKeineVorfaelle">
+  <!--v-if-->
+  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-checkbox" data-test="checkboxKeineVorkommnisse">
     <!---->
     <div class="v-input__control">
       <div class="v-selection-control v-selection-control--density-default v-checkbox-btn">
@@ -7,24 +8,7 @@
           <!---->
           <div class="v-selection-control__input"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                 <path d="M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3M19,5V19H5V5H19Z"></path>
-              </svg></i><input id="checkbox-v-0" aria-disabled="false" aria-label="Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
-        </div><label class="v-label v-label--clickable" for="checkbox-v-0">
-          <!---->Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen.
-        </label>
-      </div>
-    </div>
-    <!---->
-    <!---->
-  </div>
-  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--disabled v-checkbox" data-test="checkboxKeineVorkommnisse">
-    <!---->
-    <div class="v-input__control">
-      <div class="v-selection-control v-selection-control--disabled v-selection-control--density-default v-checkbox-btn">
-        <div class="v-selection-control__wrapper">
-          <!---->
-          <div class="v-selection-control__input"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                <path d="M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3M19,5V19H5V5H19Z"></path>
-              </svg></i><input disabled="" id="checkbox-v-3" aria-disabled="true" aria-label="Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
+              </svg></i><input id="checkbox-v-3" aria-disabled="false" aria-label="Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
         </div><label class="v-label v-label--clickable" for="checkbox-v-3">
           <!---->Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen.
         </label>

--- a/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/__snapshots__/TheEreignisseNoEventsCheckboxes.vue/visual logic/keineVorkommnisse/should_renderKeineVorkommnisseEnabled_when_noVorkommnisseAreGivenInStoreAndSchliessungsuhrzeitIsNotSetForBWB.html
+++ b/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/__snapshots__/TheEreignisseNoEventsCheckboxes.vue/visual logic/keineVorkommnisse/should_renderKeineVorkommnisseEnabled_when_noVorkommnisseAreGivenInStoreAndSchliessungsuhrzeitIsNotSetForBWB.html
@@ -1,13 +1,13 @@
 <div>
-  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-checkbox" data-test="checkboxKeineVorfaelle">
+  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-checkbox" data-test="checkboxKeineVorfaelle">
     <!---->
     <div class="v-input__control">
-      <div class="v-selection-control v-selection-control--dirty v-selection-control--density-default v-checkbox-btn">
+      <div class="v-selection-control v-selection-control--density-default v-checkbox-btn">
         <div class="v-selection-control__wrapper">
           <!---->
           <div class="v-selection-control__input"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                <path d="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3Z"></path>
-              </svg></i><input checked="" id="checkbox-v-0" aria-disabled="false" aria-label="Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
+                <path d="M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3M19,5V19H5V5H19Z"></path>
+              </svg></i><input id="checkbox-v-0" aria-disabled="false" aria-label="Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
         </div><label class="v-label v-label--clickable" for="checkbox-v-0">
           <!---->Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen.
         </label>
@@ -16,15 +16,15 @@
     <!---->
     <!---->
   </div>
-  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-input--disabled v-checkbox" data-test="checkboxKeineVorkommnisse">
+  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--disabled v-checkbox" data-test="checkboxKeineVorkommnisse">
     <!---->
     <div class="v-input__control">
-      <div class="v-selection-control v-selection-control--dirty v-selection-control--disabled v-selection-control--density-default v-checkbox-btn">
+      <div class="v-selection-control v-selection-control--disabled v-selection-control--density-default v-checkbox-btn">
         <div class="v-selection-control__wrapper">
           <!---->
           <div class="v-selection-control__input"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                <path d="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3Z"></path>
-              </svg></i><input checked="" disabled="" id="checkbox-v-3" aria-disabled="true" aria-label="Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
+                <path d="M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3M19,5V19H5V5H19Z"></path>
+              </svg></i><input disabled="" id="checkbox-v-3" aria-disabled="true" aria-label="Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
         </div><label class="v-label v-label--clickable" for="checkbox-v-3">
           <!---->Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen.
         </label>

--- a/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/__snapshots__/TheEreignisseNoEventsCheckboxes.vue/visual logic/keineVorkommnisse/should_renderKeineVorkommnisseEnabled_when_noVorkommnisseAreGivenInStoreAndSchliessunguhrzeitIsSetForUWB.html
+++ b/wls-gui-wahllokalsystem/tests/components/vorfaelleundvorkommnisse/__snapshots__/TheEreignisseNoEventsCheckboxes.vue/visual logic/keineVorkommnisse/should_renderKeineVorkommnisseEnabled_when_noVorkommnisseAreGivenInStoreAndSchliessunguhrzeitIsSetForUWB.html
@@ -7,7 +7,7 @@
           <!---->
           <div class="v-selection-control__input"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
                 <path d="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3Z"></path>
-              </svg></i><input checked="" id="checkbox-v-0" aria-disabled="false" aria-label="Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
+              </svg></i><input id="checkbox-v-0" aria-disabled="false" aria-label="Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen." type="checkbox" value="true" checked=""></div>
         </div><label class="v-label v-label--clickable" for="checkbox-v-0">
           <!---->Besondere Vorfälle während der Wahlhandlung waren nicht zu verzeichnen.
         </label>
@@ -16,15 +16,15 @@
     <!---->
     <!---->
   </div>
-  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-checkbox" data-test="checkboxKeineVorkommnisse">
+  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-checkbox" data-test="checkboxKeineVorkommnisse">
     <!---->
     <div class="v-input__control">
-      <div class="v-selection-control v-selection-control--dirty v-selection-control--density-default v-checkbox-btn">
+      <div class="v-selection-control v-selection-control--density-default v-checkbox-btn">
         <div class="v-selection-control__wrapper">
           <!---->
           <div class="v-selection-control__input"><i class="v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"><svg class="v-icon__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">
-                <path d="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3Z"></path>
-              </svg></i><input checked="" id="checkbox-v-3" aria-disabled="false" aria-label="Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
+                <path d="M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3M19,5V19H5V5H19Z"></path>
+              </svg></i><input id="checkbox-v-3" aria-disabled="false" aria-label="Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen." type="checkbox" value="true"></div>
         </div><label class="v-label v-label--clickable" for="checkbox-v-3">
           <!---->Besondere Vorkommnisse während der Auszählung waren nicht zu verzeichnen.
         </label>

--- a/wls-gui-wahllokalsystem/tests/stores/ereignisStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/ereignisStore.spec.ts
@@ -30,7 +30,8 @@ vi.mock("@/composables/vorfaelleundvorkommnisse/ereignisService", () => ({
 
 const mockedNow = new Date();
 
-const { prepareEreignis } = useVorfaelleundvorkommnisseTestDataFactory();
+const { prepareEreignis, prepareWahlbezirkEreignisse } =
+  useVorfaelleundvorkommnisseTestDataFactory();
 const { prepareUser } = useUserTestDataFactory();
 
 describe("ereignisStore.ts", () => {
@@ -437,8 +438,9 @@ describe("ereignisStore.ts", () => {
       userStore.setUser(prepareUser().wahlbezirkID(wahlbezirkID).build());
       unitUnderTest.isVorfaelleMaintained = false;
 
-      const mockedWahlbezirkEreignisse =
-        WahlbezirkEreignisseBuilder.createEmptyWahlbezirkEreignisse();
+      const mockedWahlbezirkEreignisse = prepareWahlbezirkEreignisse()
+        .ereigniseintraege([])
+        .build();
       mockDefinitions.getEreignisse.mockReturnValue(mockedWahlbezirkEreignisse);
 
       await unitUnderTest.loadEreignisse();
@@ -446,7 +448,9 @@ describe("ereignisStore.ts", () => {
       expect(unitUnderTest.wahlbezirkEreignisse).toStrictEqual(
         mockedWahlbezirkEreignisse
       );
-      expect(unitUnderTest.isVorfaelleMaintained).toBeTruthy();
+      expect(unitUnderTest.isVorfaelleMaintained).toStrictEqual(
+        mockedWahlbezirkEreignisse.keineVorfaelle
+      );
     });
 
     it("should_handleError_when_getEreignisseThrowsError", async () => {
@@ -470,6 +474,10 @@ describe("ereignisStore.ts", () => {
       const wahlbezirkID = "wahlbezirkID";
       userStore.setUser(prepareUser().wahlbezirkID(wahlbezirkID).build());
       unitUnderTest.isVorfaelleMaintained = false;
+      unitUnderTest.wahlbezirkEreignisse = prepareWahlbezirkEreignisse()
+        .keineVorfaelle(true)
+        .ereigniseintraege([])
+        .build();
 
       const mockedDatetime = new Date();
 


### PR DESCRIPTION
# Beschreibung:

- zum Nachstellen:
  - mit UWB-User
  - es dürfen keine Ereignisse und keine Schließungsuhrzeit vorhanden sein
- Fix: die Checkboxen sind zu Beginn leer

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->
<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] ~Doku aktualisiert~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [X] Unit-Tests gepflegt
- [X] ~Texte auf Rechtschreibung und Grammatik geprüft~
- [X] ~Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft~

# Referenzen[^1]:

Verwandt mit Issue #

Closes #2515

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkbox state initialization for incident tracking controls; checkboxes now display with consistent visual states.
  * Updated checkbox styling and SVG icon paths for clarity.
  * Removed unnecessary dirty-state visual indicators from checkbox components.

* **Tests**
  * Updated test snapshots to reflect checkbox appearance and state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->