### PR TITLE
2056 WahlbezirkID-Kontrolle bei Endpunkten komplettieren - Monitoring

### DIFF
--- a/wls-monitoring-service/src/main/java/de/muenchen/oss/wahllokalsystem/monitoringservice/service/waehleranzahl/WaehleranzahlService.java
+++ b/wls-monitoring-service/src/main/java/de/muenchen/oss/wahllokalsystem/monitoringservice/service/waehleranzahl/WaehleranzahlService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -22,16 +23,21 @@ public class WaehleranzahlService {
   private final ExceptionFactory exceptionFactory;
   private final WaehleranzahlClient waehleranzahlClient;
 
-  @PreAuthorize("hasAuthority('Monitoring_BUSINESSACTION_GetWahlbeteiligung')")
-  public Optional<WaehleranzahlModel> getWahlbeteiligung(BezirkUndWahlID bezirkUndWahlID) {
+  @PreAuthorize(
+      "hasAuthority('Monitoring_BUSINESSACTION_GetWahlbeteiligung')"
+          + "and @bezirkIdPermissionEvaluator.tokenUserBezirkIdMatches(#bezirkUndWahl.wahlbezirkID, authentication)")
+  public Optional<WaehleranzahlModel> getWahlbeteiligung(
+      @P("bezirkUndWahl") BezirkUndWahlID bezirkUndWahlID) {
     waehleranzahlValidator.validWahlIdUndWahlbezirkIDOrThrow(bezirkUndWahlID);
     val waehleranzahlFromRepo = waehleranzahlRepository.findById(bezirkUndWahlID);
 
     return waehleranzahlFromRepo.map(waehleranzahlModelMapper::toModel);
   }
 
-  @PreAuthorize("hasAuthority('Monitoring_BUSINESSACTION_PostWahlbeteiligung')")
-  public void postWahlbeteiligung(WaehleranzahlModel waehleranzahl) {
+  @PreAuthorize(
+      "hasAuthority('Monitoring_BUSINESSACTION_PostWahlbeteiligung')"
+          + "and @bezirkIdPermissionEvaluator.tokenUserBezirkIdMatches(#param.bezirkUndWahlID().wahlbezirkID, authentication)")
+  public void postWahlbeteiligung(@P("param") WaehleranzahlModel waehleranzahl) {
     try {
       waehleranzahlRepository.save(waehleranzahlModelMapper.toEntity(waehleranzahl));
     } catch (Exception e) {

--- a/wls-monitoring-service/src/main/java/de/muenchen/oss/wahllokalsystem/monitoringservice/service/wahllokalzustand/WahllokalZustandService.java
+++ b/wls-monitoring-service/src/main/java/de/muenchen/oss/wahllokalsystem/monitoringservice/service/wahllokalzustand/WahllokalZustandService.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,8 +19,10 @@ public class WahllokalZustandService {
   private final WahllokalZustandValidator wahllokalZustandValidator;
   private final WahllokalZustandClient wahllokalZustandClient;
 
-  @PreAuthorize("hasAuthority('Monitoring_BUSINESSACTION_PostLastSeen')")
-  public void postLastSeen(final String wahlbezirkID) {
+  @PreAuthorize(
+      "hasAuthority('Monitoring_BUSINESSACTION_PostLastSeen')"
+          + "and @bezirkIdPermissionEvaluator.tokenUserBezirkIdMatches(#wahlbezirkID, authentication)")
+  public void postLastSeen(@P("wahlbezirkID") final String wahlbezirkID) {
     wahllokalZustandValidator.validWahlbezirkIDOrThrow(
         wahlbezirkID,
         exceptionFactory.createFachlicheWlsException(
@@ -27,8 +30,10 @@ public class WahllokalZustandService {
     wahllokalZustandClient.postLastSeen(wahlbezirkID, LocalDateTime.now());
   }
 
-  @PreAuthorize("hasAuthority('Monitoring_BUSINESSACTION_PostLetzteAbmeldung')")
-  public void postLetzteAbmeldung(final String wahlbezirkID) {
+  @PreAuthorize(
+      "hasAuthority('Monitoring_BUSINESSACTION_PostLetzteAbmeldung')"
+          + "and @bezirkIdPermissionEvaluator.tokenUserBezirkIdMatches(#wahlbezirkID, authentication)")
+  public void postLetzteAbmeldung(@P("wahlbezirkID") final String wahlbezirkID) {
     wahllokalZustandValidator.validWahlbezirkIDOrThrow(
         wahlbezirkID,
         exceptionFactory.createFachlicheWlsException(
@@ -36,9 +41,12 @@ public class WahllokalZustandService {
     wahllokalZustandClient.postLetzteAbmeldung(wahlbezirkID, LocalDateTime.now());
   }
 
-  @PreAuthorize("hasAuthority('Monitoring_BUSINESSACTION_PostSchnellmeldungSendungsuhrzeit')")
+  @PreAuthorize(
+      "hasAuthority('Monitoring_BUSINESSACTION_PostSchnellmeldungSendungsuhrzeit')"
+          + "and @bezirkIdPermissionEvaluator.tokenUserBezirkIdMatches(#bezirkUndWahl.wahlbezirkID, authentication)")
   public void postSchnellmeldungSendungsuhrzeit(
-      final BezirkUndWahlID bezirkUndWahlID, final LocalDateTime schnellmeldungSendungsuhrzeit) {
+      @P("bezirkUndWahl") final BezirkUndWahlID bezirkUndWahlID,
+      final LocalDateTime schnellmeldungSendungsuhrzeit) {
     wahllokalZustandValidator.validWahlIdUndWahlbezirkIDOrThrow(
         bezirkUndWahlID,
         exceptionFactory.createFachlicheWlsException(
@@ -47,9 +55,12 @@ public class WahllokalZustandService {
         bezirkUndWahlID, schnellmeldungSendungsuhrzeit);
   }
 
-  @PreAuthorize("hasAuthority('Monitoring_BUSINESSACTION_PostSchnellmeldungDruckuhrzeit')")
+  @PreAuthorize(
+      "hasAuthority('Monitoring_BUSINESSACTION_PostSchnellmeldungDruckuhrzeit')"
+          + "and @bezirkIdPermissionEvaluator.tokenUserBezirkIdMatches(#bezirkUndWahl.wahlbezirkID, authentication)")
   public void postSchnellmeldungDruckuhrzeit(
-      final BezirkUndWahlID bezirkUndWahlID, final LocalDateTime schnellmeldungsDruckuhrzeit) {
+      @P("bezirkUndWahl") final BezirkUndWahlID bezirkUndWahlID,
+      final LocalDateTime schnellmeldungsDruckuhrzeit) {
     wahllokalZustandValidator.validWahlIdUndWahlbezirkIDOrThrow(
         bezirkUndWahlID,
         exceptionFactory.createFachlicheWlsException(
@@ -58,9 +69,12 @@ public class WahllokalZustandService {
         bezirkUndWahlID, schnellmeldungsDruckuhrzeit);
   }
 
-  @PreAuthorize("hasAuthority('Monitoring_BUSINESSACTION_PostNiederschriftSendungsuhrzeit')")
+  @PreAuthorize(
+      "hasAuthority('Monitoring_BUSINESSACTION_PostNiederschriftSendungsuhrzeit')"
+          + "and @bezirkIdPermissionEvaluator.tokenUserBezirkIdMatches(#bezirkUndWahl.wahlbezirkID, authentication)")
   public void postNiederschriftSendungsuhrzeit(
-      final BezirkUndWahlID bezirkUndWahlID, final LocalDateTime niederschriftSendungsuhrzeit) {
+      @P("bezirkUndWahl") final BezirkUndWahlID bezirkUndWahlID,
+      final LocalDateTime niederschriftSendungsuhrzeit) {
     wahllokalZustandValidator.validWahlIdUndWahlbezirkIDOrThrow(
         bezirkUndWahlID,
         exceptionFactory.createFachlicheWlsException(
@@ -69,9 +83,12 @@ public class WahllokalZustandService {
         bezirkUndWahlID, niederschriftSendungsuhrzeit);
   }
 
-  @PreAuthorize("hasAuthority('Monitoring_BUSINESSACTION_PostNiederschriftDruckuhrzeit')")
+  @PreAuthorize(
+      "hasAuthority('Monitoring_BUSINESSACTION_PostNiederschriftDruckuhrzeit')"
+          + "and @bezirkIdPermissionEvaluator.tokenUserBezirkIdMatches(#bezirkUndWahl.wahlbezirkID, authentication)")
   public void postNiederschriftDruckuhrzeit(
-      final BezirkUndWahlID bezirkUndWahlID, final LocalDateTime niederschriftDruckuhrzeit) {
+      @P("bezirkUndWahl") final BezirkUndWahlID bezirkUndWahlID,
+      final LocalDateTime niederschriftDruckuhrzeit) {
     wahllokalZustandValidator.validWahlIdUndWahlbezirkIDOrThrow(
         bezirkUndWahlID,
         exceptionFactory.createFachlicheWlsException(

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/rest/waehleranzahl/WaehleranzahlControllerIntegrationTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/rest/waehleranzahl/WaehleranzahlControllerIntegrationTest.java
@@ -1,9 +1,9 @@
 package de.muenchen.oss.wahllokalsystem.monitoringservice.rest.waehleranzahl;
 
-import static de.muenchen.oss.wahllokalsystem.monitoringservice.TestConstants.SPRING_NO_SECURITY_PROFILE;
 import static de.muenchen.oss.wahllokalsystem.monitoringservice.TestConstants.SPRING_TEST_PROFILE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -13,9 +13,11 @@ import de.muenchen.oss.wahllokalsystem.monitoringservice.domain.waehleranzahl.Wa
 import de.muenchen.oss.wahllokalsystem.monitoringservice.domain.waehleranzahl.WaehleranzahlRepository;
 import de.muenchen.oss.wahllokalsystem.monitoringservice.exception.ExceptionConstants;
 import de.muenchen.oss.wahllokalsystem.monitoringservice.service.waehleranzahl.WaehleranzahlModelMapper;
+import de.muenchen.oss.wahllokalsystem.monitoringservice.utils.Authorities;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExceptionCategory;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExceptionDTO;
 import de.muenchen.oss.wahllokalsystem.wls.common.security.domain.BezirkUndWahlID;
+import de.muenchen.oss.wahllokalsystem.wls.common.testing.SecurityUtils;
 import java.time.LocalDateTime;
 import lombok.val;
 import org.assertj.core.api.Assertions;
@@ -29,10 +31,12 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.RequestBuilder;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @SpringBootTest(
@@ -40,7 +44,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
     webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
 @AutoConfigureWireMock
-@ActiveProfiles(profiles = {SPRING_TEST_PROFILE, SPRING_NO_SECURITY_PROFILE})
+@ActiveProfiles(profiles = {SPRING_TEST_PROFILE})
 public class WaehleranzahlControllerIntegrationTest {
 
   @Value("${service.info.oid}")
@@ -60,6 +64,7 @@ public class WaehleranzahlControllerIntegrationTest {
 
   @AfterEach
   void teardown() {
+    SecurityUtils.runWith(Authorities.REPOSITORY_DELETE_WAEHLERANZAHL);
     waehleranzahlRepository.deleteAll();
   }
 
@@ -68,15 +73,20 @@ public class WaehleranzahlControllerIntegrationTest {
 
     @Test
     void should_returnEmptyResponse_when_noDataFound() throws Exception {
-      val wahlID = "wahlID01";
-      val wahlbezirkID = "wahlbezirkID01";
-      val request =
-          MockMvcRequestBuilders.get(
-              "/businessActions/wahlbeteiligung/" + wahlID + "/" + wahlbezirkID);
-
-      val response = api.perform(request).andExpect(status().isNoContent()).andReturn();
+      val wahlbezirkID = "wahlbezirkID";
+      val response =
+          api.perform(createGetRequest("wahlID", wahlbezirkID, wahlbezirkID))
+              .andExpect(status().isNoContent())
+              .andReturn();
 
       Assertions.assertThat(response.getResponse().getContentAsString()).isEmpty();
+    }
+
+    @Test
+    void should_returnForbidden_when_userHasWrongBezirkId() throws Exception {
+      String wahlbezirkID = "wahlbezirkID";
+      api.perform(createGetRequest("wahlID", wahlbezirkID, wahlbezirkID + "sth"))
+          .andExpect(status().isForbidden());
     }
 
     @Test
@@ -88,13 +98,13 @@ public class WaehleranzahlControllerIntegrationTest {
       val uhrzeit = LocalDateTime.parse("2024-09-13T12:11:21.343");
 
       val waehleranzahlToFind = new Waehleranzahl(bezirkUndWahlID, anzahlWaehler, uhrzeit);
+      SecurityUtils.runWith(Authorities.REPOSITORY_WRITE_WAEHLERANZAHL);
       waehleranzahlRepository.save(waehleranzahlToFind);
 
-      val request =
-          MockMvcRequestBuilders.get(
-              "/businessActions/wahlbeteiligung/" + wahlID + "/" + wahlbezirkID);
-
-      val response = api.perform(request).andExpect(status().isOk()).andReturn();
+      val response =
+          api.perform(createGetRequest(wahlID, wahlbezirkID, wahlbezirkID))
+              .andExpect(status().isOk())
+              .andReturn();
       val responseBodyAsDTO =
           objectMapper.readValue(
               response.getResponse().getContentAsString(), WaehleranzahlDTO.class);
@@ -102,6 +112,18 @@ public class WaehleranzahlControllerIntegrationTest {
       val expectedResponseBody =
           waehleranzahlDTOMapper.toDTO(waehleranzahlModelMapper.toModel(waehleranzahlToFind));
       Assertions.assertThat(responseBodyAsDTO).isEqualTo(expectedResponseBody);
+    }
+
+    private MockHttpServletRequestBuilder createGetRequest(
+        final String wahlID, final String wahlbezirkID, final String claimWahlbezirkID) {
+      return MockMvcRequestBuilders.get(
+              "/businessActions/wahlbeteiligung/" + wahlID + "/" + wahlbezirkID)
+          .with(
+              jwt()
+                  .authorities(
+                      new SimpleGrantedAuthority(Authorities.SERVICE_GET_WAEHLERANZAHL),
+                      new SimpleGrantedAuthority(Authorities.REPOSITORY_READ_WAEHLERANZAHL))
+                  .jwt(jwt -> jwt.claim("wahlbezirkID", claimWahlbezirkID)));
     }
 
     @Nested
@@ -117,6 +139,7 @@ public class WaehleranzahlControllerIntegrationTest {
 
         // store data with bezirkUndWahlID
         val waehleranzahlToFind = new Waehleranzahl(bezirkUndWahlID, anzahlWaehler_1, uhrzeit_1);
+        SecurityUtils.runWith(Authorities.REPOSITORY_WRITE_WAEHLERANZAHL);
         waehleranzahlRepository.save(waehleranzahlToFind);
 
         // Overwrite existing data with same bezirkUndWahlID
@@ -124,9 +147,10 @@ public class WaehleranzahlControllerIntegrationTest {
         val uhrzeit_2 = LocalDateTime.parse("2024-09-13T12:11:21.666");
         val waehleranzahlDTO_2 = new WaehleranzahlDTO(anzahlWaehler_2, uhrzeit_2);
 
-        val request_2 = buildPostRequest(wahlID, wahlbezirkID, waehleranzahlDTO_2);
+        val request_2 = buildPostRequest(wahlID, wahlbezirkID, wahlbezirkID, waehleranzahlDTO_2);
         api.perform(request_2).andExpect(status().isOk()).andReturn();
 
+        SecurityUtils.runWith(Authorities.REPOSITORY_READ_WAEHLERANZAHL);
         val waehleranzahlFromRepo_2 = waehleranzahlRepository.findById(bezirkUndWahlID).get();
         val expectedWaehleranzahl_2 =
             waehleranzahlModelMapper.toEntity(
@@ -135,6 +159,18 @@ public class WaehleranzahlControllerIntegrationTest {
         Assertions.assertThat(waehleranzahlFromRepo_2)
             .usingRecursiveComparison()
             .isEqualTo(expectedWaehleranzahl_2);
+      }
+
+      @Test
+      void should_returnForbidden_when_userHasWrongBezirkId() throws Exception {
+        val wahlID = "wahlID";
+        val wahlbezirkID = "wahlbezirkID";
+        val anzahlWaehler = 99L;
+        val uhrzeit = LocalDateTime.parse("2024-09-13T12:11:21.343");
+        val waehleranzahlDTO = new WaehleranzahlDTO(anzahlWaehler, uhrzeit);
+
+        api.perform(buildPostRequest(wahlID, wahlbezirkID, wahlbezirkID + "sth", waehleranzahlDTO))
+            .andExpect(status().isForbidden());
       }
     }
 
@@ -146,13 +182,9 @@ public class WaehleranzahlControllerIntegrationTest {
       val uhrzeit = LocalDateTime.parse("2024-09-13T12:11:21.343");
       val waehleranzahlDTO = new WaehleranzahlDTO(anzahlWaehler, uhrzeit);
 
-      val request =
-          MockMvcRequestBuilders.post(
-                  "/businessActions/wahlbeteiligung/" + wahlID + "/" + wahlbezirkID)
-              .with(csrf())
-              .contentType(MediaType.APPLICATION_JSON)
-              .content(objectMapper.writeValueAsString(waehleranzahlDTO));
+      val request = buildPostRequest(wahlID, wahlbezirkID, wahlbezirkID, waehleranzahlDTO);
 
+      SecurityUtils.runWith(Authorities.REPOSITORY_WRITE_WAEHLERANZAHL);
       Mockito.doThrow(new RuntimeException("DB-Error")).when(wahleranzahlRepository).save(any());
 
       val response = api.perform(request).andExpect(status().isInternalServerError()).andReturn();
@@ -172,10 +204,19 @@ public class WaehleranzahlControllerIntegrationTest {
     }
 
     private RequestBuilder buildPostRequest(
-        final String wahlID, final String wahlbezirkID, final WaehleranzahlDTO requestBody)
+        final String wahlID,
+        final String wahlbezirkID,
+        final String claimWahlbezirkID,
+        final WaehleranzahlDTO requestBody)
         throws Exception {
       return post("/businessActions/wahlbeteiligung/" + wahlID + "/" + wahlbezirkID)
           .with(csrf())
+          .with(
+              jwt()
+                  .authorities(
+                      new SimpleGrantedAuthority(Authorities.SERVICE_POST_WAEHLERANZAHL),
+                      new SimpleGrantedAuthority(Authorities.REPOSITORY_WRITE_WAEHLERANZAHL))
+                  .jwt(jwt -> jwt.claim("wahlbezirkID", claimWahlbezirkID)))
           .contentType(MediaType.APPLICATION_JSON)
           .content(objectMapper.writeValueAsString(requestBody));
     }

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/rest/wahllokalzustand/WahllokalZustandControllerIntegrationTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/rest/wahllokalzustand/WahllokalZustandControllerIntegrationTest.java
@@ -2,15 +2,16 @@ package de.muenchen.oss.wahllokalsystem.monitoringservice.rest.wahllokalzustand;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
-import static de.muenchen.oss.wahllokalsystem.monitoringservice.TestConstants.SPRING_NO_SECURITY_PROFILE;
 import static de.muenchen.oss.wahllokalsystem.monitoringservice.TestConstants.SPRING_TEST_PROFILE;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import de.muenchen.oss.wahllokalsystem.monitoringservice.MicroServiceApplication;
 import de.muenchen.oss.wahllokalsystem.monitoringservice.exception.ExceptionConstants;
+import de.muenchen.oss.wahllokalsystem.monitoringservice.utils.Authorities;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExceptionCategory;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.rest.model.WlsExceptionDTO;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.util.ExceptionKonstanten;
@@ -27,6 +28,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -36,7 +38,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
     webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
 @AutoConfigureWireMock
-@ActiveProfiles(profiles = {SPRING_TEST_PROFILE, SPRING_NO_SECURITY_PROFILE})
+@ActiveProfiles(profiles = {SPRING_TEST_PROFILE})
 class WahllokalZustandControllerIntegrationTest {
 
   @Value("${service.info.oid}")
@@ -56,15 +58,27 @@ class WahllokalZustandControllerIntegrationTest {
 
     @Test
     void should_notThrowAnyException_when_requestParamValid() {
+      val wahlbezirkID = "wahlbezirkID";
       val request =
-          MockMvcRequestBuilders.post("/businessActions/lastSeen/" + "validWahlbezirkID")
-              .with(csrf());
+          MockMvcRequestBuilders.post("/businessActions/lastSeen/" + wahlbezirkID)
+              .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(new SimpleGrantedAuthority(Authorities.SERVICE_POST_LASTSEEN))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", wahlbezirkID)));
       Assertions.assertThatNoException().isThrownBy(() -> mockMvc.perform(request));
     }
 
     @Test
     void should_throwWlsException_when_requestParamsAreInvalid() throws Exception {
-      val request = MockMvcRequestBuilders.post("/businessActions/lastSeen/" + "  ").with(csrf());
+      val wahlbezirkID = "  ";
+      val request =
+          MockMvcRequestBuilders.post("/businessActions/lastSeen/" + wahlbezirkID)
+              .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(new SimpleGrantedAuthority(Authorities.SERVICE_POST_LASTSEEN))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", wahlbezirkID)));
       val response = mockMvc.perform(request).andExpect(status().isBadRequest()).andReturn();
       val responseBodyAsWlsExceptionDTO =
           objectMapper.readValue(
@@ -82,6 +96,21 @@ class WahllokalZustandControllerIntegrationTest {
           .ignoringFields("message")
           .isEqualTo(expectedWlsExceptionDTO);
     }
+
+    @Test
+    void should_throwFachlicheWlsException_when_wahlbezirkIdDoesNotMatchUserWahlbezirkID()
+        throws Exception {
+      String wahlbezirkID = "wahlbezirkID";
+      val request =
+          MockMvcRequestBuilders.post("/businessActions/lastSeen/" + wahlbezirkID)
+              .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(new SimpleGrantedAuthority(Authorities.SERVICE_POST_LASTSEEN))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", wahlbezirkID + "sth")));
+
+      mockMvc.perform(request).andExpect(status().isForbidden());
+    }
   }
 
   @Nested
@@ -91,13 +120,23 @@ class WahllokalZustandControllerIntegrationTest {
     void should_notThrowAnyException_when_requestParamValid() {
       val request =
           MockMvcRequestBuilders.post("/businessActions/letzteAbmeldung/" + "validWahlbezirkID")
-              .with(csrf());
+              .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(new SimpleGrantedAuthority(Authorities.SERVICE_POST_LAST_LOGOUT))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", "wahlbezirkID")));
       Assertions.assertThatNoException().isThrownBy(() -> mockMvc.perform(request));
     }
 
     @Test
     void should_throwWlsException_when_requestParamsAreInvalid() throws Exception {
-      val request = MockMvcRequestBuilders.post("/businessActions/letzteAbmeldung/").with(csrf());
+      val request =
+          MockMvcRequestBuilders.post("/businessActions/letzteAbmeldung/")
+              .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(new SimpleGrantedAuthority(Authorities.SERVICE_POST_LAST_LOGOUT))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", "wahlbezirkID")));
       val response =
           mockMvc.perform(request).andExpect(status().isInternalServerError()).andReturn();
       val responseBodyAsWlsExceptionDTO =
@@ -116,6 +155,21 @@ class WahllokalZustandControllerIntegrationTest {
           .ignoringFields("message")
           .isEqualTo(expectedWlsExceptionDTO);
     }
+
+    @Test
+    void should_throwFachlicheWlsException_when_wahlbezirkIdDoesNotMatchUserWahlbezirkID()
+        throws Exception {
+      String wahlbezirkID = "wahlbezirkID";
+      val request =
+          MockMvcRequestBuilders.post("/businessActions/letzteAbmeldung/" + wahlbezirkID)
+              .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(new SimpleGrantedAuthority(Authorities.SERVICE_POST_LAST_LOGOUT))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", wahlbezirkID + "sth")));
+
+      mockMvc.perform(request).andExpect(status().isForbidden());
+    }
   }
 
   @Nested
@@ -123,10 +177,17 @@ class WahllokalZustandControllerIntegrationTest {
 
     @Test
     void should_notThrowAnyException_when_requestParamValid() throws Exception {
-      val sendungsDatenDTO_valid = createSendungsdatenDTO("wahlID", "wahlbezirkID");
+      val wahlbezirkID = "wahlbezirkID";
+      val sendungsDatenDTO_valid = createSendungsdatenDTO("wahlID", wahlbezirkID);
       val request_valid_param =
           MockMvcRequestBuilders.post("/businessActions/schnellmeldungSendungsuhrzeit")
               .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(
+                          new SimpleGrantedAuthority(
+                              Authorities.SERVICE_POST_SCHNELLMELDUNG_SENDUNGSUHRZEIT))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", wahlbezirkID)))
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(sendungsDatenDTO_valid));
       Assertions.assertThatNoException().isThrownBy(() -> mockMvc.perform(request_valid_param));
@@ -137,6 +198,12 @@ class WahllokalZustandControllerIntegrationTest {
       val request_sendungsDatenNull =
           MockMvcRequestBuilders.post("/businessActions/schnellmeldungSendungsuhrzeit")
               .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(
+                          new SimpleGrantedAuthority(
+                              Authorities.SERVICE_POST_SCHNELLMELDUNG_SENDUNGSUHRZEIT))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", "wahlbezirkID")))
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(null));
       val response_sendungsDatenNull =
@@ -157,6 +224,26 @@ class WahllokalZustandControllerIntegrationTest {
           .ignoringFields("message")
           .isEqualTo(expectedWlsExceptionDTO_sendungsDatenNull);
     }
+
+    @Test
+    void should_throwFachlicheWlsException_when_wahlbezirkIdDoesNotMatchUserWahlbezirkID()
+        throws Exception {
+      String wahlbezirkID = "wahlbezirkID";
+      val sendungsDatenDTO = createSendungsdatenDTO("wahlID", wahlbezirkID);
+      val request =
+          MockMvcRequestBuilders.post("/businessActions/schnellmeldungSendungsuhrzeit")
+              .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(
+                          new SimpleGrantedAuthority(
+                              Authorities.SERVICE_POST_SCHNELLMELDUNG_SENDUNGSUHRZEIT))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", wahlbezirkID + "sth")))
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(sendungsDatenDTO));
+
+      mockMvc.perform(request).andExpect(status().isForbidden());
+    }
   }
 
   @Nested
@@ -164,10 +251,17 @@ class WahllokalZustandControllerIntegrationTest {
 
     @Test
     void should_notThrowAnyException_when_requestParamValid() throws Exception {
-      val druckDatenDTO_valid = createSendungsdatenDTO("wahlID", "wahlbezirkID");
+      val wahlbezirkID = "wahlbezirkID";
+      val druckDatenDTO_valid = createSendungsdatenDTO("wahlID", wahlbezirkID);
       val request_valid_param =
           MockMvcRequestBuilders.post("/businessActions/schnellmeldungDruckuhrzeit")
               .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(
+                          new SimpleGrantedAuthority(
+                              Authorities.SERVICE_POST_SCHNELLMELDUNG_DRUCKUHRZEIT))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", wahlbezirkID)))
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(druckDatenDTO_valid));
       Assertions.assertThatNoException().isThrownBy(() -> mockMvc.perform(request_valid_param));
@@ -178,6 +272,12 @@ class WahllokalZustandControllerIntegrationTest {
       val request_druckDatenNull =
           MockMvcRequestBuilders.post("/businessActions/schnellmeldungDruckuhrzeit")
               .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(
+                          new SimpleGrantedAuthority(
+                              Authorities.SERVICE_POST_SCHNELLMELDUNG_DRUCKUHRZEIT))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", "wahlbezirkID")))
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(null));
 
@@ -199,6 +299,26 @@ class WahllokalZustandControllerIntegrationTest {
           .ignoringFields("message")
           .isEqualTo(expectedWlsExceptionDTO_druckDatenNull);
     }
+
+    @Test
+    void should_throwFachlicheWlsException_when_wahlbezirkIdDoesNotMatchUserWahlbezirkID()
+        throws Exception {
+      String wahlbezirkID = "wahlbezirkID";
+      val druckDatenDTO = createSendungsdatenDTO("wahlID", wahlbezirkID);
+      val request =
+          MockMvcRequestBuilders.post("/businessActions/schnellmeldungDruckuhrzeit")
+              .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(
+                          new SimpleGrantedAuthority(
+                              Authorities.SERVICE_POST_SCHNELLMELDUNG_DRUCKUHRZEIT))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", wahlbezirkID + "sth")))
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(druckDatenDTO));
+
+      mockMvc.perform(request).andExpect(status().isForbidden());
+    }
   }
 
   @Nested
@@ -206,10 +326,17 @@ class WahllokalZustandControllerIntegrationTest {
 
     @Test
     void should_notThrowAnyException_when_requestParamValid() throws Exception {
-      val sendungsDatenDTO_valid = createSendungsdatenDTO("wahlID", "wahlbezirkID");
+      val wahlbezirkID = "wahlbezirkID";
+      val sendungsDatenDTO_valid = createSendungsdatenDTO("wahlID", wahlbezirkID);
       val request_valid_param =
           MockMvcRequestBuilders.post("/businessActions/niederschriftSendungsuhrzeit")
               .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(
+                          new SimpleGrantedAuthority(
+                              Authorities.SERVICE_POST_NIEDERSCHRIFT_SENDUNGSUHRZEIT))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", wahlbezirkID)))
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(sendungsDatenDTO_valid));
       Assertions.assertThatNoException().isThrownBy(() -> mockMvc.perform(request_valid_param));
@@ -217,11 +344,18 @@ class WahllokalZustandControllerIntegrationTest {
 
     @Test
     void should_throwWlsException_when_requestParamsAreInvalid() throws Exception {
-      val sendungsDatenDTO_wahlID_blank = createSendungsdatenDTO("  ", "wahlbezirkID");
+      val wahlbezirkID = "wahlbezirkID";
+      val sendungsDatenDTO_wahlID_blank = createSendungsdatenDTO("  ", wahlbezirkID);
 
       val request_wahlID_blank =
           MockMvcRequestBuilders.post("/businessActions/niederschriftSendungsuhrzeit")
               .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(
+                          new SimpleGrantedAuthority(
+                              Authorities.SERVICE_POST_NIEDERSCHRIFT_SENDUNGSUHRZEIT))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", wahlbezirkID)))
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(sendungsDatenDTO_wahlID_blank));
 
@@ -245,6 +379,26 @@ class WahllokalZustandControllerIntegrationTest {
           .ignoringFields("message")
           .isEqualTo(expectedWlsExceptionDTO);
     }
+
+    @Test
+    void should_throwFachlicheWlsException_when_wahlbezirkIdDoesNotMatchUserWahlbezirkID()
+        throws Exception {
+      String wahlbezirkID = "wahlbezirkID";
+      val sendungsDatenDTO = createSendungsdatenDTO("wahlID", wahlbezirkID);
+      val request =
+          MockMvcRequestBuilders.post("/businessActions/niederschriftSendungsuhrzeit")
+              .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(
+                          new SimpleGrantedAuthority(
+                              Authorities.SERVICE_POST_NIEDERSCHRIFT_SENDUNGSUHRZEIT))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", wahlbezirkID + "sth")))
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(sendungsDatenDTO));
+
+      mockMvc.perform(request).andExpect(status().isForbidden());
+    }
   }
 
   @Nested
@@ -252,10 +406,17 @@ class WahllokalZustandControllerIntegrationTest {
 
     @Test
     void should_notThrowAnyException_when_requestParamValid() throws Exception {
-      val druckDatenDTO_valid = createSendungsdatenDTO("wahlID", "wahlbezirkID");
+      val wahlbezirkID = "wahlbezirkID";
+      val druckDatenDTO_valid = createSendungsdatenDTO("wahlID", wahlbezirkID);
       val request_valid_param =
-          MockMvcRequestBuilders.post("/businessActions/niederschriftSendungsuhrzeit")
+          MockMvcRequestBuilders.post("/businessActions/niederschriftDruckuhrzeit")
               .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(
+                          new SimpleGrantedAuthority(
+                              Authorities.SERVICE_POST_NIEDERSCHRIFT_DRUCKUHRZEIT))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", wahlbezirkID)))
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(druckDatenDTO_valid));
       Assertions.assertThatNoException().isThrownBy(() -> mockMvc.perform(request_valid_param));
@@ -267,6 +428,12 @@ class WahllokalZustandControllerIntegrationTest {
       val request_wahlbezirkID_empty =
           MockMvcRequestBuilders.post("/businessActions/niederschriftDruckuhrzeit")
               .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(
+                          new SimpleGrantedAuthority(
+                              Authorities.SERVICE_POST_NIEDERSCHRIFT_DRUCKUHRZEIT))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", "")))
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(druckDatenDTO_wahlbezirkID_empty));
 
@@ -301,6 +468,12 @@ class WahllokalZustandControllerIntegrationTest {
       val request_valid_param =
           MockMvcRequestBuilders.post("/businessActions/niederschriftDruckuhrzeit")
               .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(
+                          new SimpleGrantedAuthority(
+                              Authorities.SERVICE_POST_NIEDERSCHRIFT_DRUCKUHRZEIT))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", "wahlbezirkID")))
               .contentType(MediaType.APPLICATION_JSON)
               .content(
                   """
@@ -316,14 +489,21 @@ class WahllokalZustandControllerIntegrationTest {
 
     @Test
     void should_convertTimeToJsonFormat_when_restCallWithTimestamp() throws Exception {
+      val wahlbezirkID = "wahlbezirkID";
       val validDruckDatenDTO =
           DruckdatenDTO.builder()
               .druckuhrzeit(LocalDateTime.parse("2024-10-21T23:59:12.123"))
-              .bezirkUndWahlID(new BezirkUndWahlID("wahlID", "wahlbezirkID"))
+              .bezirkUndWahlID(new BezirkUndWahlID("wahlID", wahlbezirkID))
               .build();
       val request_wahlbezirkID_empty =
           MockMvcRequestBuilders.post("/businessActions/niederschriftDruckuhrzeit")
               .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(
+                          new SimpleGrantedAuthority(
+                              Authorities.SERVICE_POST_NIEDERSCHRIFT_DRUCKUHRZEIT))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", wahlbezirkID)))
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(validDruckDatenDTO));
 
@@ -338,6 +518,30 @@ class WahllokalZustandControllerIntegrationTest {
                   matchingJsonPath(
                       "$.druckzustaende[0].niederschriftDruckUhrzeit",
                       equalTo("2024-10-21T23:59:12.123"))));
+    }
+
+    @Test
+    void should_throwFachlicheWlsException_when_wahlbezirkIdDoesNotMatchUserWahlbezirkID()
+        throws Exception {
+      String wahlbezirkID = "wahlbezirkID";
+      val druckDatenDTO =
+          DruckdatenDTO.builder()
+              .druckuhrzeit(LocalDateTime.parse("2024-10-21T23:59:12.123"))
+              .bezirkUndWahlID(new BezirkUndWahlID("wahlID", wahlbezirkID))
+              .build();
+      val request =
+          MockMvcRequestBuilders.post("/businessActions/niederschriftDruckuhrzeit")
+              .with(csrf())
+              .with(
+                  jwt()
+                      .authorities(
+                          new SimpleGrantedAuthority(
+                              Authorities.SERVICE_POST_NIEDERSCHRIFT_DRUCKUHRZEIT))
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", wahlbezirkID + "sth")))
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(druckDatenDTO));
+
+      mockMvc.perform(request).andExpect(status().isForbidden());
     }
   }
 

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/rest/wahllokalzustand/WahllokalZustandControllerIntegrationTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/rest/wahllokalzustand/WahllokalZustandControllerIntegrationTest.java
@@ -118,13 +118,14 @@ class WahllokalZustandControllerIntegrationTest {
 
     @Test
     void should_notThrowAnyException_when_requestParamValid() {
+      String wahlbezirkID = "wahlbezirkID";
       val request =
-          MockMvcRequestBuilders.post("/businessActions/letzteAbmeldung/" + "validWahlbezirkID")
+          MockMvcRequestBuilders.post("/businessActions/letzteAbmeldung/" + wahlbezirkID)
               .with(csrf())
               .with(
                   jwt()
                       .authorities(new SimpleGrantedAuthority(Authorities.SERVICE_POST_LAST_LOGOUT))
-                      .jwt(jwt -> jwt.claim("wahlbezirkID", "wahlbezirkID")));
+                      .jwt(jwt -> jwt.claim("wahlbezirkID", wahlbezirkID)));
       Assertions.assertThatNoException().isThrownBy(() -> mockMvc.perform(request));
     }
 

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/service/waehleranzahl/WaehleranzahlServiceSecurityTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/service/waehleranzahl/WaehleranzahlServiceSecurityTest.java
@@ -11,6 +11,7 @@ import de.muenchen.oss.wahllokalsystem.monitoringservice.domain.waehleranzahl.Wa
 import de.muenchen.oss.wahllokalsystem.monitoringservice.rest.waehleranzahl.WaehleranzahlDTOMapper;
 import de.muenchen.oss.wahllokalsystem.monitoringservice.utils.Authorities;
 import de.muenchen.oss.wahllokalsystem.wls.common.exception.TechnischeWlsException;
+import de.muenchen.oss.wahllokalsystem.wls.common.security.BezirkIDPermissionEvaluator;
 import de.muenchen.oss.wahllokalsystem.wls.common.security.domain.BezirkUndWahlID;
 import de.muenchen.oss.wahllokalsystem.wls.common.testing.SecurityUtils;
 import java.time.LocalDateTime;
@@ -25,6 +26,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
@@ -48,6 +50,8 @@ public class WaehleranzahlServiceSecurityTest {
 
   @MockitoBean WaehleranzahlValidator waehleranzahlValidator;
 
+  @MockitoBean BezirkIDPermissionEvaluator bezirkIDPermissionEvaluator;
+
   @BeforeEach
   void setup() {
     clearContext();
@@ -64,6 +68,9 @@ public class WaehleranzahlServiceSecurityTest {
 
     @Test
     void should_grantAccessAndThrowNoException_when_authoritiesAreValid() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       BezirkUndWahlID bezirkUndWahlID = new BezirkUndWahlID("wahlID01", "wahlbezirkID01");
       SecurityUtils.runWith(Authorities.REPOSITORY_WRITE_WAEHLERANZAHL);
       waehleranzahlRepository.save(new Waehleranzahl(bezirkUndWahlID, 99, LocalDateTime.now()));
@@ -78,6 +85,9 @@ public class WaehleranzahlServiceSecurityTest {
     @MethodSource("getMissingAuthoritiesVariations")
     void should_failWithAccessDeniedException_when_anyAuthorityIsMissing(
         final ArgumentsAccessor argumentsAccessor) {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(argumentsAccessor.get(0, String[].class));
       BezirkUndWahlID bezirkUndWahlID = new BezirkUndWahlID("wahlID01", "wahlbezirkID01");
       Assertions.assertThatThrownBy(() -> waehleranzahlService.getWahlbeteiligung(bezirkUndWahlID))
@@ -88,6 +98,18 @@ public class WaehleranzahlServiceSecurityTest {
       return SecurityUtils.buildArgumentsForMissingAuthoritiesVariations(
           Authorities.ALL_AUTHORITIES_GET_WAEHLERANZAHL);
     }
+
+    @Test
+    void should_throwException_when_givenAllAuthoritiesButWahlbezirkIDDoesNotMatch() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(false);
+      SecurityUtils.runWith(Authorities.ALL_AUTHORITIES_GET_WAEHLERANZAHL);
+      BezirkUndWahlID bezirkUndWahlID = new BezirkUndWahlID("wahlID01", "wahlbezirkID01");
+      Assertions.assertThatExceptionOfType(AccessDeniedException.class)
+          .isThrownBy(() -> waehleranzahlService.getWahlbeteiligung(bezirkUndWahlID))
+          .withMessageStartingWith("Access Denied");
+    }
   }
 
   @Nested
@@ -95,6 +117,9 @@ public class WaehleranzahlServiceSecurityTest {
 
     @Test
     void should_grantAccessAndThrowNoException_when_authoritiesAreValid() throws Exception {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(Authorities.ALL_AUTHORITIES_SET_WAEHLERANZAHL);
       String wahlID = "wahlID01";
       String wahlbezirkID = "wahlbezirkID01";
@@ -116,6 +141,9 @@ public class WaehleranzahlServiceSecurityTest {
 
     @Test
     void should_failWithAccessDeniedException_when_serviceAuthorityIsMissing() throws Exception {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(Authorities.REPOSITORY_WRITE_WAEHLERANZAHL);
 
       String wahlID = "wahlID01";
@@ -139,6 +167,9 @@ public class WaehleranzahlServiceSecurityTest {
 
     @Test
     void should_failWithTechnischeWlsException_when_repoAuthorityIsMissing() throws Exception {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(Authorities.SERVICE_POST_WAEHLERANZAHL);
 
       String wahlID = "wahlID01";
@@ -158,6 +189,18 @@ public class WaehleranzahlServiceSecurityTest {
       Assertions.assertThatThrownBy(
               () -> waehleranzahlService.postWahlbeteiligung(waehleranzahlToSave))
           .isInstanceOf(TechnischeWlsException.class);
+    }
+
+    @Test
+    void should_throwException_when_givenAllAuthoritiesButWahlbezirkIDDoesNotMatch() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(false);
+      SecurityUtils.runWith(Authorities.ALL_AUTHORITIES_SET_WAEHLERANZAHL);
+      BezirkUndWahlID bezirkUndWahlID = new BezirkUndWahlID("wahlID01", "wahlbezirkID01");
+      Assertions.assertThatExceptionOfType(AccessDeniedException.class)
+          .isThrownBy(() -> waehleranzahlService.getWahlbeteiligung(bezirkUndWahlID))
+          .withMessageStartingWith("Access Denied");
     }
   }
 }

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/service/waehleranzahl/WaehleranzahlServiceSecurityTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/service/waehleranzahl/WaehleranzahlServiceSecurityTest.java
@@ -198,8 +198,9 @@ public class WaehleranzahlServiceSecurityTest {
           .thenReturn(false);
       SecurityUtils.runWith(Authorities.ALL_AUTHORITIES_SET_WAEHLERANZAHL);
       BezirkUndWahlID bezirkUndWahlID = new BezirkUndWahlID("wahlID01", "wahlbezirkID01");
+      val waehleranzahl = new WaehleranzahlModel(bezirkUndWahlID, 99L, LocalDateTime.now());
       Assertions.assertThatExceptionOfType(AccessDeniedException.class)
-          .isThrownBy(() -> waehleranzahlService.getWahlbeteiligung(bezirkUndWahlID))
+          .isThrownBy(() -> waehleranzahlService.postWahlbeteiligung(waehleranzahl))
           .withMessageStartingWith("Access Denied");
     }
   }

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/service/wahllokalzustand/WahllokalZustandServiceSecurityTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/service/wahllokalzustand/WahllokalZustandServiceSecurityTest.java
@@ -9,6 +9,7 @@ import de.muenchen.oss.wahllokalsystem.monitoringservice.TestConstants;
 import de.muenchen.oss.wahllokalsystem.monitoringservice.eai.aou.model.DruckzustandDTO;
 import de.muenchen.oss.wahllokalsystem.monitoringservice.eai.aou.model.WahllokalZustandDTO;
 import de.muenchen.oss.wahllokalsystem.monitoringservice.utils.Authorities;
+import de.muenchen.oss.wahllokalsystem.wls.common.security.BezirkIDPermissionEvaluator;
 import de.muenchen.oss.wahllokalsystem.wls.common.security.domain.BezirkUndWahlID;
 import de.muenchen.oss.wahllokalsystem.wls.common.testing.SecurityUtils;
 import java.time.LocalDateTime;
@@ -18,6 +19,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
@@ -25,6 +27,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest(classes = MicroServiceApplication.class)
 @ActiveProfiles({TestConstants.SPRING_TEST_PROFILE})
@@ -36,6 +39,8 @@ public class WahllokalZustandServiceSecurityTest {
 
   @Autowired ObjectMapper objectMapper;
 
+  @MockitoBean BezirkIDPermissionEvaluator bezirkIDPermissionEvaluator;
+
   @BeforeEach
   void setup() {
     clearContext();
@@ -46,6 +51,9 @@ public class WahllokalZustandServiceSecurityTest {
 
     @Test
     void should_grantAccessAndThrowNoException_when_authoritiesAreValid() throws Exception {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(Authorities.SERVICE_POST_LASTSEEN);
       String wahlbezirkID = "wahlbezirkID01";
 
@@ -67,6 +75,9 @@ public class WahllokalZustandServiceSecurityTest {
 
     @Test
     void should_failWithAccessDeniedException_when_serviceAuthorityIsMissing() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(Authorities.SERVICE_POST_LAST_LOGOUT);
       String wahlbezirkID = "wahlbezirkID01";
 
@@ -77,6 +88,20 @@ public class WahllokalZustandServiceSecurityTest {
       Assertions.assertThatThrownBy(() -> wahllokalZustandService.postLastSeen(wahlbezirkID))
           .isInstanceOf(AccessDeniedException.class);
     }
+
+    @Test
+    void should_throwException_when_givenAllAuthoritiesButWahlbezirkIDDoesNotMatch() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(false);
+      SecurityUtils.runWith(Authorities.SERVICE_POST_LASTSEEN);
+
+      val wahlbezirkID = "wahlbezirkID";
+
+      Assertions.assertThatExceptionOfType(AccessDeniedException.class)
+          .isThrownBy(() -> wahllokalZustandService.postLastSeen(wahlbezirkID))
+          .withMessageStartingWith("Access Denied");
+    }
   }
 
   @Nested
@@ -84,6 +109,9 @@ public class WahllokalZustandServiceSecurityTest {
 
     @Test
     void should_grantAccessAndThrowNoException_when_authoritiesAreValid() throws Exception {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(Authorities.SERVICE_POST_LAST_LOGOUT);
       String wahlbezirkID = "wahlbezirkID01";
 
@@ -105,6 +133,9 @@ public class WahllokalZustandServiceSecurityTest {
 
     @Test
     void should_failWithAccessDeniedException_when_serviceAuthorityIsMissing() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(Authorities.SERVICE_POST_LASTSEEN);
       String wahlbezirkID = "wahlbezirkID01";
 
@@ -115,6 +146,20 @@ public class WahllokalZustandServiceSecurityTest {
       Assertions.assertThatThrownBy(() -> wahllokalZustandService.postLetzteAbmeldung(wahlbezirkID))
           .isInstanceOf(AccessDeniedException.class);
     }
+
+    @Test
+    void should_throwException_when_givenAllAuthoritiesButWahlbezirkIDDoesNotMatch() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(false);
+      SecurityUtils.runWith(Authorities.SERVICE_POST_LAST_LOGOUT);
+
+      val wahlbezirkID = "wahlbezirkID";
+
+      Assertions.assertThatExceptionOfType(AccessDeniedException.class)
+          .isThrownBy(() -> wahllokalZustandService.postLetzteAbmeldung(wahlbezirkID))
+          .withMessageStartingWith("Access Denied");
+    }
   }
 
   @Nested
@@ -122,6 +167,9 @@ public class WahllokalZustandServiceSecurityTest {
 
     @Test
     void should_grantAccessAndThrowNoException_when_authoritiesAreValid() throws Exception {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(Authorities.SERVICE_POST_SCHNELLMELDUNG_SENDUNGSUHRZEIT);
 
       val wahlID = "wahlID";
@@ -151,6 +199,9 @@ public class WahllokalZustandServiceSecurityTest {
 
     @Test
     void should_failWithAccessDeniedException_when_serviceAuthorityIsMissing() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(Authorities.SERVICE_POST_LASTSEEN);
       val wahlID = "wahlID";
       val wahlbezirkID = "wahlbezirkID";
@@ -168,6 +219,24 @@ public class WahllokalZustandServiceSecurityTest {
                       new BezirkUndWahlID(wahlID, wahlbezirkID), LocalDateTime.now()))
           .isInstanceOf(AccessDeniedException.class);
     }
+
+    @Test
+    void should_throwException_when_givenAllAuthoritiesButWahlbezirkIDDoesNotMatch() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(false);
+      SecurityUtils.runWith(Authorities.SERVICE_POST_SCHNELLMELDUNG_SENDUNGSUHRZEIT);
+
+      val wahlID = "wahlID";
+      val wahlbezirkID = "wahlbezirkID";
+
+      Assertions.assertThatExceptionOfType(AccessDeniedException.class)
+          .isThrownBy(
+              () ->
+                  wahllokalZustandService.postSchnellmeldungSendungsuhrzeit(
+                      new BezirkUndWahlID(wahlID, wahlbezirkID), LocalDateTime.now()))
+          .withMessageStartingWith("Access Denied");
+    }
   }
 
   @Nested
@@ -175,6 +244,9 @@ public class WahllokalZustandServiceSecurityTest {
 
     @Test
     void should_grantAccessAndThrowNoException_when_authoritiesAreValid() throws Exception {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(Authorities.SERVICE_POST_SCHNELLMELDUNG_DRUCKUHRZEIT);
 
       val wahlID = "wahlID";
@@ -204,6 +276,9 @@ public class WahllokalZustandServiceSecurityTest {
 
     @Test
     void should_failWithAccessDeniedException_when_serviceAuthorityIsMissing() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(Authorities.SERVICE_POST_LASTSEEN);
       val wahlID = "wahlID";
       val wahlbezirkID = "wahlbezirkID";
@@ -221,6 +296,24 @@ public class WahllokalZustandServiceSecurityTest {
                       new BezirkUndWahlID(wahlID, wahlbezirkID), LocalDateTime.now()))
           .isInstanceOf(AccessDeniedException.class);
     }
+
+    @Test
+    void should_throwException_when_givenAllAuthoritiesButWahlbezirkIDDoesNotMatch() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(false);
+      SecurityUtils.runWith(Authorities.SERVICE_POST_SCHNELLMELDUNG_DRUCKUHRZEIT);
+
+      val wahlID = "wahlID";
+      val wahlbezirkID = "wahlbezirkID";
+
+      Assertions.assertThatExceptionOfType(AccessDeniedException.class)
+          .isThrownBy(
+              () ->
+                  wahllokalZustandService.postSchnellmeldungDruckuhrzeit(
+                      new BezirkUndWahlID(wahlID, wahlbezirkID), LocalDateTime.now()))
+          .withMessageStartingWith("Access Denied");
+    }
   }
 
   @Nested
@@ -228,6 +321,9 @@ public class WahllokalZustandServiceSecurityTest {
 
     @Test
     void should_grantAccessAndThrowNoException_when_authoritiesAreValid() throws Exception {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(Authorities.SERVICE_POST_NIEDERSCHRIFT_SENDUNGSUHRZEIT);
 
       val wahlID = "wahlID";
@@ -265,6 +361,9 @@ public class WahllokalZustandServiceSecurityTest {
 
     @Test
     void should_failWithAccessDeniedException_when_serviceAuthorityIsMissing() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(Authorities.SERVICE_POST_LASTSEEN);
 
       val wahlID = "wahlID";
@@ -283,6 +382,24 @@ public class WahllokalZustandServiceSecurityTest {
                       new BezirkUndWahlID(wahlID, wahlbezirkID), LocalDateTime.now()))
           .isInstanceOf(AccessDeniedException.class);
     }
+
+    @Test
+    void should_throwException_when_givenAllAuthoritiesButWahlbezirkIDDoesNotMatch() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(false);
+      SecurityUtils.runWith(Authorities.SERVICE_POST_NIEDERSCHRIFT_SENDUNGSUHRZEIT);
+
+      val wahlID = "wahlID";
+      val wahlbezirkID = "wahlbezirkID";
+
+      Assertions.assertThatExceptionOfType(AccessDeniedException.class)
+          .isThrownBy(
+              () ->
+                  wahllokalZustandService.postNiederschriftSendungsuhrzeit(
+                      new BezirkUndWahlID(wahlID, wahlbezirkID), LocalDateTime.now()))
+          .withMessageStartingWith("Access Denied");
+    }
   }
 
   @Nested
@@ -290,6 +407,9 @@ public class WahllokalZustandServiceSecurityTest {
 
     @Test
     void should_grantAccessAndThrowNoException_when_authoritiesAreValid() throws Exception {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(Authorities.SERVICE_POST_NIEDERSCHRIFT_DRUCKUHRZEIT);
 
       val wahlID = "wahlID";
@@ -319,6 +439,9 @@ public class WahllokalZustandServiceSecurityTest {
 
     @Test
     void should_failWithAccessDeniedException_when_serviceAuthorityIsMissing() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(true);
       SecurityUtils.runWith(Authorities.SERVICE_POST_LASTSEEN);
 
       val wahlID = "wahlID";
@@ -333,9 +456,27 @@ public class WahllokalZustandServiceSecurityTest {
 
       Assertions.assertThatThrownBy(
               () ->
-                  wahllokalZustandService.postSchnellmeldungDruckuhrzeit(
+                  wahllokalZustandService.postNiederschriftDruckuhrzeit(
                       new BezirkUndWahlID(wahlID, wahlbezirkID), LocalDateTime.now()))
           .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void should_throwException_when_givenAllAuthoritiesButWahlbezirkIDDoesNotMatch() {
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(Mockito.any(), Mockito.any()))
+          .thenReturn(false);
+      SecurityUtils.runWith(Authorities.SERVICE_POST_NIEDERSCHRIFT_DRUCKUHRZEIT);
+
+      val wahlID = "wahlID";
+      val wahlbezirkID = "wahlbezirkID";
+
+      Assertions.assertThatExceptionOfType(AccessDeniedException.class)
+          .isThrownBy(
+              () ->
+                  wahllokalZustandService.postNiederschriftDruckuhrzeit(
+                      new BezirkUndWahlID(wahlID, wahlbezirkID), LocalDateTime.now()))
+          .withMessageStartingWith("Access Denied");
     }
   }
 }


### PR DESCRIPTION
# Beschreibung:

- für alle Service-Methoden mit der WahlbezirkID als Parameter den entsprechenden Check ergänzt
- Tests erweitert und ergänzt

## Definition of Done (DoD):

### Backend ###
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [ ] ~~Doku aktualisiert~~
- [ ] ~~Swagger-API vollständig~~
- [x] Unit-Tests gepflegt
- [x] Integrationstests gepflegt
- [ ] ~~Beispiel-Requests gepflegt~~
- [x] Texte auf Rechtschreibung und Grammatik geprüft

# Referenzen[^1]:

Closes #2056

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened authorization validation to enforce district-level permission checks, ensuring users can only access and modify data for their authorized districts across all monitoring endpoints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/it-at-m/Wahllokalsystem/pull/2729)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->