### PR TITLE
2197 handle security considerations workflow does not contain permissions

### DIFF
--- a/.github/workflows/callable-run-mvn-verify.yml
+++ b/.github/workflows/callable-run-mvn-verify.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   checkout-and-verify:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 

--- a/.github/workflows/callable-run-npm-build.yml
+++ b/.github/workflows/callable-run-npm-build.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   checkout-and-verify:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: './${{ inputs.package-dir }}'

--- a/.github/workflows/callable-run-npm-build.yml
+++ b/.github/workflows/callable-run-npm-build.yml
@@ -11,7 +11,7 @@ jobs:
   checkout-and-verify:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     defaults:
       run:
         working-directory: './${{ inputs.package-dir }}'

--- a/.github/workflows/dispatch-wls-common-mvn-release.yml
+++ b/.github/workflows/dispatch-wls-common-mvn-release.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository

--- a/.github/workflows/doc_pull-request.yaml
+++ b/.github/workflows/doc_pull-request.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   run-docs-build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/doc_push-dev.yaml
+++ b/.github/workflows/doc_push-dev.yaml
@@ -11,6 +11,9 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
     defaults:
       run:
         working-directory: ./docs

--- a/.github/workflows/wls-admin-service_pull-request.yml
+++ b/.github/workflows/wls-admin-service_pull-request.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   verify-pull-request:
+    permissions:
+      contents: read
     uses:
       ./.github/workflows/callable-run-mvn-verify.yml
     with:

--- a/.github/workflows/wls-api-gateway_pull-request.yml
+++ b/.github/workflows/wls-api-gateway_pull-request.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   verify-pull-request:
+    permissions:
+      contents: read
     uses:
       ./.github/workflows/callable-run-mvn-verify.yml
     with:

--- a/.github/workflows/wls-auth-service_pull-request.yml
+++ b/.github/workflows/wls-auth-service_pull-request.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   verify-pull-request:
+    permissions:
+      contents: read
     uses:
       ./.github/workflows/callable-run-mvn-verify.yml
     with:

--- a/.github/workflows/wls-basisdaten-service_pull-request.yml
+++ b/.github/workflows/wls-basisdaten-service_pull-request.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   verify-pull-request:
+    permissions:
+      contents: read
     uses:
       ./.github/workflows/callable-run-mvn-verify.yml
     with:

--- a/.github/workflows/wls-briefwahl-service_pull-request.yml
+++ b/.github/workflows/wls-briefwahl-service_pull-request.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   verify-pull-request:
+    permissions:
+      contents: read
     uses:
       ./.github/workflows/callable-run-mvn-verify.yml
     with:

--- a/.github/workflows/wls-broadcast-service_pull-request.yml
+++ b/.github/workflows/wls-broadcast-service_pull-request.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   verify-pull-request:
+    permissions:
+      contents: read
     uses:
       ./.github/workflows/callable-run-mvn-verify.yml
     with:

--- a/.github/workflows/wls-common_pull-request.yaml
+++ b/.github/workflows/wls-common_pull-request.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   verify-pull-request:
+    permissions:
+      contents: read
     uses:
       ./.github/workflows/callable-run-mvn-verify.yml
     with:

--- a/.github/workflows/wls-eai-service_pull-request.yml
+++ b/.github/workflows/wls-eai-service_pull-request.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   verify-pull-request:
+    permissions:
+      contents: read
     uses:
       ./.github/workflows/callable-run-mvn-verify.yml
     with:

--- a/.github/workflows/wls-ergebnismeldung-service_pull-request.yml
+++ b/.github/workflows/wls-ergebnismeldung-service_pull-request.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   verify-pull-request:
+    permissions:
+      contents: read
     uses:
       ./.github/workflows/callable-run-mvn-verify.yml
     with:

--- a/.github/workflows/wls-gui-admintool_pull-request.yml
+++ b/.github/workflows/wls-gui-admintool_pull-request.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   verify-pull-request:
+    permissions:
+      contents: read
     uses:
       ./.github/workflows/callable-run-npm-build.yml
     with:

--- a/.github/workflows/wls-gui-wahllokalsystem_pull-request.yml
+++ b/.github/workflows/wls-gui-wahllokalsystem_pull-request.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   verify-pull-request:
+    permissions:
+      contents: read
     uses:
       ./.github/workflows/callable-run-npm-build.yml
     with:

--- a/.github/workflows/wls-infomanagement-service_pull-request.yml
+++ b/.github/workflows/wls-infomanagement-service_pull-request.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   verify-pull-request:
+    permissions:
+      contents: read
     uses:
       ./.github/workflows/callable-run-mvn-verify.yml
     with:

--- a/.github/workflows/wls-monitoring-service_pull-request.yml
+++ b/.github/workflows/wls-monitoring-service_pull-request.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   verify-pull-request:
+    permissions:
+      contents: read
     uses:
       ./.github/workflows/callable-run-mvn-verify.yml
     with:

--- a/.github/workflows/wls-vorfaelleundvorkommnisse-service_pull-request.yml
+++ b/.github/workflows/wls-vorfaelleundvorkommnisse-service_pull-request.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   verify-pull-request:
+    permissions:
+      contents: read
     uses:
       ./.github/workflows/callable-run-mvn-verify.yml
     with:

--- a/.github/workflows/wls-wahlvorbereitung-service_pull-request.yml
+++ b/.github/workflows/wls-wahlvorbereitung-service_pull-request.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   verify-pull-request:
+    permissions:
+      contents: read
     uses:
       ./.github/workflows/callable-run-mvn-verify.yml
     with:

--- a/.github/workflows/wls-wahlvorstand-service_pull-request.yml
+++ b/.github/workflows/wls-wahlvorstand-service_pull-request.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   verify-pull-request:
+    permissions:
+      contents: read
     uses:
       ./.github/workflows/callable-run-mvn-verify.yml
     with:

--- a/docs/src/technik/guides/new-microservice/new-service-backend.md
+++ b/docs/src/technik/guides/new-microservice/new-service-backend.md
@@ -62,6 +62,8 @@ on:
 
 jobs:
   verify-pull-request:
+    permissions: 
+      contents: read
     uses:
       ./.github/workflows/callable-run-mvn-verify.yml
     with:

--- a/docs/src/technik/guides/new-microservice/new-service-frontend.md
+++ b/docs/src/technik/guides/new-microservice/new-service-frontend.md
@@ -53,6 +53,8 @@ on:
 
 jobs:
   verify-pull-request:
+    permissions:
+      contents: read
     uses: ./.github/workflows/callable-run-npm-build.yml
     with:
       package-dir: "wls-gui-<frontend-name>"


### PR DESCRIPTION
# Beschreibung:

Workflow permissions angepasst und in doku beispielen fehlende permissins ergänzt:

- verify pull request: `contents: read`
- releases: `contents: write`
- builds: `contents: write`
- image-builds: `packages: write`
- deployments: `pages: write`
- auto assign/labeler: `contents: read` + `pull-request: write` 

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Dokumentation -->
### Dokumentation
- [x] Links geprüft

# Referenzen[^1]:

Closes #2197 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflow security by explicitly declaring required repository permissions for build, test, and deployment processes.
  * Updated documentation to reflect current workflow security best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->