### PR TITLE
Release wls common 1.8.0

### DIFF
--- a/wls-common/exception/pom.xml
+++ b/wls-common/exception/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.8.0-SNAPSHOT</version>
+        <version>1.8.0</version>
     </parent>
 
     <artifactId>exception</artifactId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
     <name>wls-common-exception</name>
     <description>Übergreifende Exception Aspekte</description>
     <url>${wls.github.url}</url>
@@ -18,7 +18,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>HEAD</tag>
+      <tag>wls-common/1.8.0</tag>
   </scm>
 
     <dependencies>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>testing</artifactId>
-            <version>1.8.0-SNAPSHOT</version>
+            <version>1.8.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/wls-common/exception/pom.xml
+++ b/wls-common/exception/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>exception</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1-SNAPSHOT</version>
     <name>wls-common-exception</name>
     <description>Übergreifende Exception Aspekte</description>
     <url>${wls.github.url}</url>
@@ -18,7 +18,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>wls-common/1.8.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>testing</artifactId>
-            <version>1.8.0</version>
+            <version>1.8.1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/wls-common/monitoring/pom.xml
+++ b/wls-common/monitoring/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.8.0-SNAPSHOT</version>
+        <version>1.8.0</version>
     </parent>
 
     <artifactId>monitoring</artifactId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
     <description>Übergreifende Monitoring Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>HEAD</tag>
+      <tag>wls-common/1.8.0</tag>
   </scm>
 
     <build>

--- a/wls-common/monitoring/pom.xml
+++ b/wls-common/monitoring/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>monitoring</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1-SNAPSHOT</version>
     <description>Übergreifende Monitoring Aspekte</description>
     <url>${wls.github.url}</url>
 
@@ -17,7 +17,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>wls-common/1.8.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
     <artifactId>parent</artifactId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
     <name>wls-common</name>
     <packaging>pom</packaging>
     <description>Serviceübergreifende Aspekte</description>
@@ -73,7 +73,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-common/1.8.0</tag>
     </scm>
 
     <profiles>

--- a/wls-common/pom.xml
+++ b/wls-common/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
     <artifactId>parent</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1-SNAPSHOT</version>
     <name>wls-common</name>
     <packaging>pom</packaging>
     <description>Serviceübergreifende Aspekte</description>
@@ -73,7 +73,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-        <tag>wls-common/1.8.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <profiles>

--- a/wls-common/security/pom.xml
+++ b/wls-common/security/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>security</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1-SNAPSHOT</version>
     <name>wls-common-security</name>
     <description>Uebergreifende Security Aspekte</description>
     <url>${wls.github.url}</url>
@@ -18,7 +18,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>wls-common/1.8.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>exception</artifactId>
-            <version>1.8.0</version>
+            <version>1.8.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>testing</artifactId>
-            <version>1.8.0</version>
+            <version>1.8.1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/wls-common/security/pom.xml
+++ b/wls-common/security/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.8.0-SNAPSHOT</version>
+        <version>1.8.0</version>
     </parent>
 
     <artifactId>security</artifactId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
     <name>wls-common-security</name>
     <description>Uebergreifende Security Aspekte</description>
     <url>${wls.github.url}</url>
@@ -18,7 +18,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-      <tag>HEAD</tag>
+      <tag>wls-common/1.8.0</tag>
   </scm>
 
     <dependencies>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>exception</artifactId>
-            <version>1.8.0-SNAPSHOT</version>
+            <version>1.8.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
             <artifactId>testing</artifactId>
-            <version>1.8.0-SNAPSHOT</version>
+            <version>1.8.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/wls-common/swagger/pom.xml
+++ b/wls-common/swagger/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.8.0-SNAPSHOT</version>
+        <version>1.8.0</version>
     </parent>
 
     <artifactId>swagger</artifactId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
     <name>wls-common-swagger</name>
     <description>Uebergreifende Swagger Config</description>
     <url>${wls.github.url}</url>
@@ -18,10 +18,10 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-common/1.8.0</tag>
   </scm>
     <properties>
-        <wls.common.version>1.8.0-SNAPSHOT</wls.common.version>
+        <wls.common.version>1.8.0</wls.common.version>
         <com.tngtech.archunit.version>1.4.2</com.tngtech.archunit.version>
     </properties>
 

--- a/wls-common/swagger/pom.xml
+++ b/wls-common/swagger/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>swagger</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1-SNAPSHOT</version>
     <name>wls-common-swagger</name>
     <description>Uebergreifende Swagger Config</description>
     <url>${wls.github.url}</url>
@@ -18,10 +18,10 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-        <tag>wls-common/1.8.0</tag>
+        <tag>HEAD</tag>
   </scm>
     <properties>
-        <wls.common.version>1.8.0</wls.common.version>
+        <wls.common.version>1.8.1-SNAPSHOT</wls.common.version>
         <com.tngtech.archunit.version>1.4.2</com.tngtech.archunit.version>
     </properties>
 

--- a/wls-common/testing/pom.xml
+++ b/wls-common/testing/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>testing</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1-SNAPSHOT</version>
     <name>wls-common-testing</name>
     <description>Übergreifende Aspekte für das Testing</description>
     <url>${wls.github.url}</url>
@@ -18,7 +18,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-        <tag>wls-common/1.8.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencies>

--- a/wls-common/testing/pom.xml
+++ b/wls-common/testing/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>de.muenchen.oss.wahllokalsystem.wls-common</groupId>
         <artifactId>parent</artifactId>
-        <version>1.8.0-SNAPSHOT</version>
+        <version>1.8.0</version>
     </parent>
 
     <artifactId>testing</artifactId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
     <name>wls-common-testing</name>
     <description>Übergreifende Aspekte für das Testing</description>
     <url>${wls.github.url}</url>
@@ -18,7 +18,7 @@
         <url>${wls.github.url}</url>
         <connection>${wls.github.scm.connection}</connection>
         <developerConnection>${wls.github.scm.connection}</developerConnection>
-        <tag>HEAD</tag>
+        <tag>wls-common/1.8.0</tag>
     </scm>
 
     <dependencies>


### PR DESCRIPTION
# Beschreibung:

release für wls-common 1.8.0


# Referenzen[^1]:

Verwandt mit Issue #2923

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language
[database-init-script-doc-link]: https://it-at-m.github.io/Wahllokalsystem/technik/guides/user-data-cleanup
