### PR TITLE
#971 - Autocomplete für konfigurierten Wahltag: aktiven Wahltag kennzeichnen

### DIFF
--- a/wls-gui-admintool/src/components/common/BaseAutocompleteWahltag.vue
+++ b/wls-gui-admintool/src/components/common/BaseAutocompleteWahltag.vue
@@ -8,7 +8,39 @@
     return-object
     data-test="autocompleteWahltage"
     no-data-text="Keine Wahltage gefunden"
-  />
+  >
+    <template #item="{ props: itemProps, item }">
+      <v-list-item
+        v-bind="itemProps"
+        :title="item.title"
+      >
+        <template
+          v-if="item.raw.aktiv"
+          #append
+        >
+          <v-chip
+            color="success"
+            size="small"
+            data-test="aktivKennzeichen"
+          >
+            aktiv
+          </v-chip>
+        </template>
+      </v-list-item>
+    </template>
+    <template #selection="{ item }">
+      <span class="v-autocomplete__selection-text">{{ item.title }}</span>
+      <v-chip
+        v-if="item.raw.aktiv"
+        class="ml-2"
+        color="success"
+        size="small"
+        data-test="aktivKennzeichen"
+      >
+        aktiv
+      </v-chip>
+    </template>
+  </v-autocomplete>
 </template>
 
 <script setup lang="ts">
@@ -16,7 +48,7 @@ import type { Wahltag } from "@/types/wahltag/Wahltag.ts";
 import type { PropType } from "vue";
 
 import { useDate } from "vuetify";
-import { VAutocomplete } from "vuetify/components";
+import { VAutocomplete, VChip, VListItem } from "vuetify/components";
 
 const date = useDate();
 

--- a/wls-gui-admintool/src/types/wahltag/Wahltag.ts
+++ b/wls-gui-admintool/src/types/wahltag/Wahltag.ts
@@ -3,4 +3,9 @@ import type { WahltagEvent } from "@/types/wahltag/WahltagEvent.ts";
 export interface Wahltag {
   wahltag: Date;
   events: WahltagEvent[];
+  /**
+   * Kennzeichnet, ob es sich um den aktuell aktiven (konfigurierten) Wahltag
+   * handelt. Wird von der einbindenden View befüllt.
+   */
+  aktiv?: boolean;
 }

--- a/wls-gui-admintool/stories/components/common/BaseAutocompleteWahltag.stories.ts
+++ b/wls-gui-admintool/stories/components/common/BaseAutocompleteWahltag.stories.ts
@@ -120,6 +120,18 @@ export const PreSelect: Story = {
   },
 };
 
+/**
+ * Ein Wahltag ist als aktiv gekennzeichnet und dadurch erkennbar.
+ */
+export const ActiveWahltag: Story = {
+  args: {
+    ...Default.args,
+    items: wahltage.map((wahltag, index) =>
+      index === 2 ? { ...wahltag, aktiv: true } : wahltag
+    ),
+  },
+};
+
 export const NoData: Story = {
   args: {
     ...Default.args,

--- a/wls-gui-admintool/tests/components/common/BaseAutocompleteWahltag.spec.ts
+++ b/wls-gui-admintool/tests/components/common/BaseAutocompleteWahltag.spec.ts
@@ -44,6 +44,7 @@ const wahltage: Wahltag[] = [
         nummer: "3.1",
       },
     ],
+    aktiv: true,
   },
 ];
 
@@ -76,6 +77,18 @@ describe("BaseAutocompleteWahltag.vue", () => {
       const tag = wahltage[0];
       await wrapper.setProps({ modelValue: tag });
 
+      await expect(wrapper.html()).toMatchFileSnapshot(
+        getSnapshotFilename(context)
+      );
+    });
+
+    it("should_renderAktivKennzeichen_when_activeWahltagIsSelected", async (context) => {
+      const aktiverWahltag = wahltage[2];
+      await wrapper.setProps({ modelValue: aktiverWahltag });
+
+      expect(wrapper.find("[data-test='aktivKennzeichen']").exists()).toBe(
+        true
+      );
       await expect(wrapper.html()).toMatchFileSnapshot(
         getSnapshotFilename(context)
       );

--- a/wls-gui-admintool/tests/components/common/__snapshots__/BaseAutocompleteWahltag.vue/visual logic/should_renderAktivKennzeichen_when_activeWahltagIsSelected.html
+++ b/wls-gui-admintool/tests/components/common/__snapshots__/BaseAutocompleteWahltag.vue/visual logic/should_renderAktivKennzeichen_when_activeWahltagIsSelected.html
@@ -26,8 +26,12 @@
         <div class="v-field__input" data-no-activator="">
           <!---->
           <!---->
-          <div class="v-autocomplete__selection"><span class="v-autocomplete__selection-text">24. Dez. 2025</span>
-            <!--v-if-->
+          <div class="v-autocomplete__selection"><span class="v-autocomplete__selection-text">20. März 2025</span><span class="v-chip v-theme--light text-success v-chip--density-default v-chip--size-small v-chip--variant-tonal ml-2" draggable="false" data-test="aktivKennzeichen"><!----><span class="v-chip__underlay"></span>
+            <!---->
+            <!---->
+            <div class="v-chip__content" data-no-activator=""> aktiv </div>
+            <!---->
+            <!----></span>
           </div><input size="1" role="combobox" type="text" aria-labelledby="input-v-2-label" id="input-v-2" aria-describedby="input-v-2-messages" aria-expanded="false" aria-controls="menu-v-0" value="">
         </div>
         <!---->

--- a/wls-gui-admintool/tests/components/common/__snapshots__/BaseAutocompleteWahltag.vue/visual logic/should_renderAutocompleteWithCorrectLabel_when_componentIsMounted.html
+++ b/wls-gui-admintool/tests/components/common/__snapshots__/BaseAutocompleteWahltag.vue/visual logic/should_renderAutocompleteWithCorrectLabel_when_componentIsMounted.html
@@ -1,4 +1,4 @@
-<div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-text-field v-autocomplete v-autocomplete--single" data-test="autocompleteWahltage">
+<div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-text-field v-autocomplete v-autocomplete--single v-autocomplete--selection-slot" data-test="autocompleteWahltage">
   <!---->
   <div class="v-input__control">
     <div class="v-field v-field--appended v-field--center-affix v-field--variant-outlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-0" aria-owns="menu-v-0">


### PR DESCRIPTION
# Beschreibung:

Setzt die Referenzstory aus Issue #971 um: Die Basis-Komponente `BaseAutocompleteWahltag` zeigt Wahltage (Datum) zur Auswahl an, liefert das **gesamte Wahltag-Objekt** als Model und macht den **aktiven (konfigurierten) Wahltag** sichtbar erkennbar.

- Wahltag-Typ um optionales Feld `aktiv` ergänzt (von einbindender View befüllt)
- `BaseAutocompleteWahltag`: aktiver Wahltag im Item- und Selection-Slot per „aktiv"-Chip erkennbar (kein Service/Mapper/Store)
- Story `ActiveWahltag` für markierten Wahltag ergänzt
- Snapshot-Test für aktiven Wahltag ergänzt, bestehende Snapshots aktualisiert

**Hinweise zum Review:** Reine props/events-Komponente – die Basiskomponente liest bewusst keinen Store. Die Datenbeschaffung inkl. Setzen von `aktiv` bleibt Aufgabe der einbindenden View/SingleUse-Komponente (gemäß Begründung der Referenzstory).

## Definition of Done (DoD):

### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet — Property `aktiv` (camelCase), `data-test="aktivKennzeichen"` (analog zum bestehenden `autocompleteWahltage`), Test `should_renderAktivKennzeichen_when_activeWahltagIsSelected` folgt dem Schema `should_<result>_when_<input>`
- [x] Doku aktualisiert — Komponenten-Doku erfolgt über Storybook; Story `ActiveWahltag` ergänzt. Keine Anpassung der [Fachlichen Beschreibung][fachliche-beschreibung-link] oder [UI/UX-ADRs][ui-ux-adrs-link] nötig (Basiskomponente, keine neue fachliche/UI-Entscheidung)
- [x] Unit-Tests gepflegt — neuer Snapshot-Test + bestehender Event-Test grün, bestehende Snapshots aktualisiert (`npm run test`: 90/90)
- [x] Texte auf Rechtschreibung und Grammatik geprüft — Chip-Text „aktiv", Typ-Kommentar und Story-Beschreibung geprüft
- [x] Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft — keine personenbezogenen/geschlechtsspezifischen Begriffe eingeführt (lediglich Fachbegriff „Wahltag" und Status „aktiv")

# Referenzen:

Closes #971

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible “aktiv” indicator chip for active Wahltag entries in the dropdown and in the selected value display.
  * Updated the component to recognize an active Wahltag state in its displayed data.

* **Tests**
  * Added coverage to confirm active Wahltag indicators render correctly when selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->