### PR TITLE
fix init oracle db http requests for stimmabgabevermerke

### DIFF
--- a/stack/http_requests/initOracleDB_KomW.http
+++ b/stack/http_requests/initOracleDB_KomW.http
@@ -33,7 +33,7 @@ Content-Type: application/json
   "nummer": "nummer2"
 }
 
-### POST stimmabgabevermerke | user wls_all_uwb | wahlbezirkID 9899cae4-df9a-4ffc-a940-f20cf2280171/1
+### POST stimmabgabevermerke | user wls_komw_uwb | wahlbezirkID 9899cae4-df9a-4ffc-a940-f20cf2280171/1
 POST {{ WLS_ERGEBNISMELDUNG_SERVICE_URL }}/businessActions/stimmabgabevermerke/9899cae4-df9a-4ffc-a940-f20cf2280171/28039463-3d3d-4ce5-acc1-0bef931a4409/1
 Authorization: Bearer {{$auth.token("auth-service")}}
 Content-Type: application/json

--- a/stack/http_requests/initOracleDB_KomW.http
+++ b/stack/http_requests/initOracleDB_KomW.http
@@ -33,86 +33,72 @@ Content-Type: application/json
   "nummer": "nummer2"
 }
 
-### POST stimmabgabevermerke - 1 Wahldaten | user wls_all_uwb | wahlbezirkID 9899cae4-df9a-4ffc-a940-f20cf2280171/1
-POST {{ WLS_ERGEBNISMELDUNG_SERVICE_URL }}/businessActions/stimmabgabevermerke/9899cae4-df9a-4ffc-a940-f20cf2280171/1
+### POST stimmabgabevermerke | user wls_all_uwb | wahlbezirkID 9899cae4-df9a-4ffc-a940-f20cf2280171/1
+POST {{ WLS_ERGEBNISMELDUNG_SERVICE_URL }}/businessActions/stimmabgabevermerke/9899cae4-df9a-4ffc-a940-f20cf2280171/28039463-3d3d-4ce5-acc1-0bef931a4409/1
 Authorization: Bearer {{$auth.token("auth-service")}}
 Content-Type: application/json
 
 {
-  "wahlbezirkID": "9899cae4-df9a-4ffc-a940-f20cf2280171",
   "waehlerverzeichnisNummer": 1,
-  "anzahlBlaetter": 2,
-  "wahldaten": [
+  "wahlbezirkID": "9899cae4-df9a-4ffc-a940-f20cf2280171",
+  "wahlID": "28039463-3d3d-4ce5-acc1-0bef931a4409",
+  "eingenommeneWahlscheine": [
     {
-      "waehlerverzeichnisNummer": 1,
-      "wahlbezirkID": "9899cae4-df9a-4ffc-a940-f20cf2280171",
-      "wahlID": "28039463-3d3d-4ce5-acc1-0bef931a4409",
-      "eingenommeneWahlscheine": [
+      "anzahl": 2,
+      "stimmzettelart": "KLEIN"
+    },
+    {
+      "anzahl": 4,
+      "stimmzettelart": "BEIDE"
+    },
+    {
+      "anzahl": 12,
+      "stimmzettelart": "GROSS"
+    }
+  ],
+  "vermerke": [
+    {
+      "blattnummer": 2,
+      "stimmzettel": [
         {
-          "anzahl": 2,
-          "stimmzettelart": "KLEIN"
-        },
-        {
-          "anzahl": 4,
-          "stimmzettelart": "BEIDE"
-        },
-        {
-          "anzahl": 12,
+          "anzahl": 1,
           "stimmzettelart": "GROSS"
-        }
-      ],
-      "vermerke": [
+        },
         {
-          "blattnummer": 2,
-          "stimmzettel": [
-            {
-              "anzahl": 1,
-              "stimmzettelart": "GROSS"
-            },
-            {
-              "anzahl": 1,
-              "stimmzettelart": "KLEIN"
-            }
-          ]
+          "anzahl": 1,
+          "stimmzettelart": "KLEIN"
         }
       ]
     }
   ]
 }
 
-### POST stimmabgabevermerke - 1 Wahldaten | user wls_all_uwb | WahlbezirkID 9899cae4-df9a-4ffc-a940-f20cf2280172
-POST {{ WLS_ERGEBNISMELDUNG_SERVICE_URL }}/businessActions/stimmabgabevermerke/9899cae4-df9a-4ffc-a940-f20cf2280172/1
+### POST stimmabgabevermerke | user wls_all_uwb | WahlbezirkID 9899cae4-df9a-4ffc-a940-f20cf2280172
+POST {{ WLS_ERGEBNISMELDUNG_SERVICE_URL }}/businessActions/stimmabgabevermerke/9899cae4-df9a-4ffc-a940-f20cf2280172/d8d2dd22-cbf6-488e-b9bc-b8c2b0ab31a1/1
 Authorization: Bearer {{$auth.token("auth-service")}}
 Content-Type: application/json
 
 {
-  "wahlbezirkID": "9899cae4-df9a-4ffc-a940-f20cf2280172",
   "waehlerverzeichnisNummer": 1,
-  "anzahlBlaetter": 2,
-  "wahldaten": [
+  "wahlbezirkID": "9899cae4-df9a-4ffc-a940-f20cf2280172",
+  "wahlID": "d8d2dd22-cbf6-488e-b9bc-b8c2b0ab31a1",
+  "eingenommeneWahlscheine": [
     {
-      "waehlerverzeichnisNummer": 1,
-      "wahlbezirkID": "9899cae4-df9a-4ffc-a940-f20cf2280172",
-      "wahlID": "d8d2dd22-cbf6-488e-b9bc-b8c2b0ab31a1",
-      "eingenommeneWahlscheine": [
+      "anzahl": 2,
+      "stimmzettelart": "KLEIN"
+    }
+  ],
+  "vermerke": [
+    {
+      "blattnummer": 2,
+      "stimmzettel": [
         {
-          "anzahl": 2,
+          "anzahl": 1,
+          "stimmzettelart": "GROSS"
+        },
+        {
+          "anzahl": 1,
           "stimmzettelart": "KLEIN"
-        }
-      ],
-      "vermerke": [
-        {
-          "blattnummer": 2,
-          "stimmzettel": [
-            {
-              "anzahl": 1,
-              "stimmzettelart": "GROSS"
-            },
-            {
-              "anzahl": 1,
-              "stimmzettelart": "KLEIN"
-            }
-          ]
         }
       ]
     }

--- a/stack/http_requests/initOracleDB_KomW.http
+++ b/stack/http_requests/initOracleDB_KomW.http
@@ -73,7 +73,7 @@ Content-Type: application/json
   ]
 }
 
-### POST stimmabgabevermerke | user wls_all_uwb | WahlbezirkID 9899cae4-df9a-4ffc-a940-f20cf2280172
+### POST stimmabgabevermerke | user wls_komw_uwb | WahlbezirkID 9899cae4-df9a-4ffc-a940-f20cf2280172
 POST {{ WLS_ERGEBNISMELDUNG_SERVICE_URL }}/businessActions/stimmabgabevermerke/9899cae4-df9a-4ffc-a940-f20cf2280172/d8d2dd22-cbf6-488e-b9bc-b8c2b0ab31a1/1
 Authorization: Bearer {{$auth.token("auth-service")}}
 Content-Type: application/json

--- a/stack/http_requests/initOracleDB_MBW.http
+++ b/stack/http_requests/initOracleDB_MBW.http
@@ -33,86 +33,72 @@ Content-Type: application/json
   "nummer": "nummer2"
 }
 
-### POST stimmabgabevermerke - 1 Wahldaten | user wls_mbw_uwb | wahlbezirkID d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a/1
-POST {{ WLS_ERGEBNISMELDUNG_SERVICE_URL }}/businessActions/stimmabgabevermerke/d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a/1
+### POST stimmabgabevermerke | user wls_mbw_uwb | wahlbezirkID d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a/1
+POST {{ WLS_ERGEBNISMELDUNG_SERVICE_URL }}/businessActions/stimmabgabevermerke/d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a/b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e/1
 Authorization: Bearer {{$auth.token("auth-service")}}
 Content-Type: application/json
 
 {
-  "wahlbezirkID": "d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a",
   "waehlerverzeichnisNummer": 1,
-  "anzahlBlaetter": 2,
-  "wahldaten": [
+  "wahlbezirkID": "d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a",
+  "wahlID": "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
+  "eingenommeneWahlscheine": [
     {
-      "waehlerverzeichnisNummer": 1,
-      "wahlbezirkID": "d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a",
-      "wahlID": "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
-      "eingenommeneWahlscheine": [
+      "anzahl": 2,
+      "stimmzettelart": "KLEIN"
+    },
+    {
+      "anzahl": 4,
+      "stimmzettelart": "BEIDE"
+    },
+    {
+      "anzahl": 12,
+      "stimmzettelart": "GROSS"
+    }
+  ],
+  "vermerke": [
+    {
+      "blattnummer": 2,
+      "stimmzettel": [
         {
-          "anzahl": 2,
-          "stimmzettelart": "KLEIN"
-        },
-        {
-          "anzahl": 4,
-          "stimmzettelart": "BEIDE"
-        },
-        {
-          "anzahl": 12,
+          "anzahl": 1,
           "stimmzettelart": "GROSS"
-        }
-      ],
-      "vermerke": [
+        },
         {
-          "blattnummer": 2,
-          "stimmzettel": [
-            {
-              "anzahl": 1,
-              "stimmzettelart": "GROSS"
-            },
-            {
-              "anzahl": 1,
-              "stimmzettelart": "KLEIN"
-            }
-          ]
+          "anzahl": 1,
+          "stimmzettelart": "KLEIN"
         }
       ]
     }
   ]
 }
 
-### POST stimmabgabevermerke - 1 Wahldaten | user wls_mbw_bwb | WahlbezirkID e5f6a7b8-c9d0-4e1f-2a3b-4c5d6e7f8a9b
-POST {{ WLS_ERGEBNISMELDUNG_SERVICE_URL }}/businessActions/stimmabgabevermerke/e5f6a7b8-c9d0-4e1f-2a3b-4c5d6e7f8a9b/1
+### POST stimmabgabevermerke | user wls_mbw_bwb | WahlbezirkID e5f6a7b8-c9d0-4e1f-2a3b-4c5d6e7f8a9b
+POST {{ WLS_ERGEBNISMELDUNG_SERVICE_URL }}/businessActions/stimmabgabevermerke/e5f6a7b8-c9d0-4e1f-2a3b-4c5d6e7f8a9b/b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e/1
 Authorization: Bearer {{$auth.token("auth-service")}}
 Content-Type: application/json
 
 {
-  "wahlbezirkID": "e5f6a7b8-c9d0-4e1f-2a3b-4c5d6e7f8a9b",
   "waehlerverzeichnisNummer": 1,
-  "anzahlBlaetter": 2,
-  "wahldaten": [
+  "wahlbezirkID": "e5f6a7b8-c9d0-4e1f-2a3b-4c5d6e7f8a9b",
+  "wahlID": "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
+  "eingenommeneWahlscheine": [
     {
-      "waehlerverzeichnisNummer": 1,
-      "wahlbezirkID": "e5f6a7b8-c9d0-4e1f-2a3b-4c5d6e7f8a9b",
-      "wahlID": "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
-      "eingenommeneWahlscheine": [
+      "anzahl": 2,
+      "stimmzettelart": "KLEIN"
+    }
+  ],
+  "vermerke": [
+    {
+      "blattnummer": 2,
+      "stimmzettel": [
         {
-          "anzahl": 2,
+          "anzahl": 1,
+          "stimmzettelart": "GROSS"
+        },
+        {
+          "anzahl": 1,
           "stimmzettelart": "KLEIN"
-        }
-      ],
-      "vermerke": [
-        {
-          "blattnummer": 2,
-          "stimmzettel": [
-            {
-              "anzahl": 1,
-              "stimmzettelart": "GROSS"
-            },
-            {
-              "anzahl": 1,
-              "stimmzettelart": "KLEIN"
-            }
-          ]
         }
       ]
     }


### PR DESCRIPTION
# Beschreibung:

mit pr #2814 wurde das datenmodell der stimmabgabevermerke angepasst, daher sind die http requests nicht mehr korrekt gewesen und wurden hiermit angepasst

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] http requests angepasst

# Referenzen:

Verwandt mit Issue #2008



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the HTTP request examples for election data submission to reflect the latest request format and endpoint structure.
  * Clarified the payload layout by sending key election details directly in the request body.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->