### PR TITLE
#2961 - Syntax gefixt für Tests

### DIFF
--- a/wls-gui-admintool/tests/composables/wahltermindaten/wahltermindatenService.spec.ts
+++ b/wls-gui-admintool/tests/composables/wahltermindaten/wahltermindatenService.spec.ts
@@ -62,7 +62,7 @@ describe("wahltermindatenService.ts", () => {
         );
 
         await expect(
-          async () => await unitUnderTest.importWahlterminDaten(wahltagID)
+          unitUnderTest.importWahlterminDaten(wahltagID)
         ).rejects.toThrow();
 
         expect(mockDefinitions.addNotification.mock.calls[0]).toEqual([
@@ -104,7 +104,7 @@ describe("wahltermindatenService.ts", () => {
         );
 
         await expect(
-          async () => await unitUnderTest.importWahlterminDaten(wahltagID)
+          unitUnderTest.importWahlterminDaten(wahltagID)
         ).rejects.toThrow();
 
         expect(spyOnValueSetterOfRef.mock.calls).toStrictEqual([
@@ -140,8 +140,7 @@ describe("wahltermindatenService.ts", () => {
         );
 
         await expect(
-          async () =>
-            await unitUnderTest.deleteAndImportWahlterminDaten(wahltagID)
+          unitUnderTest.deleteAndImportWahlterminDaten(wahltagID)
         ).rejects.toThrow();
 
         expect(mockDefinitions.addNotification.mock.calls[0]).toEqual([
@@ -160,8 +159,7 @@ describe("wahltermindatenService.ts", () => {
         );
 
         await expect(
-          async () =>
-            await unitUnderTest.deleteAndImportWahlterminDaten(wahltagID)
+          unitUnderTest.deleteAndImportWahlterminDaten(wahltagID)
         ).rejects.toThrow();
 
         expect(mockDefinitions.addNotification.mock.calls[0]).toEqual([

--- a/wls-gui-wahllokalsystem/tests/composables/ergebnismeldung/MBW/mbwUtils.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/ergebnismeldung/MBW/mbwUtils.spec.ts
@@ -336,8 +336,8 @@ describe("mbwUtils", () => {
         new Error("service call failed")
       );
 
-      expect(
-        unitUnderTest.saveGueltigeErgebnisse(mockedErgebnisseWithWahlvorschlag)
+      await expect(
+          unitUnderTest.saveGueltigeErgebnisse(mockedErgebnisseWithWahlvorschlag)
       ).rejects.toThrow();
     });
   });
@@ -470,9 +470,8 @@ describe("mbwUtils", () => {
         new Error("service call failed")
       );
 
-      expect(
-        async () =>
-          await unitUnderTest.loadAndCombineErgebnisseAndWahlvorschlaege()
+      await expect(
+          unitUnderTest.loadAndCombineErgebnisseAndWahlvorschlaege()
       ).rejects.toThrow();
     });
 

--- a/wls-gui-wahllokalsystem/tests/composables/ergebnismeldung/MBW/mbwUtils.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/ergebnismeldung/MBW/mbwUtils.spec.ts
@@ -337,7 +337,7 @@ describe("mbwUtils", () => {
       );
 
       await expect(
-          unitUnderTest.saveGueltigeErgebnisse(mockedErgebnisseWithWahlvorschlag)
+        unitUnderTest.saveGueltigeErgebnisse(mockedErgebnisseWithWahlvorschlag)
       ).rejects.toThrow();
     });
   });
@@ -471,7 +471,7 @@ describe("mbwUtils", () => {
       );
 
       await expect(
-          unitUnderTest.loadAndCombineErgebnisseAndWahlvorschlaege()
+        unitUnderTest.loadAndCombineErgebnisseAndWahlvorschlaege()
       ).rejects.toThrow();
     });
 

--- a/wls-gui-wahllokalsystem/tests/stores/ergebnismeldungStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/ergebnismeldungStore.spec.ts
@@ -315,8 +315,8 @@ describe("ergebnismeldungStore.ts", () => {
         new Error("service call failed")
       );
 
-      expect(
-        unitUnderTest.loadErgebnisseByStapelArt(wahlID, stapelArt)
+      await expect(
+          unitUnderTest.loadErgebnisseByStapelArt(wahlID, stapelArt)
       ).rejects.toThrow();
     });
   });
@@ -440,7 +440,7 @@ describe("ergebnismeldungStore.ts", () => {
         new Error("service call failed")
       );
 
-      expect(
+      await expect(
         unitUnderTest.sendErgebnisseByStapelArt(wahlID, stapelArt)
       ).rejects.toThrow();
     });
@@ -718,7 +718,7 @@ describe("ergebnismeldungStore.ts", () => {
         new Error("service call failed")
       );
 
-      expect(unitUnderTest.loadBegruendungForWahl(wahl)).rejects.toThrow();
+      await expect(unitUnderTest.loadBegruendungForWahl(wahl)).rejects.toThrow();
     });
   });
 

--- a/wls-gui-wahllokalsystem/tests/stores/ergebnismeldungStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/ergebnismeldungStore.spec.ts
@@ -316,7 +316,7 @@ describe("ergebnismeldungStore.ts", () => {
       );
 
       await expect(
-          unitUnderTest.loadErgebnisseByStapelArt(wahlID, stapelArt)
+        unitUnderTest.loadErgebnisseByStapelArt(wahlID, stapelArt)
       ).rejects.toThrow();
     });
   });
@@ -718,7 +718,9 @@ describe("ergebnismeldungStore.ts", () => {
         new Error("service call failed")
       );
 
-      await expect(unitUnderTest.loadBegruendungForWahl(wahl)).rejects.toThrow();
+      await expect(
+        unitUnderTest.loadBegruendungForWahl(wahl)
+      ).rejects.toThrow();
     });
   });
 

--- a/wls-gui-wahllokalsystem/tests/stores/kopfdatenStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/kopfdatenStore.spec.ts
@@ -70,9 +70,7 @@ describe("kopfdatenStore.ts", () => {
         new Error("service call failed")
       );
 
-      await expect(
-        async () => await unitUnderTest.initKopfdaten()
-      ).rejects.toThrow();
+      await expect(unitUnderTest.initKopfdaten()).rejects.toThrow();
     });
   });
 });

--- a/wls-gui-wahllokalsystem/tests/stores/wahlvorschlaegeStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/wahlvorschlaegeStore.spec.ts
@@ -204,10 +204,7 @@ describe("wahlvorschlaegeStore.ts", () => {
         new Error("service call failed")
       );
 
-      await expect(
-        async () =>
-          await unitUnderTest.loadWahlvorschlaege(wahlID, wahlbezirkID)
-      ).rejects.toThrow();
+      await expect(unitUnderTest.loadWahlvorschlaege(wahlID, wahlbezirkID)).rejects.toThrow();
     });
 
     it("should_returnWahlvorschlaegeSortedByOrdnungszahl_when_loaded", async () => {

--- a/wls-gui-wahllokalsystem/tests/stores/wahlvorschlaegeStore.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/stores/wahlvorschlaegeStore.spec.ts
@@ -204,7 +204,9 @@ describe("wahlvorschlaegeStore.ts", () => {
         new Error("service call failed")
       );
 
-      await expect(unitUnderTest.loadWahlvorschlaege(wahlID, wahlbezirkID)).rejects.toThrow();
+      await expect(
+        unitUnderTest.loadWahlvorschlaege(wahlID, wahlbezirkID)
+      ).rejects.toThrow();
     });
 
     it("should_returnWahlvorschlaegeSortedByOrdnungszahl_when_loaded", async () => {


### PR DESCRIPTION
# Beschreibung:
expect(actual).rejects.toThrow() wird nicht mehr automatisch awaited, sondern await muss manuell erfolgen. 
Tests wurden entsprechend angepasst in gui-admintool und gui-wahllokalsystem.

## Definition of Done (DoD):

### Frontend
- [x] ~[Naming Conventions][naming-conventions-link] beachtet~
- [x] ~Doku aktualisiert~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] Unit-Tests gepflegt
- [x] ~Texte auf Rechtschreibung und Grammatik geprüft~
- [x] ~Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft~

# Referenzen[^1]:

Closes #2961

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test assertions for promise rejection handling across multiple test suites to follow improved testing patterns. No user-facing changes or feature updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->