### PR TITLE
#2053 Die Passworteingabe ist nicht mehr nur im Klartext möglich

### DIFF
--- a/wls-auth-service/src/main/resources-non-filtered/public/js/passwordPressToShow.js
+++ b/wls-auth-service/src/main/resources-non-filtered/public/js/passwordPressToShow.js
@@ -1,0 +1,23 @@
+const passwordInput = document.getElementById("password");
+const holdButton = document.getElementById("password-press-to-show");
+
+if (passwordInput && holdButton) {
+    const showPassword = () => {
+        passwordInput.type = "text";
+    };
+
+    const hidePassword = () => {
+        passwordInput.type = "password";
+    };
+
+    holdButton.addEventListener("pointerdown", showPassword);
+    holdButton.addEventListener("pointerup", hidePassword);
+    holdButton.addEventListener("pointerleave", hidePassword);
+    holdButton.addEventListener("pointercancel", hidePassword);
+    holdButton.addEventListener("keydown", (e) => {
+        if (e.key === " ") showPassword();
+    });
+    holdButton.addEventListener("keyup", (e) => {
+        if (e.key === " ") hidePassword();
+    });
+}

--- a/wls-auth-service/src/main/resources-non-filtered/public/js/passwordPressToShow.js
+++ b/wls-auth-service/src/main/resources-non-filtered/public/js/passwordPressToShow.js
@@ -20,4 +20,7 @@ if (passwordInput && holdButton) {
     holdButton.addEventListener("keyup", (e) => {
         if (e.key === " ") hidePassword();
     });
+    holdButton.addEventListener("blur", hidePassword);
+    window.addEventListener("blur", hidePassword);
+    document.addEventListener("visibilitychange", hidePassword);
 }

--- a/wls-auth-service/src/main/resources-non-filtered/templates/loginat.ftl
+++ b/wls-auth-service/src/main/resources-non-filtered/templates/loginat.ftl
@@ -2,6 +2,34 @@
 <head>
     <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <link rel="stylesheet" href="css/style.css"/>
+    <style>
+        .password-input-wrapper {
+            position: relative;
+        }
+
+        .password-input-wrapper .form-control {
+            padding-right: 40px;
+        }
+
+        .password-press-to-show {
+            position: absolute;
+            top: 0;
+            right: 0;
+            height: 100%;
+            display: flex;
+            align-items: center;
+            border: 0;
+            background: transparent;
+            color: #888;
+            padding: 0 6px;
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .password-press-to-show:hover {
+            color: #444;
+        }
+    </style>
 </head>
 <body>
 <#if error??>
@@ -24,8 +52,19 @@
                         </div>
                         <div class="form-group">
                             <label for="password">Passwort</label>
-                            <input type="password" class="form-control" id="password" name="password"
-                                   placeholder="Passwort" required>
+                            <div class="password-input-wrapper">
+                                <input type="password" class="form-control" id="password" name="password"
+                                       placeholder="Passwort" required>
+                                <button type="button" id="password-press-to-show" class="password-press-to-show"
+                                        aria-label="Passwort anzeigen (gedrückt halten)">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="21" height="21" viewBox="0 0 24 24"
+                                         fill="none" stroke="currentColor" stroke-width="2"
+                                         stroke-linecap="round" stroke-linejoin="round">
+                                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+                                        <circle cx="12" cy="12" r="3"/>
+                                    </svg>
+                                </button>
+                            </div>
                         </div>
                         <input type="hidden" id="csrf_token" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                         <input type="submit" id="submit" value="Login" class="btn btn-default">
@@ -43,5 +82,6 @@
 <script src="js/wro.js" type="text/javascript"></script>
 <script src="js/bootstrap.js" type="text/javascript"></script>
 <script src="js/checkCapslock.js" type="text/javascript"></script>
+<script src="js/passwordPressToShow.js" type="text/javascript"></script>
 </body>
 </html>

--- a/wls-auth-service/src/main/resources-non-filtered/templates/loginwls.ftl
+++ b/wls-auth-service/src/main/resources-non-filtered/templates/loginwls.ftl
@@ -13,6 +13,7 @@
         .material-form-input.password {
             margin: 40px 0;
             padding-bottom: 8px;
+            position: relative;
         }
 
         .material-placeholder {
@@ -77,17 +78,17 @@
                             <label class="material-label">
                                 <input class="material-input" autocomplete="off" type="password" id="password"
                                        name="password" required>
-                                <button type="button" id="password-press-to-show" class="password-press-to-show"
-                                        aria-label="Passwort anzeigen (gedrückt halten)">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="21" height="21" viewBox="0 0 24 24"
-                                         fill="none" stroke="currentColor" stroke-width="2"
-                                         stroke-linecap="round" stroke-linejoin="round">
-                                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
-                                        <circle cx="12" cy="12" r="3"/>
-                                    </svg>
-                                </button>
                                 <span class="material-placeholder">Passwort</span>
                             </label>
+                            <button type="button" id="password-press-to-show" class="password-press-to-show"
+                                    aria-label="Passwort anzeigen (gedrückt halten)">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="21" height="21" viewBox="0 0 24 24"
+                                     fill="none" stroke="currentColor" stroke-width="2"
+                                     stroke-linecap="round" stroke-linejoin="round">
+                                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+                                    <circle cx="12" cy="12" r="3"/>
+                                </svg>
+                            </button>
                         </div>
                         <input type="hidden" id="csrf_token" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                         <div onClick="javascript:this.parentNode.submit();" type="submit" id="submit" value="Login"

--- a/wls-auth-service/src/main/resources-non-filtered/templates/loginwls.ftl
+++ b/wls-auth-service/src/main/resources-non-filtered/templates/loginwls.ftl
@@ -26,6 +26,29 @@
         .lp_minimize {
             visibility: hidden;
         }
+
+        .material-form-input.password .material-input {
+            padding-right: 40px;
+        }
+
+        .password-press-to-show {
+            position: absolute;
+            right: 0;
+            top: 15px;
+            height: 30px;
+            display: flex;
+            align-items: center;
+            border: 0;
+            background: transparent;
+            color: #888;
+            padding: 0 6px;
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .password-press-to-show:hover {
+            color: #444;
+        }
     </style>
 </head>
 <body>
@@ -52,8 +75,17 @@
 
                         <div class="material-form-input password">
                             <label class="material-label">
-                                <input class="material-input" autocomplete="off" type="text" id="password"
+                                <input class="material-input" autocomplete="off" type="password" id="password"
                                        name="password" required>
+                                <button type="button" id="password-press-to-show" class="password-press-to-show"
+                                        aria-label="Passwort anzeigen (gedrückt halten)">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="21" height="21" viewBox="0 0 24 24"
+                                         fill="none" stroke="currentColor" stroke-width="2"
+                                         stroke-linecap="round" stroke-linejoin="round">
+                                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+                                        <circle cx="12" cy="12" r="3"/>
+                                    </svg>
+                                </button>
                                 <span class="material-placeholder">Passwort</span>
                             </label>
                         </div>
@@ -75,6 +107,7 @@
 <script src="js/wro.js" type="text/javascript"></script>
 <script src="js/bootstrap.js" type="text/javascript"></script>
 <script src="js/checkCapslock.js" type="text/javascript"></script>
+<script src="js/passwordPressToShow.js" type="text/javascript"></script>
 
 <script>
 


### PR DESCRIPTION
# Beschreibung:

Passwörter werden standardmäßig maskiert angezeigt und können durch einen neuen Icon-Button (Augen-Symbol) temporär angezeigt werden.
Der Button muss dafür gedrückt gehalten werden. Alternativ ist auch eine Tastatursteuerung möglich (Space-Button).

Die Änderungen wurden für den Wahllokalsystem-Login und den Admintool-Login übernommen.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [ ] Doku aktualisiert
    - [Fachliche Beschreibung][fachliche-beschreibung-link]
    - [UI/UX-Adrs][ui-ux-adrs-link]
- [ ] Unit-Tests gepflegt
- [ ] Texte auf Rechtschreibung und Grammatik geprüft
- [ ] Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft

# Referenzen:

Closes #2053

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a password visibility toggle to login forms, allowing users to press and hold a button (or use the Space key) to temporarily reveal the password during entry.
  * Integrated corresponding UI and styling updates to support the new toggle functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->