### PR TITLE
#2975 - Hinzufügen Button für Stapel E als Secondary Button.

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/ergebnismeldung/MBW/stapelE/TheStimmzettelBeschlussfassungTable.vue
+++ b/wls-gui-wahllokalsystem/src/components/ergebnismeldung/MBW/stapelE/TheStimmzettelBeschlussfassungTable.vue
@@ -32,7 +32,6 @@
     <v-card-actions>
       <base-text-button
         prepend-icon="$add"
-        active
         @click="onAddBedenklicherStimmzettelClicked()"
         >Neuen Beschluss erfassen</base-text-button
       >


### PR DESCRIPTION
# Beschreibung:

Button zum Hinzufügen eines neuen Beschlusses als Secondary Button.

## Definition of Done (DoD):
<!-- Frontend -->
### Frontend
- [x] ~[Naming Conventions][naming-conventions-link] beachtet~
- [x] ~Doku aktualisiert~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] ~Unit-Tests gepflegt~
- [x] ~Texte auf Rechtschreibung und Grammatik geprüft~
- [x] ~Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft~

# Referenzen[^1]:


Closes #2975

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the button for adding a new “bedenklicher Stimmzettel” so it no longer shows an incorrect active state, improving the consistency of the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->