### PR TITLE
2630 Navigation zur Erfassung der Anwesenheiten nach Zählen der Stimmzettel in UWB

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/ergebnismeldung/common/TheErgebnisermittlungStimmzettelumschlaegeCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/ergebnismeldung/common/TheErgebnisermittlungStimmzettelumschlaegeCard.vue
@@ -147,7 +147,9 @@ async function continueInWorkflow() {
     props.wahlbezirkId,
     MbwRoutesEnum.MBW_AUSZAEHLUNG_STIMMZETTEL
   );
-  resetAllAnwesenheiten();
+  if (props.useTime) {
+    resetAllAnwesenheiten();
+  }
   await router.push(getNextRoute());
 }
 </script>

--- a/wls-gui-wahllokalsystem/tests/components/ergebnismeldung/common/TheErgebnisermittlungStimmzettelumschlaegeCard.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/components/ergebnismeldung/common/TheErgebnisermittlungStimmzettelumschlaegeCard.spec.ts
@@ -24,6 +24,7 @@ import BaseButtonSave from "@/components/common/buttons/BaseButtonSave.vue";
 import TheErgebnisermittlungStimmzettelumschlaegeCard from "@/components/ergebnismeldung/common/TheErgebnisermittlungStimmzettelumschlaegeCard.vue";
 import router from "@/plugins/router.ts";
 import vuetify from "@/plugins/vuetify.ts";
+import { useInfomanagementStore } from "@/stores/infomanagementStore.ts";
 import { useWahlenStore } from "@/stores/wahlenStore.ts";
 
 const { prepareWahl } = useWahlTestDataFactory();
@@ -175,12 +176,26 @@ describe("TheErgebnisermittlungStimmzettelumschlaegeCard.vue", () => {
       await saveButton.trigger("click");
 
       expect(mockDefinitions.postStimmzettelumschlaege).toHaveBeenCalled();
+      expect(mockDefinitions.resetAllAnwesenheiten).not.toHaveBeenCalled();
     });
 
-    it("should_resetAllAnwesenheiten_when_saveIsCompleted", async () => {
-      _initWahlenStore(33);
+    it("should_resetAllAnwesenheiten_when_saveIsCompletedInBWB", async () => {
+      const infomanagementStore = useInfomanagementStore();
+      // @ts-expect-error: cannot set readonly
+      infomanagementStore.fruehesteSchliessungsuhrzeit = "08:00:00";
 
-      const wrapper = _mountComponent(testPinia);
+      const wahlenStore = useWahlenStore();
+      wahlenStore.wahlenState.wahlen = [
+        prepareWahl()
+          .wahlID("123")
+          .stimmzettelumschlaege({
+            anzahlWaehler: 33,
+            urneneroeffnungsUhrzeit: new Date("2026-01-01T08:00:00"),
+          })
+          .build(),
+      ];
+
+      const wrapper = _mountComponent(testPinia, true);
 
       await flushPromises();
 
@@ -199,7 +214,7 @@ describe("TheErgebnisermittlungStimmzettelumschlaegeCard.vue", () => {
   });
 });
 
-function _mountComponent(testPinia: TestingPinia) {
+function _mountComponent(testPinia: TestingPinia, useTime = false) {
   return mount(TheErgebnisermittlungStimmzettelumschlaegeCard, {
     global: {
       plugins: [testPinia, vuetify],
@@ -208,6 +223,7 @@ function _mountComponent(testPinia: TestingPinia) {
       wahlId: "123",
       wahlbezirkId: "456",
       title: "Titel",
+      useTime: useTime,
     },
   });
 }


### PR DESCRIPTION
# Beschreibung:

In der `The ErgebnisermittlungStimmzettelumschlaegeCard` sollen die Anwesenheiten nur zurückgesetzt werden, wenn eine Schließungsuhrzeit erfasst wird und es sich damit um ein BWB handelt.

## Definition of Done (DoD):

### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [ ] ~~Doku aktualisiert~~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] Unit-Tests gepflegt
- [x] Texte auf Rechtschreibung und Grammatik geprüft
- [x] Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft

# Referenzen[^1]:

Closes #2630

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conditional logic for attendance reset in ballot envelope counting to only apply when time-based configuration is enabled.

* **Tests**
  * Updated tests to verify correct behavior when time-based settings are enabled and disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->