### PR TITLE
2973 - Hilfemenü: keine fixe Höhe, height passt sich an Items an.

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/basisdaten/TheAppSupportMenu.vue
+++ b/wls-gui-wahllokalsystem/src/components/basisdaten/TheAppSupportMenu.vue
@@ -12,9 +12,7 @@
         color="white"
       />
     </template>
-    <v-card
-      width="275"
-    >
+    <v-card width="275">
       <v-list class="pt-0 mb-2">
         <v-list-item class="list-header">
           <strong>Hilfe und Support</strong>

--- a/wls-gui-wahllokalsystem/src/components/basisdaten/TheAppSupportMenu.vue
+++ b/wls-gui-wahllokalsystem/src/components/basisdaten/TheAppSupportMenu.vue
@@ -13,7 +13,7 @@
       />
     </template>
     <v-card width="275">
-      <v-list class="pt-0>
+      <v-list class="pt-0">
         <v-list-item class="list-header">
           <strong>Hilfe und Support</strong>
         </v-list-item>

--- a/wls-gui-wahllokalsystem/src/components/basisdaten/TheAppSupportMenu.vue
+++ b/wls-gui-wahllokalsystem/src/components/basisdaten/TheAppSupportMenu.vue
@@ -14,9 +14,8 @@
     </template>
     <v-card
       width="275"
-      height="395"
     >
-      <v-list class="pt-0">
+      <v-list class="pt-0 mb-2">
         <v-list-item class="list-header">
           <strong>Hilfe und Support</strong>
         </v-list-item>

--- a/wls-gui-wahllokalsystem/src/components/basisdaten/TheAppSupportMenu.vue
+++ b/wls-gui-wahllokalsystem/src/components/basisdaten/TheAppSupportMenu.vue
@@ -13,7 +13,7 @@
       />
     </template>
     <v-card width="275">
-      <v-list class="pt-0 mb-2">
+      <v-list class="pt-0>
         <v-list-item class="list-header">
           <strong>Hilfe und Support</strong>
         </v-list-item>


### PR DESCRIPTION
# Beschreibung:

Testfeedback-Fix für Hilfemenü - diesen Space entfernen
ALT:
<img width="296" height="456" alt="c9733f38-b276-4960-8367-b6ba3ca7275a" src="https://github.com/user-attachments/assets/8fdc48c5-3474-4c06-9089-9030fc14dd24" />

Beim Menü-Dialogfenster fixe Breite entfernt und unten noch ein bisschen margin, damit sich das Menü je nach Anzahl der Items selbst korrekt vergrößert/verkleinert.

NEU:
<img width="851" height="543" alt="image" src="https://github.com/user-attachments/assets/9166e80d-9d36-4d6b-8a6a-2a740ef4642a" />
<img width="551" height="663" alt="image" src="https://github.com/user-attachments/assets/c6dcab98-2f99-49a6-b99b-a426d3bc3254" />



## Definition of Done (DoD):
<!-- Frontend -->
### Frontend
- [x] ~[Naming Conventions][naming-conventions-link] beachtet~
- [x] ~Doku aktualisiert~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] ~Unit-Tests gepflegt~
- [x] ~Texte auf Rechtschreibung und Grammatik geprüft~
- [x] ~Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft~

# Referenzen[^1]:

#2973

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the help/support dropdown’s card layout for a cleaner, more flexible display.
  * Removed a fixed height so the menu can adapt better to its content while keeping a consistent width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->