### PR TITLE
2027 es können keine ergebnisdaten mehr gespeichert werden nachdem die niederschrift gedruckt wurde

### DIFF
--- a/docs/src/about/index.md
+++ b/docs/src/about/index.md
@@ -337,3 +337,5 @@ Im Urnenwahl - sowie im Briefwahlbezirk wird von der Schriftführung eine Wahlni
 Wahlhandlung sowie die Ermittlung und Feststellung des Wahlergebnisses erstellt.
 
 Die Niederschrift wird automatisch erstellt, kann dann korrigiert und versendet sowie gedruckt werden.
+Nach dem Druck der Niederschrift gilt die entsprechende Wahl als abgeschlossen. Alle Speicher-Buttons für Inputs 
+dieser Wahl sind deaktiviert und die Nutzer\*innen können keine neuen Werte mehr erfassen.

--- a/docs/src/about/index.md
+++ b/docs/src/about/index.md
@@ -337,5 +337,5 @@ Im Urnenwahl - sowie im Briefwahlbezirk wird von der Schriftführung eine Wahlni
 Wahlhandlung sowie die Ermittlung und Feststellung des Wahlergebnisses erstellt.
 
 Die Niederschrift wird automatisch erstellt, kann dann korrigiert und versendet sowie gedruckt werden.
-Nach dem Druck der Niederschrift gilt die entsprechende Wahl als abgeschlossen. Alle Speicher-Buttons für Inputs 
+Nach dem Druck der Niederschrift gilt die entsprechende Wahl als abgeschlossen. Alle Speicher-Buttons für Inputs
 dieser Wahl sind deaktiviert und die Nutzer\*innen können keine neuen Werte mehr erfassen.

--- a/wls-gui-wahllokalsystem/src/components/ergebnismeldung/MBW/stapelAB/TheMBWGueltigeStimmzettelErfassenCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/ergebnismeldung/MBW/stapelAB/TheMBWGueltigeStimmzettelErfassenCard.vue
@@ -11,7 +11,9 @@
     </v-card-text>
     <v-card-actions>
       <base-button-save
-        :disabled="!isGueltigeStimmzettelErfassenTableValid"
+        :disabled="
+          isMBWAuszaehlungDone || !isGueltigeStimmzettelErfassenTableValid
+        "
         :loading="isErgebnisseSaving"
         :tabindex="modelValue.length * 2 + 1"
         save-text="Speichern und Weiter"
@@ -24,7 +26,7 @@
 import type { MbwErgebnisseAndWahlvorschlag } from "@/types/ergebnismeldung/MBW/MbwErgebnisseAndWahlvorschlag.ts";
 import type { PropType } from "vue";
 
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 import BaseButtonSave from "@/components/common/buttons/BaseButtonSave.vue";
 import TheMBWGueltigeStimmzettelErfassenTable from "@/components/ergebnismeldung/MBW/stapelAB/TheMBWGueltigeStimmzettelErfassenTable.vue";
@@ -34,7 +36,7 @@ import router from "@/plugins/router.ts";
 import { useWorkflowStore } from "@/stores/workflowStore.ts";
 import { MbwRoutesEnum } from "@/types/navigation/MbwRoutesEnum.ts";
 
-const { setStepDone } = useWorkflowStore();
+const { setStepDone, isElectionFinished } = useWorkflowStore();
 const { getNextRoute } = useNavigationUtils();
 
 const modelValue = defineModel({
@@ -59,6 +61,9 @@ const { isErgebnisseSaving, saveGueltigeErgebnisse } = useMbwUtils(
 );
 
 const isGueltigeStimmzettelErfassenTableValid = ref<boolean | null>(null);
+const isMBWAuszaehlungDone = computed(() =>
+  isElectionFinished(props.wahlID, props.wahlbezirkID ?? "")
+);
 
 async function onSaveClicked() {
   await saveGueltigeErgebnisse(modelValue.value);

--- a/wls-gui-wahllokalsystem/src/components/ergebnismeldung/MBW/stapelAB/TheMBWGueltigeStimmzettelErfassenCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/ergebnismeldung/MBW/stapelAB/TheMBWGueltigeStimmzettelErfassenCard.vue
@@ -62,7 +62,7 @@ const { isErgebnisseSaving, saveGueltigeErgebnisse } = useMbwUtils(
 
 const isGueltigeStimmzettelErfassenTableValid = ref<boolean | null>(null);
 const isMBWAuszaehlungDone = computed(() =>
-  isElectionFinished(props.wahlID, props.wahlbezirkID ?? "")
+  isElectionFinished(props.wahlID, props.wahlbezirkID)
 );
 
 async function onSaveClicked() {

--- a/wls-gui-wahllokalsystem/src/components/ergebnismeldung/MBW/stapelBC/BaseCardWahlvorschlagKandidatenStimmenErfassen.vue
+++ b/wls-gui-wahllokalsystem/src/components/ergebnismeldung/MBW/stapelBC/BaseCardWahlvorschlagKandidatenStimmenErfassen.vue
@@ -11,7 +11,7 @@
     </v-card-text>
     <v-card-actions>
       <base-button-save
-        :disabled="!isFormValid"
+        :disabled="isWahlFinished || !isFormValid"
         :loading="isSaving"
         @click="onSaveButtonClicked"
       />
@@ -35,6 +35,10 @@ const wahlvorschlagModel = defineModel("modelValue", {
 
 defineProps({
   isSaving: {
+    type: Boolean,
+    required: true,
+  },
+  isWahlFinished: {
     type: Boolean,
     required: true,
   },

--- a/wls-gui-wahllokalsystem/src/components/ergebnismeldung/MBW/stapelBC/TheWahlvorschlaegeKandidatenStimmenCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/ergebnismeldung/MBW/stapelBC/TheWahlvorschlaegeKandidatenStimmenCard.vue
@@ -191,7 +191,7 @@ const expandedRowIndex = ref<number | null>(null);
 const dirtyRows = ref<Record<number, boolean>>({});
 
 const isMBWAuszaehlungDone = computed(() =>
-  isElectionFinished(props.wahlID, props.wahlbezirkID ?? "")
+  isElectionFinished(props.wahlID, props.wahlbezirkID)
 );
 
 const COUNT_COLUMNS_BEFORE_SUM = 3;

--- a/wls-gui-wahllokalsystem/src/components/ergebnismeldung/MBW/stapelBC/TheWahlvorschlaegeKandidatenStimmenCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/ergebnismeldung/MBW/stapelBC/TheWahlvorschlaegeKandidatenStimmenCard.vue
@@ -92,6 +92,7 @@
                     <base-card-wahlvorschlag-kandidaten-stimmen-erfassen
                       :model-value="proxyModel.value[index]!"
                       :is-saving="isSaving"
+                      :is-wahl-finished="isMBWAuszaehlungDone"
                       @do-save="onSaveWahlvorschlag(index, save)"
                       @dirty="onInputChanged(index)"
                     />
@@ -156,7 +157,7 @@ import { useWorkflowStore } from "@/stores/workflowStore.ts";
 import { MbwRoutesEnum } from "@/types/navigation/MbwRoutesEnum.ts";
 
 const { scrollIntoView } = useViewportUtils();
-const { setStepDone } = useWorkflowStore();
+const { setStepDone, isElectionFinished } = useWorkflowStore();
 const { getNextRoute } = useNavigationUtils();
 
 const COLUMN_COUNT_FULL_COL_SPAN = 8;
@@ -188,6 +189,10 @@ const { loadAndCombineErgebnisseAndWahlvorschlaege } = useMbwUtils(
 const ergebnisseAndWahlvorschlaege = ref<MbwErgebnisseAndWahlvorschlag[]>([]);
 const expandedRowIndex = ref<number | null>(null);
 const dirtyRows = ref<Record<number, boolean>>({});
+
+const isMBWAuszaehlungDone = computed(() =>
+  isElectionFinished(props.wahlID, props.wahlbezirkID ?? "")
+);
 
 const COUNT_COLUMNS_BEFORE_SUM = 3;
 

--- a/wls-gui-wahllokalsystem/src/components/ergebnismeldung/common/BaseCardSnippedErgebnis.vue
+++ b/wls-gui-wahllokalsystem/src/components/ergebnismeldung/common/BaseCardSnippedErgebnis.vue
@@ -14,7 +14,7 @@
       <v-card-actions>
         <base-button-save
           :loading="isErgebnisSaving"
-          :disabled="!isFormValid"
+          :disabled="isWahlFinished || !isFormValid"
           save-text="Speichern und Weiter"
           @click="onSaveClicked"
         />
@@ -55,6 +55,10 @@ defineProps({
     type: Boolean,
     required: false,
     default: false,
+  },
+  isWahlFinished: {
+    type: Boolean,
+    required: true,
   },
 });
 

--- a/wls-gui-wahllokalsystem/src/components/ergebnismeldung/common/TheErgebnisermittlungStimmzettelumschlaegeCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/ergebnismeldung/common/TheErgebnisermittlungStimmzettelumschlaegeCard.vue
@@ -120,7 +120,7 @@ const wahl = computed(() => wahlenActions.getWahlOrUndefinedById(props.wahlId));
 const anzahlStimmzettelValidForm = ref<null | boolean>(null);
 
 const isMBWAuszaehlungDone = computed(() =>
-  isElectionFinished(props.wahlId, props.wahlbezirkId ?? "")
+  isElectionFinished(props.wahlId, props.wahlbezirkId)
 );
 const isSaveButtonDisabled = computed(() => {
   return !anzahlStimmzettelValidForm.value;

--- a/wls-gui-wahllokalsystem/src/components/ergebnismeldung/common/TheErgebnisermittlungStimmzettelumschlaegeCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/ergebnismeldung/common/TheErgebnisermittlungStimmzettelumschlaegeCard.vue
@@ -25,7 +25,7 @@
       <v-card-actions>
         <base-button-save
           :loading="stimmzettelumschlaegeState.isStimmzettelumschlaegeSaving"
-          :disabled="isSaveButtonDisabled"
+          :disabled="isMBWAuszaehlungDone || isSaveButtonDisabled"
           save-text="Speichern und Weiter"
           @click="onSaveClicked"
         />
@@ -113,12 +113,15 @@ const {
   getDialogContent,
 } = useSingleDifferenceDialogUtils(props.wahlId, props.wahlbezirkId);
 const { getNextRoute } = useNavigationUtils();
-const { setStepDone } = useWorkflowStore();
+const { setStepDone, isElectionFinished } = useWorkflowStore();
 
 const wahl = computed(() => wahlenActions.getWahlOrUndefinedById(props.wahlId));
 
 const anzahlStimmzettelValidForm = ref<null | boolean>(null);
 
+const isMBWAuszaehlungDone = computed(() =>
+  isElectionFinished(props.wahlId, props.wahlbezirkId ?? "")
+);
 const isSaveButtonDisabled = computed(() => {
   return !anzahlStimmzettelValidForm.value;
 });

--- a/wls-gui-wahllokalsystem/src/views/ergebnismeldung/MBW/MBWStapelDView.vue
+++ b/wls-gui-wahllokalsystem/src/views/ergebnismeldung/MBW/MBWStapelDView.vue
@@ -3,6 +3,7 @@
     v-model="ergebnis"
     snipped-title="Ungültige Stimmzettel"
     :is-ergebnis-saving="isErgebnisSaving"
+    :is-wahl-finished="isMBWAuszaehlungDone"
     @save="onSave"
   />
 </template>
@@ -11,7 +12,7 @@
 import type { Ergebnis } from "@/types/ergebnismeldung/common/Ergebnis.ts";
 import type { Ergebnisse } from "@/types/ergebnismeldung/common/Ergebnisse.ts";
 
-import { onMounted, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 import BaseCardSnippedErgebnis from "@/components/ergebnismeldung/common/BaseCardSnippedErgebnis.vue";
@@ -29,7 +30,7 @@ const route = useRoute();
 const router = useRouter();
 const { wahlenActions } = useWahlenStore();
 const { getWahlbezirkIdFromWahlMetaDataByWahlId } = useUserStore();
-const { setStepDone } = useWorkflowStore();
+const { setStepDone, isElectionFinished } = useWorkflowStore();
 const { getErgebnisse, postErgebnisse } = useErgebnisService();
 const { logError } = useLogging("requestStrategies");
 const { getNextRoute } = useNavigationUtils();
@@ -47,6 +48,10 @@ const ergebnis = ref<Ergebnis>({
   ergebnis: null,
   numIndex: null,
 });
+
+const isMBWAuszaehlungDone = computed(() =>
+  isElectionFinished(wahlID, wahlbezirkID ?? "")
+);
 
 if (!wahl) {
   router.push({

--- a/wls-gui-wahllokalsystem/stories/components/ergebnismeldung/common/BaseCardSnippedErgebnis.stories.ts
+++ b/wls-gui-wahllokalsystem/stories/components/ergebnismeldung/common/BaseCardSnippedErgebnis.stories.ts
@@ -21,6 +21,7 @@ export const Default: Story = {
   args: {
     modelValue: prepareErgebnis().build(),
     snippedTitle: "Ungültige Stimmzettel",
+    isWahlFinished: false,
   },
 };
 
@@ -30,5 +31,6 @@ export const MinMaxValue: Story = {
     snippedTitle: "Ungültige Stimmzettel",
     minValue: 5,
     maxValue: 20,
+    isWahlFinished: false,
   },
 };

--- a/wls-gui-wahllokalsystem/tests/components/ergebnismeldung/common/BaseCardSnippedErgebnis.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/components/ergebnismeldung/common/BaseCardSnippedErgebnis.spec.ts
@@ -27,6 +27,7 @@ describe("BaseCardSnippedErgebnis.vue", () => {
         props: {
           modelValue: prepareErgebnis().ergebnis(10000).build(),
           snippedTitle: "BaseCard",
+          isWahlFinished: false,
         },
       });
 
@@ -42,6 +43,7 @@ describe("BaseCardSnippedErgebnis.vue", () => {
           modelValue: prepareErgebnis().ergebnis(5).build(),
           snippedTitle: "BaseCard",
           minValue: 10,
+          isWahlFinished: false,
         },
       });
 
@@ -56,6 +58,7 @@ describe("BaseCardSnippedErgebnis.vue", () => {
         props: {
           modelValue: prepareErgebnis().ergebnis(20).build(),
           snippedTitle: "BaseCard",
+          isWahlFinished: false,
         },
       });
 


### PR DESCRIPTION
# Beschreibung:

speicher buttons für eingaben der mbw sind disabled, sobald die niederschrift gedruckt wurde

## Hinweis

damit man sich in der anwendung durchklicken kann und diese sich nach dem drucken der niederschrift wie gewünscht verhält, sind die anpassungen aus pr #2568 notwendig. alternativ kann man den wert `isNiederschriftDone` im Workflowstore manuell auf true setzen

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Dokumentation -->
### Dokumentation
- [ ] ~Links geprüft~
- [x] Texte auf Rechtschreibung und Grammatik geprüft
- [x] Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft

<!-- Frontend -->
### Frontend
- [ ] ~[Naming Conventions][naming-conventions-link] beachtet~
- [x] Doku aktualisiert
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [ ] ~Unit-Tests gepflegt~
- [ ] ~Texte auf Rechtschreibung und Grammatik geprüft~
- [ ] ~Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft~

# Referenzen[^1]:

Closes #2027

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Save buttons and input controls now automatically disable when an election is marked as complete, preventing further data entry.

* **Documentation**
  * Added post-processing rules documenting election completion behavior.

* **Tests**
  * Updated test scenarios to cover the new election completion state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->