### PR TITLE
2542 requests verwenden falsche offline strategie

### DIFF
--- a/wls-gui-wahllokalsystem/src/composables/basisdaten/ungueltigeWahlscheineService.ts
+++ b/wls-gui-wahllokalsystem/src/composables/basisdaten/ungueltigeWahlscheineService.ts
@@ -5,6 +5,7 @@ import {
   Configuration,
   UngueltigeWahlscheineControllerApi,
 } from "@/api/wls-clients/generated-basisdaten-api";
+import { useCommonApiUtils } from "@/composables/api/commonApiUtils.ts";
 import { useUngueltigeWahlscheineMapper } from "@/composables/basisdaten/ungueltigeWahlscheineMapper.ts";
 import { useUserNotificationService } from "@/composables/userNotification/userNotificationService.ts";
 import { BASISDATEN_SERVICE_API_URL } from "@/constants.ts";
@@ -20,6 +21,7 @@ export function useUngueltigeWahlscheineService() {
 
   const { addNotification } = useUserNotificationService();
   const { toModel } = useUngueltigeWahlscheineMapper();
+  const { axiosConfigWrapper } = useCommonApiUtils();
 
   async function getUngueltigeWahlscheine(
     wahltagID: string,
@@ -30,7 +32,8 @@ export function useUngueltigeWahlscheineService() {
       const ungueltigeWahlscheineCSVString = (
         await ungueltigeWahlscheineControllerApi.getUngueltigeWahlscheine(
           wahltagID,
-          wahlbezirksArt
+          wahlbezirksArt,
+          axiosConfigWrapper().requestAsOnlineFirst()
         )
       ).data;
 

--- a/wls-gui-wahllokalsystem/src/composables/ergebnismeldung/common/aWerteService.ts
+++ b/wls-gui-wahllokalsystem/src/composables/ergebnismeldung/common/aWerteService.ts
@@ -2,6 +2,7 @@ import {
   AWerteControllerApi,
   Configuration,
 } from "@/api/wls-clients/generated-ergebnismeldung-api";
+import { useCommonApiUtils } from "@/composables/api/commonApiUtils.ts";
 import { useAWerteMapper } from "@/composables/ergebnismeldung/common/aWerteMapper.ts";
 import { useUserNotificationService } from "@/composables/userNotification/userNotificationService.ts";
 import { ERGEBNISMELDUNG_SERVICE_API_URL } from "@/constants.ts";
@@ -9,6 +10,7 @@ import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotif
 
 const { toModel } = useAWerteMapper();
 const { addNotification } = useUserNotificationService();
+const { axiosConfigWrapper } = useCommonApiUtils();
 
 export function useAWerteService() {
   const aWerteController = new AWerteControllerApi(
@@ -17,7 +19,10 @@ export function useAWerteService() {
 
   async function getAWerte(wahlbezirkId: string, sendNotification = true) {
     try {
-      const response = await aWerteController.getAWerte(wahlbezirkId);
+      const response = await aWerteController.getAWerte(
+        wahlbezirkId,
+        axiosConfigWrapper().requestAsOnlineFirst()
+      );
       if (sendNotification) {
         addNotification(
           `AWerte erfolgreich geladen`,

--- a/wls-gui-wahllokalsystem/src/composables/infomanagement/konfigurationsparameterService.ts
+++ b/wls-gui-wahllokalsystem/src/composables/infomanagement/konfigurationsparameterService.ts
@@ -4,11 +4,11 @@ import {
   Configuration,
   KonfigurationControllerApi,
 } from "@/api/wls-clients/generated-infomanagement-api";
+import { useCommonApiUtils } from "@/composables/api/commonApiUtils.ts";
 import { useKonfigurationsparameterMapper } from "@/composables/infomanagement/konfigurationsparameterMapper.ts";
 import { useUserNotificationService } from "@/composables/userNotification/userNotificationService.ts";
 import { INFOMANAGEMENT_SERVICE_API_URL } from "@/constants.ts";
 import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
-import { useCommonApiUtils } from "@/composables/api/commonApiUtils.ts";
 
 const userNotificationService = useUserNotificationService();
 const { toModel } = useKonfigurationsparameterMapper();

--- a/wls-gui-wahllokalsystem/src/composables/infomanagement/konfigurationsparameterService.ts
+++ b/wls-gui-wahllokalsystem/src/composables/infomanagement/konfigurationsparameterService.ts
@@ -8,9 +8,11 @@ import { useKonfigurationsparameterMapper } from "@/composables/infomanagement/k
 import { useUserNotificationService } from "@/composables/userNotification/userNotificationService.ts";
 import { INFOMANAGEMENT_SERVICE_API_URL } from "@/constants.ts";
 import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
+import { useCommonApiUtils } from "@/composables/api/commonApiUtils.ts";
 
 const userNotificationService = useUserNotificationService();
 const { toModel } = useKonfigurationsparameterMapper();
+const { axiosConfigWrapper } = useCommonApiUtils();
 
 export function useKonfigurationsparameterService() {
   const konfigurationControllerApi = new KonfigurationControllerApi(
@@ -23,7 +25,9 @@ export function useKonfigurationsparameterService() {
     sendNotification = true
   ): Promise<Konfigurationsparameter[]> {
     try {
-      const response = await konfigurationControllerApi.getKonfigurations();
+      const response = await konfigurationControllerApi.getKonfigurations(
+        axiosConfigWrapper().requestAsOnlineFirst()
+      );
       return toModel(response.data);
     } catch {
       if (sendNotification) {

--- a/wls-gui-wahllokalsystem/tests/composables/basisdaten/ungueltigeWahlscheineService.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/basisdaten/ungueltigeWahlscheineService.spec.ts
@@ -2,10 +2,10 @@ import { useWahlbezirkTestDataFactory } from "@tests/utils/wahlbezirk/Wahlbezirk
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useUngueltigeWahlscheineService } from "@/composables/basisdaten/ungueltigeWahlscheineService.ts";
-import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
-import { WahlbezirksArtEnum } from "@/types/wahlbezirksArtEnum.ts";
 import { REQUEST_HEADER_OFFLINE_STRATEGY } from "@/constants.ts";
 import { FetchStrategiesEnum } from "@/types/api/FetchStrategiesEnum.ts";
+import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
+import { WahlbezirksArtEnum } from "@/types/wahlbezirksArtEnum.ts";
 
 const mockDefinitions = vi.hoisted(() => ({
   addNotification: vi.fn(),
@@ -69,8 +69,9 @@ describe("ungueltigeWahlscheineService.ts", () => {
         wahlbezirksArt,
         expect.objectContaining({
           headers: expect.objectContaining({
-            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
-          })
+            [REQUEST_HEADER_OFFLINE_STRATEGY]:
+              FetchStrategiesEnum.STRATEGY_ONLINE_FIRST,
+          }),
         })
       );
       expect(mockDefinitions.addNotification.mock.calls).toStrictEqual([
@@ -102,8 +103,9 @@ describe("ungueltigeWahlscheineService.ts", () => {
         wahlbezirksArt,
         expect.objectContaining({
           headers: expect.objectContaining({
-            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
-          })
+            [REQUEST_HEADER_OFFLINE_STRATEGY]:
+              FetchStrategiesEnum.STRATEGY_ONLINE_FIRST,
+          }),
         })
       );
     });
@@ -127,8 +129,9 @@ describe("ungueltigeWahlscheineService.ts", () => {
         wahlbezirksArt,
         expect.objectContaining({
           headers: expect.objectContaining({
-            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
-          })
+            [REQUEST_HEADER_OFFLINE_STRATEGY]:
+              FetchStrategiesEnum.STRATEGY_ONLINE_FIRST,
+          }),
         })
       );
       expect(mockDefinitions.addNotification.mock.calls).toEqual([
@@ -155,8 +158,9 @@ describe("ungueltigeWahlscheineService.ts", () => {
         wahlbezirksArt,
         expect.objectContaining({
           headers: expect.objectContaining({
-            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
-          })
+            [REQUEST_HEADER_OFFLINE_STRATEGY]:
+              FetchStrategiesEnum.STRATEGY_ONLINE_FIRST,
+          }),
         })
       );
       expect(mockDefinitions.addNotification.mock.calls).toHaveLength(0);

--- a/wls-gui-wahllokalsystem/tests/composables/basisdaten/ungueltigeWahlscheineService.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/basisdaten/ungueltigeWahlscheineService.spec.ts
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useUngueltigeWahlscheineService } from "@/composables/basisdaten/ungueltigeWahlscheineService.ts";
 import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
 import { WahlbezirksArtEnum } from "@/types/wahlbezirksArtEnum.ts";
+import { REQUEST_HEADER_OFFLINE_STRATEGY } from "@/constants.ts";
+import { FetchStrategiesEnum } from "@/types/api/FetchStrategiesEnum.ts";
 
 const mockDefinitions = vi.hoisted(() => ({
   addNotification: vi.fn(),
@@ -62,8 +64,14 @@ describe("ungueltigeWahlscheineService.ts", () => {
       expect(mockDefinitions.mapToModel.mock.calls).toStrictEqual([
         [mockedUngueltigeWahlscheineApiResponseData],
       ]);
-      expect(mockDefinitions.getUngueltigeWahlscheine.mock.calls).toStrictEqual(
-        [[wahltagID, wahlbezirksArt]]
+      expect(mockDefinitions.getUngueltigeWahlscheine).toHaveBeenCalledWith(
+        wahltagID,
+        wahlbezirksArt,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
+          })
+        })
       );
       expect(mockDefinitions.addNotification.mock.calls).toStrictEqual([
         [expect.any(String), UserNotificationCategoryEnum.SUCCESS],
@@ -89,6 +97,15 @@ describe("ungueltigeWahlscheineService.ts", () => {
       await getUngueltigeWahlscheine(wahltagID, wahlbezirksArt, false);
 
       expect(mockDefinitions.addNotification.mock.calls).toHaveLength(0);
+      expect(mockDefinitions.getUngueltigeWahlscheine).toHaveBeenCalledWith(
+        wahltagID,
+        wahlbezirksArt,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
+          })
+        })
+      );
     });
 
     it("should_addNotification_when_apiCallFailed", async () => {
@@ -105,8 +122,14 @@ describe("ungueltigeWahlscheineService.ts", () => {
       ).rejects.toThrow(apiCallError);
 
       expect(mockDefinitions.mapToModel.mock.calls).toHaveLength(0);
-      expect(mockDefinitions.getUngueltigeWahlscheine.mock.calls).toStrictEqual(
-        [[wahltagID, wahlbezirksArt]]
+      expect(mockDefinitions.getUngueltigeWahlscheine).toHaveBeenCalledWith(
+        wahltagID,
+        wahlbezirksArt,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
+          })
+        })
       );
       expect(mockDefinitions.addNotification.mock.calls).toEqual([
         [expect.any(String), UserNotificationCategoryEnum.ERROR],
@@ -127,8 +150,14 @@ describe("ungueltigeWahlscheineService.ts", () => {
       ).rejects.toThrow(apiCallError);
 
       expect(mockDefinitions.mapToModel.mock.calls).toHaveLength(0);
-      expect(mockDefinitions.getUngueltigeWahlscheine.mock.calls).toStrictEqual(
-        [[wahltagID, wahlbezirksArt]]
+      expect(mockDefinitions.getUngueltigeWahlscheine).toHaveBeenCalledWith(
+        wahltagID,
+        wahlbezirksArt,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
+          })
+        })
       );
       expect(mockDefinitions.addNotification.mock.calls).toHaveLength(0);
     });

--- a/wls-gui-wahllokalsystem/tests/composables/ergebnismeldung/common/aWerteService.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/ergebnismeldung/common/aWerteService.spec.ts
@@ -12,9 +12,9 @@ import {
 } from "vitest";
 
 import { useAWerteService } from "@/composables/ergebnismeldung/common/aWerteService.ts";
-import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
 import { REQUEST_HEADER_OFFLINE_STRATEGY } from "@/constants.ts";
 import { FetchStrategiesEnum } from "@/types/api/FetchStrategiesEnum.ts";
+import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
 
 const mockDefinitions = vi.hoisted(() => ({
   mapToModel: vi.fn(),
@@ -81,8 +81,9 @@ describe("aWerteService.ts", () => {
         wahlbezirkId,
         expect.objectContaining({
           headers: expect.objectContaining({
-            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
-          })
+            [REQUEST_HEADER_OFFLINE_STRATEGY]:
+              FetchStrategiesEnum.STRATEGY_ONLINE_FIRST,
+          }),
         })
       );
       expect(mockDefinitions.addNotification.mock.calls).toEqual([
@@ -112,8 +113,9 @@ describe("aWerteService.ts", () => {
         wahlbezirkId,
         expect.objectContaining({
           headers: expect.objectContaining({
-            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
-          })
+            [REQUEST_HEADER_OFFLINE_STRATEGY]:
+              FetchStrategiesEnum.STRATEGY_ONLINE_FIRST,
+          }),
         })
       );
     });
@@ -133,8 +135,9 @@ describe("aWerteService.ts", () => {
         wahlbezirkId,
         expect.objectContaining({
           headers: expect.objectContaining({
-            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
-          })
+            [REQUEST_HEADER_OFFLINE_STRATEGY]:
+              FetchStrategiesEnum.STRATEGY_ONLINE_FIRST,
+          }),
         })
       );
     });
@@ -154,8 +157,9 @@ describe("aWerteService.ts", () => {
         wahlbezirkId,
         expect.objectContaining({
           headers: expect.objectContaining({
-            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
-          })
+            [REQUEST_HEADER_OFFLINE_STRATEGY]:
+              FetchStrategiesEnum.STRATEGY_ONLINE_FIRST,
+          }),
         })
       );
     });

--- a/wls-gui-wahllokalsystem/tests/composables/ergebnismeldung/common/aWerteService.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/ergebnismeldung/common/aWerteService.spec.ts
@@ -13,6 +13,8 @@ import {
 
 import { useAWerteService } from "@/composables/ergebnismeldung/common/aWerteService.ts";
 import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
+import { REQUEST_HEADER_OFFLINE_STRATEGY } from "@/constants.ts";
+import { FetchStrategiesEnum } from "@/types/api/FetchStrategiesEnum.ts";
 
 const mockDefinitions = vi.hoisted(() => ({
   mapToModel: vi.fn(),
@@ -75,9 +77,14 @@ describe("aWerteService.ts", () => {
       const result = await unitUnderTest.getAWerte(wahlbezirkId);
       expect(result).toStrictEqual([mockedAWerteModel, mockedAWerteModel]);
 
-      expect(mockDefinitions.getAWerte.mock.calls).toStrictEqual([
-        [wahlbezirkId],
-      ]);
+      expect(mockDefinitions.getAWerte).toHaveBeenCalledWith(
+        wahlbezirkId,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
+          })
+        })
+      );
       expect(mockDefinitions.addNotification.mock.calls).toEqual([
         [expect.any(String), UserNotificationCategoryEnum.SUCCESS],
       ]);
@@ -101,6 +108,14 @@ describe("aWerteService.ts", () => {
       expect(mockDefinitions.addNotification.mock.calls.length).toStrictEqual(
         0
       );
+      expect(mockDefinitions.getAWerte).toHaveBeenCalledWith(
+        wahlbezirkId,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
+          })
+        })
+      );
     });
 
     it("should_throwErrorAndSendNotification_when_apiCallFailed", async () => {
@@ -114,6 +129,14 @@ describe("aWerteService.ts", () => {
       expect(mockDefinitions.addNotification.mock.calls).toEqual([
         [expect.any(String), UserNotificationCategoryEnum.ERROR],
       ]);
+      expect(mockDefinitions.getAWerte).toHaveBeenCalledWith(
+        wahlbezirkId,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
+          })
+        })
+      );
     });
 
     it("should_throwErrorAndSendNoNotification_when_apiCallFailedAndSendNotificationIsFalse", async () => {
@@ -126,6 +149,14 @@ describe("aWerteService.ts", () => {
       ).rejects.toThrow(`Get AWerte failed for wahlbezirkId: ${wahlbezirkId}`);
       expect(mockDefinitions.addNotification.mock.calls.length).toStrictEqual(
         0
+      );
+      expect(mockDefinitions.getAWerte).toHaveBeenCalledWith(
+        wahlbezirkId,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
+          })
+        })
       );
     });
   });

--- a/wls-gui-wahllokalsystem/tests/composables/infomanagement/konfigurationsparameterService.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/infomanagement/konfigurationsparameterService.spec.ts
@@ -2,9 +2,9 @@ import { useKonfigurationsparameterTestDataFactory } from "@tests/utils/infomana
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useKonfigurationsparameterService } from "@/composables/infomanagement/konfigurationsparameterService.ts";
-import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
 import { REQUEST_HEADER_OFFLINE_STRATEGY } from "@/constants.ts";
 import { FetchStrategiesEnum } from "@/types/api/FetchStrategiesEnum.ts";
+import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
 
 const mockDefinitions = vi.hoisted(() => ({
   getKonfigurations: vi.fn(),
@@ -64,8 +64,9 @@ describe("konfigurationsparameterService", () => {
       expect(mockDefinitions.getKonfigurations).toHaveBeenCalledWith(
         expect.objectContaining({
           headers: expect.objectContaining({
-            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
-          })
+            [REQUEST_HEADER_OFFLINE_STRATEGY]:
+              FetchStrategiesEnum.STRATEGY_ONLINE_FIRST,
+          }),
         })
       );
     });
@@ -89,8 +90,9 @@ describe("konfigurationsparameterService", () => {
       expect(mockDefinitions.getKonfigurations).toHaveBeenCalledWith(
         expect.objectContaining({
           headers: expect.objectContaining({
-            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
-          })
+            [REQUEST_HEADER_OFFLINE_STRATEGY]:
+              FetchStrategiesEnum.STRATEGY_ONLINE_FIRST,
+          }),
         })
       );
     });
@@ -110,8 +112,9 @@ describe("konfigurationsparameterService", () => {
       expect(mockDefinitions.getKonfigurations).toHaveBeenCalledWith(
         expect.objectContaining({
           headers: expect.objectContaining({
-            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
-          })
+            [REQUEST_HEADER_OFFLINE_STRATEGY]:
+              FetchStrategiesEnum.STRATEGY_ONLINE_FIRST,
+          }),
         })
       );
     });

--- a/wls-gui-wahllokalsystem/tests/composables/infomanagement/konfigurationsparameterService.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/infomanagement/konfigurationsparameterService.spec.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useKonfigurationsparameterService } from "@/composables/infomanagement/konfigurationsparameterService.ts";
 import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
+import { REQUEST_HEADER_OFFLINE_STRATEGY } from "@/constants.ts";
+import { FetchStrategiesEnum } from "@/types/api/FetchStrategiesEnum.ts";
 
 const mockDefinitions = vi.hoisted(() => ({
   getKonfigurations: vi.fn(),
@@ -59,6 +61,13 @@ describe("konfigurationsparameterService", () => {
       const result = await getKonfigurationsparameter();
 
       expect(result).toEqual(mockedMappedKonfigurationsparameter);
+      expect(mockDefinitions.getKonfigurations).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
+          })
+        })
+      );
     });
 
     it("should_triggerNotification_when_anExceptionOccurredDuringApiCall", async () => {
@@ -77,6 +86,13 @@ describe("konfigurationsparameterService", () => {
         expect.any(String),
         UserNotificationCategoryEnum.ERROR,
       ]);
+      expect(mockDefinitions.getKonfigurations).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
+          })
+        })
+      );
     });
 
     it("should_notTriggerNotification_when_anExceptionOccurredDuringApiCallAndNotificationFlagFalse", async () => {
@@ -90,6 +106,13 @@ describe("konfigurationsparameterService", () => {
 
       expect(mockDefinitions.addNotification.mock.calls.length).toStrictEqual(
         0
+      );
+      expect(mockDefinitions.getKonfigurations).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            [REQUEST_HEADER_OFFLINE_STRATEGY]: FetchStrategiesEnum.STRATEGY_ONLINE_FIRST
+          })
+        })
       );
     });
   });


### PR DESCRIPTION
# Beschreibung:

Die Requests für AWerte, Konfiguration und UngültigeWahlscheine verwenden jetzt die Strategie ONLINE_FIRST anstatt der zuvor greifenden Default-Strategie.

Zusätzlich wurden noch die zugehörigen Frontend-Tests angepasst, damit die Übergabe der Requests-Strategie ebenfalls geprüft wird.

## Definition of Done (DoD):
### Frontend
- [X] [Naming Conventions][naming-conventions-link] beachtet
- [ ] Doku aktualisiert
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [X] Unit-Tests gepflegt
- [X] Texte auf Rechtschreibung und Grammatik geprüft
- [X] Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft

Closes #2542 

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Data retrieval now uses online-first fetch strategy for invalid ballots, A-values, and configuration parameters.

* **Tests**
  * Test suites updated to verify online-first request configuration is correctly applied across all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->