### PR TITLE
2059 - WahlbezirkID-Kontrolle bei Endpunkten komplettieren - Broadcast

### DIFF
--- a/wls-broadcast-service/src/main/java/de/muenchen/oss/wahllokalsystem/broadcastservice/service/BroadcastService.java
+++ b/wls-broadcast-service/src/main/java/de/muenchen/oss/wahllokalsystem/broadcastservice/service/BroadcastService.java
@@ -17,6 +17,7 @@ import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -51,8 +52,10 @@ public class BroadcastService {
     messageRepo.saveAll(messagesToSave);
   }
 
-  @PreAuthorize("hasAuthority('Broadcast_BUSINESSACTION_GetMessage')")
-  public MessageDTO getOldestMessage(String wahlbezirkID) {
+  @PreAuthorize(
+      "hasAuthority('Broadcast_BUSINESSACTION_GetMessage')"
+          + " and @bezirkIdPermissionEvaluator.tokenUserBezirkIdMatches(#wahlbezirkID, authentication)")
+  public MessageDTO getOldestMessage(@P("wahlbezirkID") String wahlbezirkID) {
     log.debug("#nachrichtenAbrufen wahlbezirkID {} length {}", wahlbezirkID, wahlbezirkID.length());
 
     if (StringUtils.isEmpty(wahlbezirkID) || StringUtils.isBlank(wahlbezirkID)) {

--- a/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/rest/BroadcastControllerIntegrationTest.java
+++ b/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/rest/BroadcastControllerIntegrationTest.java
@@ -209,17 +209,10 @@ public class BroadcastControllerIntegrationTest {
     void should_throwFachlicheWlsException_when_wahlbezirkIdDoesNotMatchUserWahlbezirkID()
         throws Exception {
       log.debug("#GetMessageIntegrationTestGetParamEmpty");
-      String wahlbezirkID = "";
+      String wahlbezirkID = "wahlbezirkID";
 
       mvc.perform(createGetRequest(wahlbezirkID, wahlbezirkID + "sth"))
-          .andExpect(status().isInternalServerError())
-          .andExpect(
-              result -> {
-                String actualStringResponse = result.getResponse().getContentAsString();
-                String expectedStringResponse =
-                    "{\"category\":\"T\",\"code\":\"999\",\"service\":\"WLS-BROADCAST\",\"message\":\"Ursache: class org.springframework.web.servlet.resource.NoResourceFoundException, Nachricht: No static resource businessActions/getMessage.\"}";
-                Assertions.assertThat(actualStringResponse).isEqualTo(expectedStringResponse);
-              });
+          .andExpect(status().isForbidden());
     }
 
     @Test

--- a/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/rest/BroadcastControllerIntegrationTest.java
+++ b/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/rest/BroadcastControllerIntegrationTest.java
@@ -156,13 +156,14 @@ public class BroadcastControllerIntegrationTest {
     void should_returnBroadcastMessage_when_givenWahlbezirkId() throws Exception {
       log.debug("#GetMessageIntegrationTest");
       SecurityUtils.runWith(Authorities.REPOSITORY_WRITE_MESSAGE);
+      val wahlbezirkID = "123";
       messageRepository.save(
           TestdataFactory.CreateMessageEntity.withCustomParams(
-              "123", "Das ist ein Test", LocalDateTime.now()));
+              wahlbezirkID, "Das ist ein Test", LocalDateTime.now()));
       SecurityContextHolder.clearContext();
 
       MockHttpServletResponse result =
-          mvc.perform(createGetRequest("123")).andReturn().getResponse();
+          mvc.perform(createGetRequest(wahlbezirkID, wahlbezirkID)).andReturn().getResponse();
       String content = result.getContentAsString();
       Message message = objectMapper.readValue(content, Message.class);
       Assertions.assertThat(message.getNachricht()).isEqualTo("Das ist ein Test");
@@ -171,7 +172,8 @@ public class BroadcastControllerIntegrationTest {
     @Test
     void should_throwFachlicheWlsException_when_wahlbezirkIdIsBlank() throws Exception {
       log.debug("#GetMessageIntegrationTestGetParamBlank");
-      mvc.perform(createGetRequest("   "))
+      val wahlbezirkID = "   ";
+      mvc.perform(createGetRequest(wahlbezirkID, wahlbezirkID))
           .andExpect(status().isBadRequest())
           .andExpect(
               result -> {
@@ -192,7 +194,24 @@ public class BroadcastControllerIntegrationTest {
       log.debug("#GetMessageIntegrationTestGetParamEmpty");
       String wahlbezirkID = "";
 
-      mvc.perform(createGetRequest(wahlbezirkID))
+      mvc.perform(createGetRequest(wahlbezirkID, wahlbezirkID))
+          .andExpect(status().isInternalServerError())
+          .andExpect(
+              result -> {
+                String actualStringResponse = result.getResponse().getContentAsString();
+                String expectedStringResponse =
+                    "{\"category\":\"T\",\"code\":\"999\",\"service\":\"WLS-BROADCAST\",\"message\":\"Ursache: class org.springframework.web.servlet.resource.NoResourceFoundException, Nachricht: No static resource businessActions/getMessage.\"}";
+                Assertions.assertThat(actualStringResponse).isEqualTo(expectedStringResponse);
+              });
+    }
+
+    @Test
+    void should_throwFachlicheWlsException_when_wahlbezirkIdDoesNotMatchUserWahlbezirkID()
+        throws Exception {
+      log.debug("#GetMessageIntegrationTestGetParamEmpty");
+      String wahlbezirkID = "";
+
+      mvc.perform(createGetRequest(wahlbezirkID, wahlbezirkID + "sth"))
           .andExpect(status().isInternalServerError())
           .andExpect(
               result -> {
@@ -206,7 +225,8 @@ public class BroadcastControllerIntegrationTest {
     @Test
     void should_throwFachlicheWlsException_when_noMessageFound() throws Exception {
       log.debug("#GetMessageNoContentIntegrationTest");
-      mvc.perform(createGetRequest("123"))
+      val wahlbezirkID = "123";
+      mvc.perform(createGetRequest(wahlbezirkID, wahlbezirkID))
           .andExpect(status().isNoContent())
           .andExpect(
               result -> {
@@ -218,13 +238,15 @@ public class BroadcastControllerIntegrationTest {
               });
     }
 
-    private MockHttpServletRequestBuilder createGetRequest(final String wahlbezirkId) {
+    private MockHttpServletRequestBuilder createGetRequest(
+        final String wahlbezirkId, final String claimWahlbezirkID) {
       return get(GETMESSAGE_URL + wahlbezirkId)
           .with(
               jwt()
                   .authorities(
                       new SimpleGrantedAuthority(Authorities.SERVICE_GET_MESSAGE),
-                      new SimpleGrantedAuthority(Authorities.REPOSITORY_READ_MESSAGE)))
+                      new SimpleGrantedAuthority(Authorities.REPOSITORY_READ_MESSAGE))
+                  .jwt(jwt -> jwt.claim("wahlbezirkID", claimWahlbezirkID)))
           .contentType(MediaType.APPLICATION_JSON_UTF8)
           .accept(MediaType.APPLICATION_JSON);
     }

--- a/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/service/BroadcastServiceSecurityTest.java
+++ b/wls-broadcast-service/src/test/java/de/muenchen/oss/wahllokalsystem/broadcastservice/service/BroadcastServiceSecurityTest.java
@@ -7,6 +7,7 @@ import de.muenchen.oss.wahllokalsystem.broadcastservice.domain.MessageRepository
 import de.muenchen.oss.wahllokalsystem.broadcastservice.rest.BroadcastMessageDTO;
 import de.muenchen.oss.wahllokalsystem.broadcastservice.utils.Authorities;
 import de.muenchen.oss.wahllokalsystem.broadcastservice.utils.TestdataFactory;
+import de.muenchen.oss.wahllokalsystem.wls.common.security.BezirkIDPermissionEvaluator;
 import de.muenchen.oss.wahllokalsystem.wls.common.testing.SecurityUtils;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -25,6 +26,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.access.AccessDeniedException;
@@ -33,6 +35,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest(
     classes = {MicroServiceApplication.class},
@@ -40,6 +43,8 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles(profiles = {SPRING_TEST_PROFILE})
 @Slf4j
 public class BroadcastServiceSecurityTest {
+
+  @MockitoBean BezirkIDPermissionEvaluator bezirkIDPermissionEvaluator;
 
   @Autowired MessageRepository messageRepository;
 
@@ -102,6 +107,9 @@ public class BroadcastServiceSecurityTest {
 
     @Test
     void should_throwAccessDeniedException_when_runWithDummyRole() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith("ROLE_DUMMY");
       Assertions.assertThatExceptionOfType(AccessDeniedException.class)
           .isThrownBy(() -> broadcastService.getOldestMessage(null))
@@ -112,6 +120,9 @@ public class BroadcastServiceSecurityTest {
     @MethodSource("getMissingAuthoritiesVariations")
     void should_throwAccessDeniedException_when_anyAuthorityMissing(
         final ArgumentsAccessor argumentsAccessor) {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(argumentsAccessor.get(0, String[].class));
 
       Assertions.assertThatExceptionOfType(AccessDeniedException.class)
@@ -126,9 +137,23 @@ public class BroadcastServiceSecurityTest {
 
     @Test
     void should_notThrowException_when_givenAllAuthorities() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(Authorities.ALL_AUTHORITIES_GET_BROADCAST);
       Assertions.assertThatThrownBy(() -> broadcastService.getOldestMessage("wahlbezirkId"))
           .isNotInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void should_throwException_when_givenAllAuthoritiesButWahlbezirkIDDoesNotMatch() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(false);
+      SecurityUtils.runWith(Authorities.ALL_AUTHORITIES_GET_BROADCAST);
+      Assertions.assertThatExceptionOfType(AccessDeniedException.class)
+          .isThrownBy(() -> broadcastService.getOldestMessage("wahlbezirkId"))
+          .withMessageStartingWith("Access Denied");
     }
   }
 
@@ -137,6 +162,9 @@ public class BroadcastServiceSecurityTest {
 
     @Test
     void should_throwAccessDeniedException_when_runWithDummyRole() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith("ROLE_DUMMY");
       Assertions.assertThatExceptionOfType(AccessDeniedException.class)
           .isThrownBy(() -> broadcastService.deleteMessage(null))
@@ -147,6 +175,9 @@ public class BroadcastServiceSecurityTest {
     @MethodSource("getMissingAuthoritiesVariations")
     void should_throwAccessDeniedException_when_anyAuthorityMissing(
         final ArgumentsAccessor argumentsAccessor) {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(Authorities.REPOSITORY_WRITE_MESSAGE);
       val wahlbezirkID = "wahlbezirkId";
       val message =
@@ -177,6 +208,9 @@ public class BroadcastServiceSecurityTest {
 
     @Test
     void should_notThrowException_when_givenAllAuthorities() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(Authorities.REPOSITORY_WRITE_MESSAGE);
       val wahlbezirkID = "wahlbezirkId";
       val message =


### PR DESCRIPTION
# Beschreibung:

BezirkIdPermissionEvaluator ergänzt und entsprechend Tests ergänzt

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [X] [Naming Conventions][naming-conventions-link] beachtet
- [X] ~~Doku aktualisiert~~
- [X] ~~Swagger-API vollständig~~
- [X] Unit-Tests gepflegt
- [X] Integrationstests gepflegt
- [X] ~~Beispiel-Requests gepflegt~~
- [X] ~~Texte auf Rechtschreibung und Grammatik geprüft~~

# Referenzen[^1]:

Closes #2059

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Implemented bezirk-level access control for message retrieval to ensure users can only access messages from their assigned bezirk region, preventing unauthorized access across bezirks.

* **Tests**
  * Updated integration and security tests to comprehensively validate bezirk-level permission enforcement and authorization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->