### PR TITLE
Release sprint 44 - Backend Services

### DIFF
--- a/wls-admin-service/pom.xml
+++ b/wls-admin-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-admin-service</artifactId>
-    <version>0.4.16-SNAPSHOT</version>
+    <version>0.4.16</version>
     <name>wls_admin_service</name>
 
     <properties>
@@ -313,7 +313,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-admin-service/0.4.16</tag>
     </scm>
 
 

--- a/wls-admin-service/pom.xml
+++ b/wls-admin-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-admin-service</artifactId>
-    <version>0.4.16</version>
+    <version>0.4.17-SNAPSHOT</version>
     <name>wls_admin_service</name>
 
     <properties>
@@ -313,7 +313,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-admin-service/0.4.16</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-api-gateway/pom.xml
+++ b/wls-api-gateway/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-api-gateway</artifactId>
-    <version>0.1.9-SNAPSHOT</version>
+    <version>0.1.9</version>
 
     <name>wls_api_gateway</name>
     <description>api gateway for wahllokalsystem</description>
@@ -27,7 +27,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-api-gateway/0.1.9</tag>
     </scm>
 
     <properties>

--- a/wls-api-gateway/pom.xml
+++ b/wls-api-gateway/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-api-gateway</artifactId>
-    <version>0.1.9</version>
+    <version>0.1.10-SNAPSHOT</version>
 
     <name>wls_api_gateway</name>
     <description>api gateway for wahllokalsystem</description>
@@ -27,7 +27,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-api-gateway/0.1.9</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/wls-auth-service/pom.xml
+++ b/wls-auth-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-auth-service</artifactId>
-    <version>0.7.12-SNAPSHOT</version>
+    <version>0.8.0</version>
     <name>wls_auth_service</name>
 
     <properties>
@@ -327,7 +327,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-auth-service/0.8.0</tag>
     </scm>
 
 

--- a/wls-auth-service/pom.xml
+++ b/wls-auth-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-auth-service</artifactId>
-    <version>0.8.0</version>
+    <version>0.8.1-SNAPSHOT</version>
     <name>wls_auth_service</name>
 
     <properties>
@@ -327,7 +327,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-auth-service/0.8.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-basisdaten-service/pom.xml
+++ b/wls-basisdaten-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-basisdaten-service</artifactId>
-    <version>0.6.0-SNAPSHOT</version>
+    <version>0.6.0</version>
     <name>wls_basisdaten_service</name>
 
     <properties>
@@ -305,7 +305,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-basisdaten-service/0.6.0</tag>
     </scm>
 
 

--- a/wls-basisdaten-service/pom.xml
+++ b/wls-basisdaten-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-basisdaten-service</artifactId>
-    <version>0.6.0</version>
+    <version>0.6.1-SNAPSHOT</version>
     <name>wls_basisdaten_service</name>
 
     <properties>
@@ -305,7 +305,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-basisdaten-service/0.6.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-briefwahl-service/pom.xml
+++ b/wls-briefwahl-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-briefwahl-service</artifactId>
-    <version>0.3.15-SNAPSHOT</version>
+    <version>0.3.15</version>
     <name>wls_briefwahl_service</name>
 
 
@@ -292,7 +292,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-briefwahl-service/0.3.15</tag>
     </scm>
 
 

--- a/wls-briefwahl-service/pom.xml
+++ b/wls-briefwahl-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-briefwahl-service</artifactId>
-    <version>0.3.15</version>
+    <version>0.3.16-SNAPSHOT</version>
     <name>wls_briefwahl_service</name>
 
 
@@ -292,7 +292,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-briefwahl-service/0.3.15</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-broadcast-service/pom.xml
+++ b/wls-broadcast-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-broadcast-service</artifactId>
-    <version>0.4.15-SNAPSHOT</version>
+    <version>0.4.15</version>
     <name>wls_broadcast_service</name>
 
     <properties>
@@ -300,7 +300,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-broadcast-service/0.4.15</tag>
     </scm>
 
     <build>

--- a/wls-broadcast-service/pom.xml
+++ b/wls-broadcast-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-broadcast-service</artifactId>
-    <version>0.4.15</version>
+    <version>0.4.16-SNAPSHOT</version>
     <name>wls_broadcast_service</name>
 
     <properties>
@@ -300,7 +300,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-broadcast-service/0.4.15</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <build>

--- a/wls-eai-service/pom.xml
+++ b/wls-eai-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-eai-service</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.9.0</version>
     <name>wls_eai_service</name>
 
     <properties>
@@ -291,7 +291,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-eai-service/0.9.0</tag>
     </scm>
 
 

--- a/wls-eai-service/pom.xml
+++ b/wls-eai-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-eai-service</artifactId>
-    <version>0.9.0</version>
+    <version>0.9.1-SNAPSHOT</version>
     <name>wls_eai_service</name>
 
     <properties>
@@ -291,7 +291,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-eai-service/0.9.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-ergebnismeldung-service/pom.xml
+++ b/wls-ergebnismeldung-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-ergebnismeldung-service</artifactId>
-    <version>0.6.2</version>
+    <version>0.6.3-SNAPSHOT</version>
     <name>wls_ergebnismeldung_service</name>
 
     <properties>
@@ -308,7 +308,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-ergebnismeldung-service/0.6.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-ergebnismeldung-service/pom.xml
+++ b/wls-ergebnismeldung-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-ergebnismeldung-service</artifactId>
-    <version>0.6.2-SNAPSHOT</version>
+    <version>0.6.2</version>
     <name>wls_ergebnismeldung_service</name>
 
     <properties>
@@ -308,7 +308,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-ergebnismeldung-service/0.6.2</tag>
     </scm>
 
 

--- a/wls-infomanagement-service/pom.xml
+++ b/wls-infomanagement-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-infomanagement-service</artifactId>
-    <version>0.5.3</version>
+    <version>0.5.4-SNAPSHOT</version>
     <name>wls_infomanagement_service</name>
 
 
@@ -296,7 +296,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-infomanagement-service/0.5.3</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-infomanagement-service/pom.xml
+++ b/wls-infomanagement-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-infomanagement-service</artifactId>
-    <version>0.5.3-SNAPSHOT</version>
+    <version>0.5.3</version>
     <name>wls_infomanagement_service</name>
 
 
@@ -296,7 +296,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-infomanagement-service/0.5.3</tag>
     </scm>
 
 

--- a/wls-monitoring-service/pom.xml
+++ b/wls-monitoring-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-monitoring-service</artifactId>
-    <version>0.3.17</version>
+    <version>0.3.18-SNAPSHOT</version>
     <name>wls_monitoring_service</name>
 
     <properties>
@@ -306,7 +306,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-monitoring-service/0.3.17</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-monitoring-service/pom.xml
+++ b/wls-monitoring-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-monitoring-service</artifactId>
-    <version>0.3.17-SNAPSHOT</version>
+    <version>0.3.17</version>
     <name>wls_monitoring_service</name>
 
     <properties>
@@ -306,7 +306,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-monitoring-service/0.3.17</tag>
     </scm>
 
 

--- a/wls-vorfaelleundvorkommnisse-service/pom.xml
+++ b/wls-vorfaelleundvorkommnisse-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-vorfaelleundvorkommnisse-service</artifactId>
-    <version>0.5.14</version>
+    <version>0.5.15-SNAPSHOT</version>
     <name>wls_vorfaelleundvorkommnisse_service</name>
 
     <properties>
@@ -296,7 +296,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-vorfaelleundvorkommnisse-service/0.5.14</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <build>

--- a/wls-vorfaelleundvorkommnisse-service/pom.xml
+++ b/wls-vorfaelleundvorkommnisse-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-vorfaelleundvorkommnisse-service</artifactId>
-    <version>0.5.14-SNAPSHOT</version>
+    <version>0.5.14</version>
     <name>wls_vorfaelleundvorkommnisse_service</name>
 
     <properties>
@@ -296,7 +296,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-vorfaelleundvorkommnisse-service/0.5.14</tag>
     </scm>
 
     <build>

--- a/wls-wahlvorbereitung-service/pom.xml
+++ b/wls-wahlvorbereitung-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-wahlvorbereitung-service</artifactId>
-    <version>0.4.16-SNAPSHOT</version>
+    <version>0.4.16</version>
     <name>wls_wahlvorbereitung_service</name>
 
 
@@ -292,7 +292,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-wahlvorbereitung-service/0.4.16</tag>
     </scm>
 
 

--- a/wls-wahlvorbereitung-service/pom.xml
+++ b/wls-wahlvorbereitung-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-wahlvorbereitung-service</artifactId>
-    <version>0.4.16</version>
+    <version>0.4.17-SNAPSHOT</version>
     <name>wls_wahlvorbereitung_service</name>
 
 
@@ -292,7 +292,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-wahlvorbereitung-service/0.4.16</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-wahlvorstand-service/pom.xml
+++ b/wls-wahlvorstand-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-wahlvorstand-service</artifactId>
-    <version>0.5.17</version>
+    <version>0.5.18-SNAPSHOT</version>
     <name>wls_wahlvorstand_service</name>
 
     <properties>
@@ -307,7 +307,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-wahlvorstand-service/0.5.17</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/wls-wahlvorstand-service/pom.xml
+++ b/wls-wahlvorstand-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-wahlvorstand-service</artifactId>
-    <version>0.5.17-SNAPSHOT</version>
+    <version>0.5.17</version>
     <name>wls_wahlvorstand_service</name>
 
     <properties>
@@ -307,7 +307,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-wahlvorstand-service/0.5.17</tag>
     </scm>
 
 


### PR DESCRIPTION
# Beschreibung:

Releases der Backendservice für den Sprint 44 erstellt.

Das Release für die Gui erfolgt zu einem späteren Zeitpunkt. Wird aber aktuell zu keiner Codeänderung führen.

## Admin-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-admin-service%2F0.4.16)
- [Image-Tag](https://github.com/orgs/it-at-m/packages/container/wahllokalsystem-wls-admin-service/994032688?tag=0.4.16)


## Auth-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-auth-service%2F0.8.0)
- [Image-Tag](https://github.com/orgs/it-at-m/packages/container/wahllokalsystem-wls-auth-service/994039046?tag=0.8.0)


## Basisdaten-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-basisdaten-service%2F0.6.0)
- [Image-Tag](https://github.com/orgs/it-at-m/packages/container/wahllokalsystem-wls-basisdaten-service/994050166?tag=0.6.0)


## Briefwahl-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-briefwahl-service%2F0.3.15)
- [Image-Tag](https://github.com/orgs/it-at-m/packages/container/wahllokalsystem-wls-briefwahl-service/994053976?tag=0.3.15)


## Broadcast-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-broadcast-service%2F0.4.15)
- [Image-Tag](https://github.com/orgs/it-at-m/packages/container/wahllokalsystem-wls-broadcast-service/994058098?tag=0.4.15)


## EAI-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-eai-service%2F0.9.0)
- [Image-Tag](https://github.com/orgs/it-at-m/packages/container/wahllokalsystem-wls-eai-service/994062277?tag=0.9.0)


## Ergebnismeldung-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-ergebnismeldung-service%2F0.6.2)
- [Image-Tag](https://github.com/orgs/it-at-m/packages/container/wahllokalsystem-wls-ergebnismeldung-service/994077684?tag=0.6.2)


## Infomanagment-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-infomanagement-service%2F0.5.3)
- [Image-Tag](https://github.com/orgs/it-at-m/packages/container/wahllokalsystem-wls-infomanagement-service/994081711?tag=0.5.3)


## Monitoring-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-monitoring-service%2F0.3.17)
- [Image-Tag](https://github.com/orgs/it-at-m/packages/container/wahllokalsystem-wls-monitoring-service/994087887?tag=0.3.17)


## Vorfaelle-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-vorfaelleundvorkommnisse-service%2F0.5.14)
- [Image-Tag](https://github.com/orgs/it-at-m/packages/container/wahllokalsystem-wls-vorfaelleundvorkommnisse-service/994092824?tag=0.5.14)

## Wahlvorbereitung-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-wahlvorbereitung-service%2F0.4.16)
- [Image-Tag](https://github.com/orgs/it-at-m/packages/container/wahllokalsystem-wls-wahlvorbereitung-service/994103235?tag=0.4.16)


## Wahlvorstand-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-wahlvorstand-service%2F0.5.17)
- [Image-Tag](https://github.com/orgs/it-at-m/packages/container/wahllokalsystem-wls-wahlvorstand-service/994113832?tag=0.5.17)


## API-Gateway-Service

- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-api-gateway%2F0.1.9)
- [Image-Tag](https://github.com/orgs/it-at-m/packages/container/wahllokalsystem-wls-api-gateway/994032937?tag=0.1.9)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped snapshot versions across multiple services and modules.
  * Updated release numbers for admin, API gateway, auth, basis data, briefwahl, broadcast, EAI, result reporting, information management, monitoring, incidents/events, election preparation, and election board components.
  * No functional, dependency, or build-config changes were included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->