### PR TITLE
2706-fehlermeldung-beim-drucken-der-niederschrift-sollte-als-fehler-angezeigt-werden

### DIFF
--- a/wls-gui-wahllokalsystem/src/views/ergebnismeldung/MBW/MBWNiederschriftView.vue
+++ b/wls-gui-wahllokalsystem/src/views/ergebnismeldung/MBW/MBWNiederschriftView.vue
@@ -206,7 +206,7 @@ async function onDruckenClicked() {
   } catch {
     addNotification(
       "Fehler beim Drucken der Niederschrift.",
-      UserNotificationCategoryEnum.WARNING
+      UserNotificationCategoryEnum.ERROR
     );
   } finally {
     isDruckenLoading.value = false;


### PR DESCRIPTION
# Beschreibung:

- warning auf error geändert

## Definition of Done (DoD):

# Referenzen[^1]:

Verwandt mit Issue #

Closes #2706 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced print error notifications to display with increased severity, ensuring users receive clearer alerts when printing encounters failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->