### PR TITLE
2643 Anwendung startet nicht un zeigt keine Fehler wenn ServiceWorker deaktiviert ist

### DIFF
--- a/wls-gui-wahllokalsystem/src/composables/serviceWorker/serviceWorkerPinSyncer.ts
+++ b/wls-gui-wahllokalsystem/src/composables/serviceWorker/serviceWorkerPinSyncer.ts
@@ -3,6 +3,7 @@ import type { ServiceWorkerMessage } from "@/types/serviceWorker/ServiceWorkerMe
 import { storeToRefs } from "pinia";
 import { watch } from "vue";
 
+import { useLogging } from "@/composables/common/logging.ts";
 import { useCryptoUtils } from "@/composables/crypto/cryptoUtils.ts";
 import { useServiceWorkerUtils } from "@/composables/serviceWorker/serviceWorkerUtils.ts";
 import { useUserStore } from "@/stores/userStore.ts";
@@ -12,6 +13,7 @@ export function useServiceWorkerPinSyncer() {
   const { user } = storeToRefs(useUserStore());
   const { importKey } = useCryptoUtils();
   const { sendMessage } = useServiceWorkerUtils();
+  const { logWarn } = useLogging("serviceWorkerPinSyncer");
 
   watch(
     () => user.value.pin,
@@ -29,9 +31,7 @@ export function useServiceWorkerPinSyncer() {
       syncPin()
     );
   } else {
-    console.debug(
-      "ServiceWorkerPinSyncer konnte EventListener nicht registrieren"
-    );
+    logWarn("ServiceWorkerPinSyncer konnte EventListener nicht registrieren");
   }
 
   async function syncPin() {

--- a/wls-gui-wahllokalsystem/src/composables/serviceWorker/serviceWorkerPinSyncer.ts
+++ b/wls-gui-wahllokalsystem/src/composables/serviceWorker/serviceWorkerPinSyncer.ts
@@ -20,11 +20,19 @@ export function useServiceWorkerPinSyncer() {
     }
   );
 
-  navigator.serviceWorker.addEventListener("message", (event) =>
-    _handleServiceWorkerInstalledMessage(event.data)
-  );
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.addEventListener("message", (event) =>
+      _handleServiceWorkerInstalledMessage(event.data)
+    );
 
-  navigator.serviceWorker.addEventListener("controllerchange", () => syncPin());
+    navigator.serviceWorker.addEventListener("controllerchange", () =>
+      syncPin()
+    );
+  } else {
+    console.debug(
+      "ServiceWorkerPinSyncer konnte EventListener nicht registrieren"
+    );
+  }
 
   async function syncPin() {
     const cryptoKey = await importKey(user.value.pin);

--- a/wls-gui-wahllokalsystem/src/composables/serviceWorker/serviceWorkerUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/serviceWorker/serviceWorkerUtils.ts
@@ -5,13 +5,13 @@ export function useServiceWorkerUtils() {
   const { logDebug } = useLogging("useServiceWorkerUtils");
 
   function isServiceWorkerActive() {
-    return !!navigator.serviceWorker.controller;
+    return !!navigator.serviceWorker?.controller;
   }
 
   function sendMessage(message: ServiceWorkerMessage) {
-    if (navigator.serviceWorker.controller) {
+    if (navigator.serviceWorker?.controller) {
       logDebug(`sending message of type ${message.type}`);
-      navigator.serviceWorker.controller.postMessage(message);
+      navigator.serviceWorker?.controller.postMessage(message);
     }
   }
 


### PR DESCRIPTION
# Beschreibung:

Überprüfung für aktiven ServiceWorker im `serviceWorkerPinSyncer` ergänzt. Es kommt zu keiner Fehlermeldung, dass die Registrierung der EventListener fehlgeschlagen ist. 

Im Anschluss greift das Handling aus den `serviceWorkerUtils`. Dem User wird angezeigt, dass der Service-Worker deaktiviert ist.

# Referenzen[^1]:

Closes #2643

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application stability by adding compatibility checks for environments where service workers are not supported, preventing potential runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->