### PR TITLE
Releases sprint 43

### DIFF
--- a/wls-admin-service/pom.xml
+++ b/wls-admin-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-admin-service</artifactId>
-    <version>0.4.15-SNAPSHOT</version>
+    <version>0.4.15</version>
     <name>wls_admin_service</name>
 
     <properties>
@@ -313,7 +313,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-admin-service/0.4.15</tag>
     </scm>
 
 

--- a/wls-admin-service/pom.xml
+++ b/wls-admin-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-admin-service</artifactId>
-    <version>0.4.15</version>
+    <version>0.4.16-SNAPSHOT</version>
     <name>wls_admin_service</name>
 
     <properties>
@@ -313,7 +313,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-admin-service/0.4.15</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-api-gateway/pom.xml
+++ b/wls-api-gateway/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-api-gateway</artifactId>
-    <version>0.1.8-SNAPSHOT</version>
+    <version>0.1.8</version>
 
     <name>wls_api_gateway</name>
     <description>api gateway for wahllokalsystem</description>
@@ -27,7 +27,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-api-gateway/0.1.8</tag>
     </scm>
 
     <properties>

--- a/wls-api-gateway/pom.xml
+++ b/wls-api-gateway/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-api-gateway</artifactId>
-    <version>0.1.8</version>
+    <version>0.1.9-SNAPSHOT</version>
 
     <name>wls_api_gateway</name>
     <description>api gateway for wahllokalsystem</description>
@@ -27,7 +27,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-api-gateway/0.1.8</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/wls-auth-service/pom.xml
+++ b/wls-auth-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-auth-service</artifactId>
-    <version>0.7.11-SNAPSHOT</version>
+    <version>0.7.11</version>
     <name>wls_auth_service</name>
 
     <properties>
@@ -327,7 +327,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-auth-service/0.7.11</tag>
     </scm>
 
 

--- a/wls-auth-service/pom.xml
+++ b/wls-auth-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-auth-service</artifactId>
-    <version>0.7.11</version>
+    <version>0.7.12-SNAPSHOT</version>
     <name>wls_auth_service</name>
 
     <properties>
@@ -327,7 +327,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-auth-service/0.7.11</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-basisdaten-service/pom.xml
+++ b/wls-basisdaten-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-basisdaten-service</artifactId>
-    <version>0.5.14-SNAPSHOT</version>
+    <version>0.5.14</version>
     <name>wls_basisdaten_service</name>
 
     <properties>
@@ -305,7 +305,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-basisdaten-service/0.5.14</tag>
     </scm>
 
 

--- a/wls-basisdaten-service/pom.xml
+++ b/wls-basisdaten-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-basisdaten-service</artifactId>
-    <version>0.5.14</version>
+    <version>0.5.15-SNAPSHOT</version>
     <name>wls_basisdaten_service</name>
 
     <properties>
@@ -305,7 +305,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-basisdaten-service/0.5.14</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-briefwahl-service/pom.xml
+++ b/wls-briefwahl-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-briefwahl-service</artifactId>
-    <version>0.3.14</version>
+    <version>0.3.15-SNAPSHOT</version>
     <name>wls_briefwahl_service</name>
 
 
@@ -292,7 +292,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-briefwahl-service/0.3.14</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-briefwahl-service/pom.xml
+++ b/wls-briefwahl-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-briefwahl-service</artifactId>
-    <version>0.3.14-SNAPSHOT</version>
+    <version>0.3.14</version>
     <name>wls_briefwahl_service</name>
 
 
@@ -292,7 +292,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-briefwahl-service/0.3.14</tag>
     </scm>
 
 

--- a/wls-broadcast-service/pom.xml
+++ b/wls-broadcast-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-broadcast-service</artifactId>
-    <version>0.4.14</version>
+    <version>0.4.15-SNAPSHOT</version>
     <name>wls_broadcast_service</name>
 
     <properties>
@@ -300,7 +300,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-broadcast-service/0.4.14</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <build>

--- a/wls-broadcast-service/pom.xml
+++ b/wls-broadcast-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-broadcast-service</artifactId>
-    <version>0.4.14-SNAPSHOT</version>
+    <version>0.4.14</version>
     <name>wls_broadcast_service</name>
 
     <properties>
@@ -300,7 +300,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-broadcast-service/0.4.14</tag>
     </scm>
 
     <build>

--- a/wls-eai-service/pom.xml
+++ b/wls-eai-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-eai-service</artifactId>
-    <version>0.8.15</version>
+    <version>0.8.16-SNAPSHOT</version>
     <name>wls_eai_service</name>
 
     <properties>
@@ -291,7 +291,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-eai-service/0.8.15</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-eai-service/pom.xml
+++ b/wls-eai-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-eai-service</artifactId>
-    <version>0.8.15-SNAPSHOT</version>
+    <version>0.8.15</version>
     <name>wls_eai_service</name>
 
     <properties>
@@ -291,7 +291,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-eai-service/0.8.15</tag>
     </scm>
 
 

--- a/wls-ergebnismeldung-service/pom.xml
+++ b/wls-ergebnismeldung-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-ergebnismeldung-service</artifactId>
-    <version>0.6.1</version>
+    <version>0.6.2-SNAPSHOT</version>
     <name>wls_ergebnismeldung_service</name>
 
     <properties>
@@ -308,7 +308,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-ergebnismeldung-service/0.6.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-ergebnismeldung-service/pom.xml
+++ b/wls-ergebnismeldung-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-ergebnismeldung-service</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.6.1</version>
     <name>wls_ergebnismeldung_service</name>
 
     <properties>
@@ -308,7 +308,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-ergebnismeldung-service/0.6.1</tag>
     </scm>
 
 

--- a/wls-infomanagement-service/pom.xml
+++ b/wls-infomanagement-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-infomanagement-service</artifactId>
-    <version>0.5.2</version>
+    <version>0.5.3-SNAPSHOT</version>
     <name>wls_infomanagement_service</name>
 
 
@@ -296,7 +296,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-infomanagement-service/0.5.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-infomanagement-service/pom.xml
+++ b/wls-infomanagement-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-infomanagement-service</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.5.2</version>
     <name>wls_infomanagement_service</name>
 
 
@@ -296,7 +296,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-infomanagement-service/0.5.2</tag>
     </scm>
 
 

--- a/wls-monitoring-service/pom.xml
+++ b/wls-monitoring-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-monitoring-service</artifactId>
-    <version>0.3.16-SNAPSHOT</version>
+    <version>0.3.16</version>
     <name>wls_monitoring_service</name>
 
     <properties>
@@ -306,7 +306,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-monitoring-service/0.3.16</tag>
     </scm>
 
 

--- a/wls-monitoring-service/pom.xml
+++ b/wls-monitoring-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-monitoring-service</artifactId>
-    <version>0.3.16</version>
+    <version>0.3.17-SNAPSHOT</version>
     <name>wls_monitoring_service</name>
 
     <properties>
@@ -306,7 +306,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-monitoring-service/0.3.16</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-vorfaelleundvorkommnisse-service/pom.xml
+++ b/wls-vorfaelleundvorkommnisse-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-vorfaelleundvorkommnisse-service</artifactId>
-    <version>0.5.13-SNAPSHOT</version>
+    <version>0.5.13</version>
     <name>wls_vorfaelleundvorkommnisse_service</name>
 
     <properties>
@@ -296,7 +296,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-vorfaelleundvorkommnisse-service/0.5.13</tag>
     </scm>
 
     <build>

--- a/wls-vorfaelleundvorkommnisse-service/pom.xml
+++ b/wls-vorfaelleundvorkommnisse-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-vorfaelleundvorkommnisse-service</artifactId>
-    <version>0.5.13</version>
+    <version>0.5.14-SNAPSHOT</version>
     <name>wls_vorfaelleundvorkommnisse_service</name>
 
     <properties>
@@ -296,7 +296,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-vorfaelleundvorkommnisse-service/0.5.13</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <build>

--- a/wls-wahlvorbereitung-service/pom.xml
+++ b/wls-wahlvorbereitung-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-wahlvorbereitung-service</artifactId>
-    <version>0.4.15-SNAPSHOT</version>
+    <version>0.4.15</version>
     <name>wls_wahlvorbereitung_service</name>
 
 
@@ -292,7 +292,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-wahlvorbereitung-service/0.4.15</tag>
     </scm>
 
 

--- a/wls-wahlvorbereitung-service/pom.xml
+++ b/wls-wahlvorbereitung-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-wahlvorbereitung-service</artifactId>
-    <version>0.4.15</version>
+    <version>0.4.16-SNAPSHOT</version>
     <name>wls_wahlvorbereitung_service</name>
 
 
@@ -292,7 +292,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-wahlvorbereitung-service/0.4.15</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-wahlvorstand-service/pom.xml
+++ b/wls-wahlvorstand-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-wahlvorstand-service</artifactId>
-    <version>0.5.16</version>
+    <version>0.5.17-SNAPSHOT</version>
     <name>wls_wahlvorstand_service</name>
 
     <properties>
@@ -307,7 +307,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-wahlvorstand-service/0.5.16</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-wahlvorstand-service/pom.xml
+++ b/wls-wahlvorstand-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-wahlvorstand-service</artifactId>
-    <version>0.5.16-SNAPSHOT</version>
+    <version>0.5.16</version>
     <name>wls_wahlvorstand_service</name>
 
     <properties>
@@ -307,7 +307,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-wahlvorstand-service/0.5.16</tag>
     </scm>
 
 


### PR DESCRIPTION
# Beschreibung:

Releases der Backendservice für den Sprint 43 erstellt.

## Admin-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-admin-service%2F0.4.15)
- [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-admin-service/955540960?tag=0.4.15)


## Auth-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-auth-service%2F0.7.11)
- [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-auth-service/955551086?tag=0.7.11)


## Basisdaten-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-basisdaten-service%2F0.5.14)
- [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-basisdaten-service/955563563?tag=0.5.14)


## Briefwahl-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-briefwahl-service%2F0.3.14)
- [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-briefwahl-service/955592086?tag=0.3.14)


## Broadcast-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-broadcast-service%2F0.4.14)
- [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-broadcast-service/955604049?tag=0.4.14)


## EAI-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-eai-service%2F0.8.15)
- [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-eai-service/955613515?tag=0.8.15)


## Ergebnismeldung-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-ergebnismeldung-service%2F0.6.1)
- [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-ergebnismeldung-service/955785066?tag=0.6.1)


## Infomanagment-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-infomanagement-service%2F0.5.2)
- [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-infomanagement-service/955624535?tag=0.5.2)


## Monitoring-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-monitoring-service%2F0.3.16)
- [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-monitoring-service/955634777?tag=0.3.16)


## Vorfaelle-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-vorfaelleundvorkommnisse-service%2F0.5.13)
- [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-vorfaelleundvorkommnisse-service/955655498?tag=0.5.13)

## Wahlvorbereitung-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-wahlvorbereitung-service%2F0.4.15)
- [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-wahlvorbereitung-service/955766134?tag=0.4.15)


## Wahlvorstand-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-wahlvorstand-service%2F0.5.16)
- [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-wahlvorstand-service/955806759?tag=0.5.16)


## API-Gateway-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-api-gateway%2F0.1.8)
- [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-api-gateway/955528777?tag=0.1.8)


## GUI-Wls 

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-gui-wahllokalsystem%2F0.20.0)
- [Image-Tag](https://github.com/it-at-m/Wahllokalsystem/pkgs/container/wahllokalsystem-wls-gui-wahllokalsystem/955837210?tag=0.20.0)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version numbers across multiple services as part of routine development maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->