### PR TITLE
2539 Senden einer Abmeldung an den Monitoring-Service

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/wlsComponents/TheWlsAppBar.vue
+++ b/wls-gui-wahllokalsystem/src/components/wlsComponents/TheWlsAppBar.vue
@@ -93,6 +93,7 @@ const {
   user,
   currentUserWahltag,
   currentUserWahlbezirkNummer,
+  currentUserWahlbezirkID,
   isUWB,
   isUserLoggedIn,
 } = storeToRefs(useUserStore());
@@ -111,7 +112,7 @@ const wahlbezirknummer = computed(() =>
 
 async function onLogoutClicked() {
   try {
-    await logout();
+    await logout(currentUserWahlbezirkID.value);
   } catch {
     addNotification(
       "Logout fehlgeschlagen. Bitte versuchen Sie es später erneut.",

--- a/wls-gui-wahllokalsystem/src/composables/user/logoutService.ts
+++ b/wls-gui-wahllokalsystem/src/composables/user/logoutService.ts
@@ -4,9 +4,14 @@ import {
   AuthServerControllerApi,
   Configuration,
 } from "@/api/wls-clients/generated-auth-api";
+import { WahllokalZustandControllerApi } from "@/api/wls-clients/generated-monitoring-api";
 import { useCommonApiUtils } from "@/composables/api/commonApiUtils.ts";
 import { useLogging } from "@/composables/common/logging.ts";
-import { AUTH_SERVICE_API_URL, ROUTE_LOGOUT } from "@/constants.ts";
+import {
+  AUTH_SERVICE_API_URL,
+  MONITORING_SERVICE_API_URL,
+  ROUTE_LOGOUT,
+} from "@/constants.ts";
 import router from "@/plugins/router.ts";
 import { useSchedulerStore } from "@/stores/schedulerStore.ts";
 import { useUserStore } from "@/stores/userStore.ts";
@@ -25,13 +30,25 @@ export function useLogoutService() {
     })
   );
 
-  async function logout() {
+  const wahllokalZustandControllerApi = new WahllokalZustandControllerApi(
+    new Configuration({
+      basePath: MONITORING_SERVICE_API_URL,
+    })
+  );
+
+  async function logout(wahlbezirkID: string) {
     try {
       const logoutUrl = (
         await authServerControllerApi.getLogoutUrl(
           axiosConfigWrapper().requestAsOnlineOnly()
         )
       ).data.url;
+
+      await wahllokalZustandControllerApi.postLetzteAbmeldung(
+        wahlbezirkID,
+        axiosConfigWrapper().requestAsOnlineOnly()
+      );
+
       const request = new Request(logoutUrl, {
         method: "GET",
         credentials: "include",

--- a/wls-gui-wahllokalsystem/tests/composables/user/logoutService.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/user/logoutService.spec.ts
@@ -20,6 +20,7 @@ import router from "@/plugins/router.ts";
 
 const mockDefinitions = vi.hoisted(() => ({
   getLogoutUrl: vi.fn(),
+  postLetzteAbmeldung: vi.fn(),
   fetch: vi.fn(),
   isUserLoggedIn: undefined as Ref<boolean> | undefined,
   routerPush: vi.fn(),
@@ -36,6 +37,20 @@ vi.mock("@/api/wls-clients/generated-auth-api", async (importOriginal) => {
   };
 });
 
+vi.mock(
+  "@/api/wls-clients/generated-monitoring-api",
+  async (importOriginal) => {
+    const mod = await importOriginal();
+    return {
+      ...(mod as object),
+      WahllokalZustandControllerApi: vi.fn().mockImplementation(() => ({
+        postLetzteAbmeldung: mockDefinitions.postLetzteAbmeldung,
+      })),
+      Configuration: vi.fn(),
+    };
+  }
+);
+
 vi.mock("@/stores/userStore.ts", () => ({
   useUserStore: () => ({
     isUserLoggedIn: mockDefinitions.isUserLoggedIn,
@@ -50,6 +65,8 @@ const { createResolvedUrlDTO } = useResolvedUrlTestDataFactory();
 
 describe("logoutService.ts", () => {
   let unitUnderTest: ReturnType<typeof useLogoutService>;
+
+  const WAHLBEZIRK_ID = "wahlbezirkID";
 
   beforeEach(() => {
     setActivePinia(createPinia());
@@ -76,12 +93,15 @@ describe("logoutService.ts", () => {
         })
       );
 
+      mockDefinitions.postLetzteAbmeldung.mockResolvedValue(Promise.resolve());
+
       mockDefinitions.fetch.mockImplementation(() => {
         return Promise.resolve({ ok: true });
       });
 
-      await unitUnderTest.logout();
+      await unitUnderTest.logout(WAHLBEZIRK_ID);
 
+      expect(mockDefinitions.postLetzteAbmeldung).toHaveBeenCalledOnce();
       expect(mockDefinitions.fetch).toHaveBeenCalledTimes(2);
       expect(
         (mockDefinitions.fetch.mock.calls[0]?.[0] as Request)?.url
@@ -98,7 +118,7 @@ describe("logoutService.ts", () => {
       const mockedGetLogoutUrlError = new Error("mocked get logout url failed");
       mockDefinitions.getLogoutUrl.mockRejectedValue(mockedGetLogoutUrlError);
 
-      await expect(unitUnderTest.logout()).rejects.toThrow(
+      await expect(unitUnderTest.logout(WAHLBEZIRK_ID)).rejects.toThrow(
         mockedGetLogoutUrlError
       );
     });
@@ -123,7 +143,7 @@ describe("logoutService.ts", () => {
         }
       });
 
-      await expect(unitUnderTest.logout()).rejects.toThrow();
+      await expect(unitUnderTest.logout(WAHLBEZIRK_ID)).rejects.toThrow();
     });
 
     it("should_throwError_when_logoutOnGatewayFailed", async () => {
@@ -146,7 +166,16 @@ describe("logoutService.ts", () => {
         }
       });
 
-      await expect(unitUnderTest.logout()).rejects.toThrow();
+      await expect(unitUnderTest.logout(WAHLBEZIRK_ID)).rejects.toThrow();
+    });
+
+    it("should_notPostLetzteAbmeldung_when_getLogoutUrlFailed", async () => {
+      mockDefinitions.getLogoutUrl.mockResolvedValue(
+        Promise.reject(new Error("no logout url"))
+      );
+
+      await expect(unitUnderTest.logout(WAHLBEZIRK_ID)).rejects.toThrow();
+      expect(mockDefinitions.postLetzteAbmeldung).not.toHaveBeenCalled();
     });
   });
 });

--- a/wls-gui-wahllokalsystem/tests/composables/user/logoutService.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/user/logoutService.spec.ts
@@ -14,6 +14,7 @@ import {
 } from "vitest";
 import { ref } from "vue";
 
+import { useCommonApiUtils } from "@/composables/api/commonApiUtils.ts";
 import { useLogoutService } from "@/composables/user/logoutService.ts";
 import { ROUTE_LOGOUT } from "@/constants.ts";
 import router from "@/plugins/router.ts";
@@ -62,6 +63,7 @@ global.fetch = mockDefinitions.fetch;
 
 const { createAxiosResponse } = useAxiosTestDataFactory();
 const { createResolvedUrlDTO } = useResolvedUrlTestDataFactory();
+const { axiosConfigWrapper } = useCommonApiUtils();
 
 describe("logoutService.ts", () => {
   let unitUnderTest: ReturnType<typeof useLogoutService>;
@@ -101,7 +103,10 @@ describe("logoutService.ts", () => {
 
       await unitUnderTest.logout(WAHLBEZIRK_ID);
 
-      expect(mockDefinitions.postLetzteAbmeldung).toHaveBeenCalledOnce();
+      expect(mockDefinitions.postLetzteAbmeldung).toHaveBeenCalledWith(
+        WAHLBEZIRK_ID,
+        axiosConfigWrapper().requestAsOnlineOnly()
+      );
       expect(mockDefinitions.fetch).toHaveBeenCalledTimes(2);
       expect(
         (mockDefinitions.fetch.mock.calls[0]?.[0] as Request)?.url


### PR DESCRIPTION
# Beschreibung:

Nach der Abfrage der Logout-Url wird der Request für die letzte Abmeldung an den Monitoring-Service geschickt

## Definition of Done (DoD):

### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [ ] Doku aktualisiert
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] Unit-Tests gepflegt
- [x] Texte auf Rechtschreibung und Grammatik geprüft
- [x] Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft

# Referenzen[^1]:

Closes #2539 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced logout process to include user district information during sign-out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->