### PR TITLE
2087 Überarbeitung Broadcastnachrichtdialog

### DIFF
--- a/wls-gui-wahllokalsystem/src/App.vue
+++ b/wls-gui-wahllokalsystem/src/App.vue
@@ -91,11 +91,12 @@ onMounted(async () => {
     await syncPin();
     await wahlenActions.initWahlen();
     await initTasks();
-    startBroadcastMessageInterval();
 
     showTestdruckDialog.value = true;
   } catch (error) {
     console.debug(error);
+  } finally {
+    startBroadcastMessageInterval();
   }
 });
 

--- a/wls-gui-wahllokalsystem/src/App.vue
+++ b/wls-gui-wahllokalsystem/src/App.vue
@@ -90,8 +90,8 @@ onMounted(async () => {
     isOfflineCacheReady.value = await awaitServiceWorkerActive();
     await syncPin();
     await wahlenActions.initWahlen();
-    startBroadcastMessageInterval();
     await initTasks();
+    startBroadcastMessageInterval();
 
     showTestdruckDialog.value = true;
   } catch (error) {

--- a/wls-gui-wahllokalsystem/src/composables/broadcast/broadcastCronjobService.ts
+++ b/wls-gui-wahllokalsystem/src/composables/broadcast/broadcastCronjobService.ts
@@ -17,9 +17,7 @@ export function useBroadcastCronjobService() {
 
     broadcastMessageActiveInterval = registerInterval({
       title: "Broadcast Message Interval",
-      action: function () {
-        loadLatestMessage(false);
-      },
+      action: () => loadLatestMessage(false),
       delay: broadcastMessagePollingInterval,
       runActionAfterRegister: true,
     });

--- a/wls-gui-wahllokalsystem/src/composables/broadcast/broadcastCronjobService.ts
+++ b/wls-gui-wahllokalsystem/src/composables/broadcast/broadcastCronjobService.ts
@@ -17,7 +17,9 @@ export function useBroadcastCronjobService() {
 
     broadcastMessageActiveInterval = registerInterval({
       title: "Broadcast Message Interval",
-      action: loadLatestMessage,
+      action: function () {
+        loadLatestMessage(false);
+      },
       delay: broadcastMessagePollingInterval,
       runActionAfterRegister: true,
     });

--- a/wls-gui-wahllokalsystem/src/composables/broadcast/broadcastService.ts
+++ b/wls-gui-wahllokalsystem/src/composables/broadcast/broadcastService.ts
@@ -23,7 +23,8 @@ export function useBroadcastService() {
   );
 
   async function getMessage(
-    wahlbezirkID: string
+    wahlbezirkID: string,
+    sendNotification = true
   ): Promise<BroadcastMessage | null> {
     try {
       const response = await broadcastCA.getMessage(
@@ -34,10 +35,12 @@ export function useBroadcastService() {
       const responseData = getNullOn204OrElseResponseData(response);
       return responseData ? dtoToModel(responseData) : null;
     } catch {
-      addNotification(
-        "Abrufen der Broadcastnachricht ist fehlgeschlagen",
-        UserNotificationCategoryEnum.ERROR
-      );
+      if (sendNotification) {
+        addNotification(
+          "Abrufen der Broadcastnachricht ist fehlgeschlagen",
+          UserNotificationCategoryEnum.ERROR
+        );
+      }
       return null;
     }
   }

--- a/wls-gui-wahllokalsystem/src/stores/broadcastStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/broadcastStore.ts
@@ -16,9 +16,10 @@ export const useBroadcastStore = defineStore(broadcastStoreId, () => {
 
   const currentBroadcastNachricht = ref<BroadcastMessage | null>(null);
 
-  async function loadLatestMessage() {
+  async function loadLatestMessage(sendNotification = true) {
     currentBroadcastNachricht.value = await getMessage(
-      currentUserWahlbezirkID.value
+      currentUserWahlbezirkID.value,
+      sendNotification
     );
   }
 

--- a/wls-gui-wahllokalsystem/tests/composables/broadcast/broadcastService.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/broadcast/broadcastService.spec.ts
@@ -97,6 +97,22 @@ describe("BroadcastService.ts", () => {
         UserNotificationCategoryEnum.ERROR,
       ]);
     });
+
+    it("shouldnotTriggerErrorNotification_when_anExceptionOccurredDuringApiCallButSendNotificationIsFalse", async () => {
+      const wahlbezirkID = "wahlbezirkID";
+
+      mockDefinitions.getMessage.mockRejectedValue(
+        new Error("api called failed")
+      );
+
+      const result = await getMessage(wahlbezirkID, false);
+
+      expect(result).toBeNull();
+
+      expect(mockDefinitions.addNotification.mock.calls.length).toStrictEqual(
+        0
+      );
+    });
   });
 
   describe("deleteMessage", () => {

--- a/wls-gui-wahllokalsystem/tests/composables/broadcast/broadcastService.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/broadcast/broadcastService.spec.ts
@@ -98,7 +98,7 @@ describe("BroadcastService.ts", () => {
       ]);
     });
 
-    it("shouldnotTriggerErrorNotification_when_anExceptionOccurredDuringApiCallButSendNotificationIsFalse", async () => {
+    it("should_notTriggerErrorNotification_when_anExceptionOccurredDuringApiCallButSendNotificationIsFalse", async () => {
       const wahlbezirkID = "wahlbezirkID";
 
       mockDefinitions.getMessage.mockRejectedValue(

--- a/wls-gui-wahllokalsystem/tests/stores/broadcastStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/broadcastStore.spec.ts
@@ -24,6 +24,8 @@ const { prepareUser } = useUserTestDataFactory();
 describe("broadcastStore.ts", () => {
   let unitUnderTest: ReturnType<typeof useBroadcastStore>;
 
+  const WAHLBEZIRK_ID = "wahlbezirkID";
+
   beforeEach(() => {
     setActivePinia(createPinia());
     unitUnderTest = useBroadcastStore();
@@ -36,7 +38,7 @@ describe("broadcastStore.ts", () => {
   describe("loadLatestMessage", () => {
     it("should_setState_when_messageWasReceived", async () => {
       const userStore = useUserStore();
-      userStore.setUser(prepareUser().wahlbezirkID("wahlbezirkID").build());
+      userStore.setUser(prepareUser().wahlbezirkID(WAHLBEZIRK_ID).build());
 
       const mockedBroadcastMessage = createBroadcastMessage();
 
@@ -49,36 +51,40 @@ describe("broadcastStore.ts", () => {
       expect(unitUnderTest.currentBroadcastNachricht).toStrictEqual(
         mockedBroadcastMessage
       );
-    });
-
-    it("should_setStateWithoutNotification_when_messageWasReceivedAndParameterIsSet", async () => {
-      const userStore = useUserStore();
-      userStore.setUser(prepareUser().wahlbezirkID("wahlbezirkID").build());
-      const wahlbezirkID = "wahlbezirkID";
-      userStore.setUser(prepareUser().wahlbezirkID(wahlbezirkID).build());
-
-      const mockedBroadcastMessage = createBroadcastMessage();
-
-      mockDefinitions.getMessage.mockResolvedValue(
-        Promise.resolve(mockedBroadcastMessage)
-      );
-
-      await unitUnderTest.loadLatestMessage(false);
-
-      expect(unitUnderTest.currentBroadcastNachricht).toStrictEqual(
-        mockedBroadcastMessage
-      );
       expect(mockDefinitions.getMessage.mock.calls).toStrictEqual([
-        [wahlbezirkID, false],
+        [WAHLBEZIRK_ID, true],
       ]);
     });
+
+    it.each([{ sendNotification: true }, { sendNotification: false }])(
+      "should_setStateWithoutNotification_when_messageWasReceivedAndNotificationParameterIsUsed",
+      async (argument) => {
+        const userStore = useUserStore();
+        userStore.setUser(prepareUser().wahlbezirkID(WAHLBEZIRK_ID).build());
+        userStore.setUser(prepareUser().wahlbezirkID(WAHLBEZIRK_ID).build());
+
+        const mockedBroadcastMessage = createBroadcastMessage();
+
+        mockDefinitions.getMessage.mockResolvedValue(
+          Promise.resolve(mockedBroadcastMessage)
+        );
+
+        await unitUnderTest.loadLatestMessage(argument.sendNotification);
+
+        expect(unitUnderTest.currentBroadcastNachricht).toStrictEqual(
+          mockedBroadcastMessage
+        );
+        expect(mockDefinitions.getMessage.mock.calls).toStrictEqual([
+          [WAHLBEZIRK_ID, argument.sendNotification],
+        ]);
+      }
+    );
   });
 
   describe("markMessageAsReadAndLoadNextMessage", () => {
     it("should_deleteAndLoadNextMessage_when_broadcastMessageIdAndWahlbezirkIdIsGiven", async () => {
       const userStore = useUserStore();
-      const wahlbezirkID = "wahlbezirkID";
-      userStore.setUser(prepareUser().wahlbezirkID(wahlbezirkID).build());
+      userStore.setUser(prepareUser().wahlbezirkID(WAHLBEZIRK_ID).build());
 
       const broadcastMessageToDelete = createBroadcastMessage();
       unitUnderTest.currentBroadcastNachricht = broadcastMessageToDelete;
@@ -95,7 +101,7 @@ describe("broadcastStore.ts", () => {
         [broadcastMessageToDelete.id],
       ]);
       expect(mockDefinitions.getMessage.mock.calls).toStrictEqual([
-        [wahlbezirkID, true],
+        [WAHLBEZIRK_ID, true],
       ]);
     });
 
@@ -109,8 +115,7 @@ describe("broadcastStore.ts", () => {
 
     it("should_loadNextMessage_when_noBroadcastMessageIsInState", async () => {
       const userStore = useUserStore();
-      const wahlbezirkID = "wahlbezirkID";
-      userStore.setUser(prepareUser().wahlbezirkID(wahlbezirkID).build());
+      userStore.setUser(prepareUser().wahlbezirkID(WAHLBEZIRK_ID).build());
 
       unitUnderTest.currentBroadcastNachricht = null;
 
@@ -123,7 +128,7 @@ describe("broadcastStore.ts", () => {
       await unitUnderTest.markMessageAsReadAndLoadNextMessage();
 
       expect(mockDefinitions.getMessage.mock.calls).toStrictEqual([
-        [wahlbezirkID, true],
+        [WAHLBEZIRK_ID, true],
       ]);
     });
   });

--- a/wls-gui-wahllokalsystem/tests/stores/broadcastStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/broadcastStore.spec.ts
@@ -50,6 +50,28 @@ describe("broadcastStore.ts", () => {
         mockedBroadcastMessage
       );
     });
+
+    it("should_setStateWithoutNotification_when_messageWasReceivedAndParameterIsSet", async () => {
+      const userStore = useUserStore();
+      userStore.setUser(prepareUser().wahlbezirkID("wahlbezirkID").build());
+      const wahlbezirkID = "wahlbezirkID";
+      userStore.setUser(prepareUser().wahlbezirkID(wahlbezirkID).build());
+
+      const mockedBroadcastMessage = createBroadcastMessage();
+
+      mockDefinitions.getMessage.mockResolvedValue(
+        Promise.resolve(mockedBroadcastMessage)
+      );
+
+      await unitUnderTest.loadLatestMessage(false);
+
+      expect(unitUnderTest.currentBroadcastNachricht).toStrictEqual(
+        mockedBroadcastMessage
+      );
+      expect(mockDefinitions.getMessage.mock.calls).toStrictEqual([
+        [wahlbezirkID, false],
+      ]);
+    });
   });
 
   describe("markMessageAsReadAndLoadNextMessage", () => {
@@ -73,7 +95,7 @@ describe("broadcastStore.ts", () => {
         [broadcastMessageToDelete.id],
       ]);
       expect(mockDefinitions.getMessage.mock.calls).toStrictEqual([
-        [wahlbezirkID],
+        [wahlbezirkID, true],
       ]);
     });
 
@@ -101,7 +123,7 @@ describe("broadcastStore.ts", () => {
       await unitUnderTest.markMessageAsReadAndLoadNextMessage();
 
       expect(mockDefinitions.getMessage.mock.calls).toStrictEqual([
-        [wahlbezirkID],
+        [wahlbezirkID, true],
       ]);
     });
   });


### PR DESCRIPTION
# Beschreibung:

- Start des Broadcastintervalls erst nach den Init-Tasks
- SendNotification Parameter `false` beim Laden der Broadcast-Nachrichten innerhalb des Intervalls 

## Definition of Done (DoD):

### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [ ] ~~Doku aktualisiert~~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] Unit-Tests gepflegt
- [x] Texte auf Rechtschreibung und Grammatik geprüft
- [x] Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft

# Referenzen[^1]:

Closes #2087 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application initialization sequence for more reliable startup.

* **Improvements**
  * Enhanced control over error notifications when broadcast messages fail to load.

* **Tests**
  * Updated test coverage for notification behavior in broadcast message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->