### PR TITLE
Bugfix release sprint 44

### DIFF
--- a/wls-ergebnismeldung-service/pom.xml
+++ b/wls-ergebnismeldung-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-ergebnismeldung-service</artifactId>
-    <version>0.6.3-SNAPSHOT</version>
+    <version>0.6.3</version>
     <name>wls_ergebnismeldung_service</name>
 
     <properties>
@@ -308,7 +308,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-ergebnismeldung-service/0.6.3</tag>
     </scm>
 
 

--- a/wls-ergebnismeldung-service/pom.xml
+++ b/wls-ergebnismeldung-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem</groupId>
     <artifactId>wls-ergebnismeldung-service</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4-SNAPSHOT</version>
     <name>wls_ergebnismeldung_service</name>
 
     <properties>
@@ -308,7 +308,7 @@
         <url>https://github.com/it-at-m/Wahllokalsystem</url>
         <connection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</connection>
         <developerConnection>scm:git:https://github.com/it-at-m/Wahllokalsystem.git</developerConnection>
-        <tag>wls-ergebnismeldung-service/0.6.3</tag>
+        <tag>HEAD</tag>
     </scm>
 
 


### PR DESCRIPTION
# Ergebnismeldungsservice aktualisiert
- [Release-Notes](https://github.com/it-at-m/Wahllokalsystem/releases/tag/wls-ergebnismeldung-service%2F0.6.3)
- [Image](https://github.com/orgs/it-at-m/packages/container/wahllokalsystem-wls-ergebnismeldung-service/997869378?tag=0.6.3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the service version to the next snapshot release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->