### PR TITLE
set workflow states for navigation

### DIFF
--- a/wls-gui-wahllokalsystem/src/views/ergebnismeldung/MBW/MBWNiederschriftView.vue
+++ b/wls-gui-wahllokalsystem/src/views/ergebnismeldung/MBW/MBWNiederschriftView.vue
@@ -65,6 +65,7 @@ import { useWahlenStore } from "@/stores/wahlenStore.ts";
 import { useWorkflowStore } from "@/stores/workflowStore.ts";
 import { InputFeedbackTypeEnum } from "@/types/common/InputFeedbackTypeEnum.ts";
 import { MeldungsArtEnum } from "@/types/ergebnismeldung/common/MeldungsartEnum.ts";
+import { MbwRoutesEnum } from "@/types/navigation/MbwRoutesEnum.ts";
 
 const route = useRoute();
 const router = useRouter();
@@ -76,7 +77,7 @@ const { isNiederschriftAndStatusSaving } = storeToRefs(
 const { hasDoneVorkommnisse } = useEreignisUtils();
 const { status } = storeToRefs(useStatusStore());
 const { getEreignisse } = useEreignisService();
-const { getElectionWorkflowState } = useWorkflowStore();
+const { setStepDone, getElectionWorkflowState } = useWorkflowStore();
 
 // button logic to be implemented
 const isKorrigierenValid = ref<null | boolean>();
@@ -127,6 +128,15 @@ async function onDruckenClicked() {
     printWindow.document.body.innerHTML = pdfText;
     printWindow.print();
     printWindow.close();
+
+    setStepDone(
+      wahlID,
+      currentUserWahlbezirkID,
+      MbwRoutesEnum.MBW_NIEDERSCHRIFT
+    );
+    if (workflowState.value) {
+      workflowState.value.isNiederschriftDone = true;
+    }
   }
   const statusForWahlAndWahlbezirk = status.value.find(
     (status) =>
@@ -135,9 +145,6 @@ async function onDruckenClicked() {
   );
   if (statusForWahlAndWahlbezirk) {
     statusForWahlAndWahlbezirk.niederschrift.gedruckt = true;
-  }
-  if (workflowState.value) {
-    workflowState.value.isNiederschriftDone = true;
   }
   await sendAusdruckNiederschrift(MeldungsArtEnum.Niederschrift, pdfText);
 

--- a/wls-gui-wahllokalsystem/src/views/ergebnismeldung/MBW/MBWNiederschriftView.vue
+++ b/wls-gui-wahllokalsystem/src/views/ergebnismeldung/MBW/MBWNiederschriftView.vue
@@ -45,7 +45,7 @@
 import type { WahlbezirkEreignisse } from "@/types/vorfaelleundvorkommnisse/WahlbezirkEreignisse.ts";
 
 import { storeToRefs } from "pinia";
-import { onActivated, ref } from "vue";
+import { computed, onActivated, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 import BaseErgebnismeldungCardsContainer from "@/components/ergebnismeldung/common/BaseErgebnismeldungCardsContainer.vue";
@@ -62,6 +62,7 @@ import { ROUTE_NOTFOUND } from "@/constants.ts";
 import { useErgebnismeldungStore } from "@/stores/ergebnismeldungStore.ts";
 import { useStatusStore } from "@/stores/statusStore.ts";
 import { useWahlenStore } from "@/stores/wahlenStore.ts";
+import { useWorkflowStore } from "@/stores/workflowStore.ts";
 import { InputFeedbackTypeEnum } from "@/types/common/InputFeedbackTypeEnum.ts";
 import { MeldungsArtEnum } from "@/types/ergebnismeldung/common/MeldungsartEnum.ts";
 
@@ -75,6 +76,7 @@ const { isNiederschriftAndStatusSaving } = storeToRefs(
 const { hasDoneVorkommnisse } = useEreignisUtils();
 const { status } = storeToRefs(useStatusStore());
 const { getEreignisse } = useEreignisService();
+const { getElectionWorkflowState } = useWorkflowStore();
 
 // button logic to be implemented
 const isKorrigierenValid = ref<null | boolean>();
@@ -94,6 +96,10 @@ if (!wahl) {
     name: ROUTE_NOTFOUND,
   });
 }
+
+const workflowState = computed(() =>
+  getElectionWorkflowState(wahlID, currentUserWahlbezirkID)
+);
 
 onActivated(async () => {
   ereignisse.value = await getEreignisse(currentUserWahlbezirkID);
@@ -129,6 +135,9 @@ async function onDruckenClicked() {
   );
   if (statusForWahlAndWahlbezirk) {
     statusForWahlAndWahlbezirk.niederschrift.gedruckt = true;
+  }
+  if (workflowState.value) {
+    workflowState.value.isNiederschriftDone = true;
   }
   await sendAusdruckNiederschrift(MeldungsArtEnum.Niederschrift, pdfText);
 

--- a/wls-gui-wahllokalsystem/src/views/ergebnismeldung/MBW/MBWSchnellmeldungView.vue
+++ b/wls-gui-wahllokalsystem/src/views/ergebnismeldung/MBW/MBWSchnellmeldungView.vue
@@ -127,10 +127,10 @@ async function onDruckenClicked() {
         isSendenActive.value = false;
         setStepDone(wahlID, wahlbezirkID, MbwRoutesEnum.MBW_SCHNELLMELDUNG);
         await router.push(getNextRoute());
-      }
 
-      if (workflowState.value) {
-        workflowState.value.isSchnellmeldungDone = true;
+        if (workflowState.value) {
+          workflowState.value.isSchnellmeldungDone = true;
+        }
       }
 
       // todo update status #2002

--- a/wls-gui-wahllokalsystem/src/views/ergebnismeldung/MBW/MBWSchnellmeldungView.vue
+++ b/wls-gui-wahllokalsystem/src/views/ergebnismeldung/MBW/MBWSchnellmeldungView.vue
@@ -34,7 +34,7 @@
 import type { SchnellmeldungDruckInput } from "@/types/ergebnismeldung/common/SchnellmeldungDruckInput.ts";
 
 import { storeToRefs } from "pinia";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 import BaseErgebnismeldungCardsContainer from "@/components/ergebnismeldung/common/BaseErgebnismeldungCardsContainer.vue";
@@ -69,7 +69,7 @@ const {
   prepareDataForSchnellmeldungDruck,
 } = useMbwUtils(wahlID, wahlbezirkID);
 const { buildSchnellmeldungTemplateFromData } = useSchnellmeldungDruck();
-const { setStepDone } = useWorkflowStore();
+const { setStepDone, getElectionWorkflowState } = useWorkflowStore();
 const { getNextRoute } = useNavigationUtils();
 
 // button logic to be implemented
@@ -84,6 +84,10 @@ if (!wahl) {
     name: ROUTE_NOTFOUND,
   });
 }
+
+const workflowState = computed(() =>
+  getElectionWorkflowState(wahlID, wahlbezirkID)
+);
 
 function onSendenClicked() {
   sendSchnellmeldung();
@@ -123,6 +127,10 @@ async function onDruckenClicked() {
         isSendenActive.value = false;
         setStepDone(wahlID, wahlbezirkID, MbwRoutesEnum.MBW_SCHNELLMELDUNG);
         await router.push(getNextRoute());
+      }
+
+      if (workflowState.value) {
+        workflowState.value.isSchnellmeldungDone = true;
       }
 
       // todo update status #2002


### PR DESCRIPTION
# Beschreibung:

damit der bearbeitungsstatus der wahlen auch für die navigation vorhanden ist wurden die electionWorkflowState props nach dem drucken der ergebnismeldungen geupdated

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [ ] [Naming Conventions][naming-conventions-link] beachtet
- [ ] Doku aktualisiert
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [ ] Unit-Tests gepflegt
- [ ] Texte auf Rechtschreibung und Grammatik geprüft
- [ ] Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft

# Referenzen[^1]:

Issue #2002 behandelt den Status, der an das backend übermittelt wurde, für den Workflowsatus habe ich kein eigenes Issue gefunden

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Improved workflow tracking to automatically mark reporting tasks as complete when official documents are printed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->