### PR TITLE
3015 offline sync der erfassten stimmzettel

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/common/dialogs/TheManualOfflineDataSyncDialog.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/dialogs/TheManualOfflineDataSyncDialog.vue
@@ -2,65 +2,49 @@
   <base-dialog
     :visible="isDialogVisible"
     dialogtitle="Offline-Synchronisierung"
-    :confirmtext="hasDirtyTasks ? 'Synchronisieren' : 'Schließen'"
+    :confirmtext="hasTasksToRun ? 'Synchronisieren' : 'Schließen'"
     :is-confirm-loading="isOfflineDataSyncing"
-    :canceltext="hasDirtyTasks ? 'Schließen' : ''"
+    :canceltext="hasTasksToRun ? 'Schließen' : ''"
     icon="$offlineSync"
     @cancel="onCancelClicked"
     @confirm="onConfirmClicked"
   >
-    <base-offline-data-sync-widget :dirty-tasks="dirtyTasks" />
+    <the-offline-data-sync-widget />
   </base-dialog>
 </template>
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
-import { computed, ref, watch } from "vue";
+import { watch } from "vue";
 
 import BaseDialog from "@/components/common/dialogs/BaseDialog.vue";
-import BaseOfflineDataSyncWidget from "@/components/common/widgets/BaseOfflineDataSyncWidget.vue";
+import TheOfflineDataSyncWidget from "@/components/common/widgets/TheOfflineDataSyncWidget.vue";
 import { useDataSyncStore } from "@/stores/dataSyncStore.ts";
 
 const dataSyncStore = useDataSyncStore();
-const { synchronizeOfflineData, getSyncTasks } = dataSyncStore;
-const { isOfflineDataSyncing } = storeToRefs(dataSyncStore);
+const { synchronizeOfflineData } = dataSyncStore;
+const { isOfflineDataSyncing, hasTasksToRun } = storeToRefs(dataSyncStore);
 
 const isDialogVisible = defineModel("modelValue", {
   type: Boolean,
   required: true,
 });
 
-const dirtyTasks = ref(0);
-const hasDirtyTasks = computed(() => dirtyTasks.value > 0);
-
 watch(
   () => isDialogVisible.value,
   async () => {
     if (!isDialogVisible.value) return;
 
-    await updateDirtyTasks();
-    await synchronizeData();
+    await synchronizeOfflineData();
   }
 );
-
-async function updateDirtyTasks() {
-  const openTasks = await getSyncTasks();
-  dirtyTasks.value = openTasks.length;
-}
-
-async function synchronizeData() {
-  if (isOfflineDataSyncing.value) return;
-
-  await synchronizeOfflineData();
-  await updateDirtyTasks();
-}
 
 function onCancelClicked(): void {
   isDialogVisible.value = false;
 }
 
 async function onConfirmClicked() {
-  if (hasDirtyTasks.value) {
-    await synchronizeData();
+  if (hasTasksToRun.value) {
+    await synchronizeOfflineData();
   } else {
     isDialogVisible.value = false;
   }

--- a/wls-gui-wahllokalsystem/src/components/common/widgets/TheOfflineDataSyncWidget.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/widgets/TheOfflineDataSyncWidget.vue
@@ -16,7 +16,7 @@
         class="my-5"
       />
     </div>
-    <div v-if="!hasDirtyTasks">
+    <div v-if="!hasTasksToRun || !hasDirtyTasksAfterSync">
       <v-icon
         icon="$valid"
         color="success"
@@ -49,33 +49,26 @@
           class="mr-2"
           size="x-small"
         />
-        Fehlgeschlagene Datensätze: {{ dirtyTasks }}
+        Fehlgeschlagene Datensätze: {{ numberOfDirtyTasksAfterSync }}
       </v-row>
     </div>
   </div>
 </template>
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
-import { computed } from "vue";
 
 import BaseProgressLinear from "@/components/common/progressLinear/BaseProgressLinear.vue";
 import { useDateTimeFormatter } from "@/composables/common/dateTimeFormatter.ts";
 import { useDataSyncStore } from "@/stores/dataSyncStore.ts";
 
 const {
+  hasDirtyTasksAfterSync,
+  hasTasksToRun,
   isOfflineDataSyncing,
+  numberOfDirtyTasksAfterSync,
   numberOfTasksFinished,
   numberOfTasksToRun,
   lastSyncUpdateTime,
 } = storeToRefs(useDataSyncStore());
 const { toHhMm } = useDateTimeFormatter();
-
-const props = defineProps({
-  dirtyTasks: {
-    type: Number,
-    required: true,
-  },
-});
-
-const hasDirtyTasks = computed(() => props.dirtyTasks > 0);
 </script>

--- a/wls-gui-wahllokalsystem/src/components/common/widgets/TheOfflineDataSyncWidget.vue
+++ b/wls-gui-wahllokalsystem/src/components/common/widgets/TheOfflineDataSyncWidget.vue
@@ -16,7 +16,7 @@
         class="my-5"
       />
     </div>
-    <div v-if="!hasTasksToRun || !hasDirtyTasksAfterSync">
+    <div v-if="!hasTasksToRun || numberOfDirtyTasksAfterSync === 0">
       <v-icon
         icon="$valid"
         color="success"
@@ -62,7 +62,6 @@ import { useDateTimeFormatter } from "@/composables/common/dateTimeFormatter.ts"
 import { useDataSyncStore } from "@/stores/dataSyncStore.ts";
 
 const {
-  hasDirtyTasksAfterSync,
   hasTasksToRun,
   isOfflineDataSyncing,
   numberOfDirtyTasksAfterSync,

--- a/wls-gui-wahllokalsystem/src/components/dse/TheStimmzettelerfassungBeendenDialog.vue
+++ b/wls-gui-wahllokalsystem/src/components/dse/TheStimmzettelerfassungBeendenDialog.vue
@@ -14,7 +14,10 @@
       abgeschlossen ist und keine weiteren Papier-Stimmzettel mehr erfasst oder
       korrigiert werden sollen.
     </div>
-    <v-card v-if="isSyncWidgetVisible">
+    <v-card
+      v-if="isSyncWidgetVisible"
+      class="mt-2"
+    >
       <v-card-title>Offline-Synchronisierung</v-card-title>
       <v-card-text>
         <the-offline-data-sync-widget />

--- a/wls-gui-wahllokalsystem/src/components/dse/TheStimmzettelerfassungBeendenDialog.vue
+++ b/wls-gui-wahllokalsystem/src/components/dse/TheStimmzettelerfassungBeendenDialog.vue
@@ -17,7 +17,7 @@
     <v-card v-if="isSyncWidgetVisible">
       <v-card-title>Offline-Synchronisierung</v-card-title>
       <v-card-text>
-        <the-offline-data-sync-widget v-if="isSyncWidgetVisible" />
+        <the-offline-data-sync-widget />
       </v-card-text>
     </v-card>
   </base-dialog>

--- a/wls-gui-wahllokalsystem/src/components/dse/TheStimmzettelerfassungBeendenDialog.vue
+++ b/wls-gui-wahllokalsystem/src/components/dse/TheStimmzettelerfassungBeendenDialog.vue
@@ -2,33 +2,55 @@
   <base-dialog
     :visible="isDialogVisible"
     dialogtitle="Beenden der Stimmzettelerfassung"
-    :is-confirm-loading="isSaving"
-    confirmtext="Bestätigen"
+    :is-confirm-loading="isSaving || isOfflineDataSyncing"
+    confirmtext="Synchronisieren und Bestätigen"
     canceltext="Abbrechen"
     icon="$warning"
     @cancel="onCancelClicked"
     @confirm="onConfirmClicked"
   >
-    Bitte bestätigen Sie, dass die Stimmzettelerfassung in Ihrem Team
-    abgeschlossen ist und keine weiteren Papier-Stimmzettel mehr erfasst oder
-    korrigiert werden sollen.
+    <div>
+      Bitte bestätigen Sie, dass die Stimmzettelerfassung in Ihrem Team
+      abgeschlossen ist und keine weiteren Papier-Stimmzettel mehr erfasst oder
+      korrigiert werden sollen.
+    </div>
+    <v-card v-if="isSyncWidgetVisible">
+      <v-card-title>Offline-Synchronisierung</v-card-title>
+      <v-card-text>
+        <base-offline-data-sync-widget
+          v-if="isSyncWidgetVisible"
+          :dirty-tasks="dirtyTasks"
+        />
+      </v-card-text>
+    </v-card>
   </base-dialog>
 </template>
 
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
+import { computed, ref } from "vue";
 
 import BaseDialog from "@/components/common/dialogs/BaseDialog.vue";
+import BaseOfflineDataSyncWidget from "@/components/common/widgets/BaseOfflineDataSyncWidget.vue";
 import { useStimmzettelerfassungStatusTeamService } from "@/composables/dse/stimmzettelerfassungTeamStatusService.ts";
+import { useUserNotificationService } from "@/composables/userNotification/userNotificationService.ts";
 import { ROUTE_FINISHED } from "@/constants.ts";
 import router from "@/plugins/router.ts";
+import { useDataSyncStore } from "@/stores/dataSyncStore.ts";
 import { useUserStore } from "@/stores/userStore.ts";
 import { StimmzettelerfassungTeamStatusEnum } from "@/types/dse/StimmzettelerfassungTeamStatusEnum.ts";
 import { DseStepsEnum } from "@/types/navigation/DseStepsEnum.ts";
+import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
 
 const { hasRoleErfassungsteam } = storeToRefs(useUserStore());
 const { isSaving, postErfassungTeamStatus } =
   useStimmzettelerfassungStatusTeamService();
+
+const { addNotification } = useUserNotificationService();
+
+const dataSyncStore = useDataSyncStore();
+const { synchronizeOfflineData, getSyncTasks } = dataSyncStore;
+const { isOfflineDataSyncing } = storeToRefs(dataSyncStore);
 
 const isDialogVisible = defineModel("modelValue", {
   type: Boolean,
@@ -41,31 +63,60 @@ const props = defineProps<{
   teamId: string;
 }>();
 
+const isSyncWidgetVisible = ref(false);
+const dirtyTasks = ref(0);
+const hasDirtyTasks = computed(() => dirtyTasks.value > 0);
+
 function onCancelClicked(): void {
   closeDialog();
 }
 
 async function onConfirmClicked() {
-  await postErfassungTeamStatus(
-    props.wahlId,
-    props.wahlbezirkId,
-    props.teamId,
-    { status: StimmzettelerfassungTeamStatusEnum.ABGESCHLOSSEN },
-    true
-  );
-
-  if (hasRoleErfassungsteam.value) {
-    await router.push({ name: ROUTE_FINISHED });
-  } else {
-    await router.push({
-      name: DseStepsEnum.DSE_MONITORING,
-      params: { wahlId: props.wahlId, wahlbezirkId: props.wahlbezirkId },
-    });
+  isSyncWidgetVisible.value = true;
+  await updateDirtyTasks();
+  if (hasDirtyTasks.value) {
+    await synchronizeData();
   }
-  closeDialog();
+  if (hasDirtyTasks.value) {
+    addNotification(
+      "Beenden kann nicht abgeschlossen werden, weil die Synchronisierung nicht erfolgreich war.",
+      UserNotificationCategoryEnum.ERROR
+    );
+  } else {
+    await postErfassungTeamStatus(
+      props.wahlId,
+      props.wahlbezirkId,
+      props.teamId,
+      { status: StimmzettelerfassungTeamStatusEnum.ABGESCHLOSSEN },
+      true
+    );
+
+    if (hasRoleErfassungsteam.value) {
+      await router.push({ name: ROUTE_FINISHED });
+    } else {
+      await router.push({
+        name: DseStepsEnum.DSE_MONITORING,
+        params: { wahlId: props.wahlId, wahlbezirkId: props.wahlbezirkId },
+      });
+    }
+    closeDialog();
+  }
 }
 
 function closeDialog() {
   isDialogVisible.value = false;
+  isSyncWidgetVisible.value = false;
+}
+
+async function synchronizeData() {
+  if (isOfflineDataSyncing.value) return;
+
+  await synchronizeOfflineData();
+  await updateDirtyTasks();
+}
+
+async function updateDirtyTasks() {
+  const openTasks = await getSyncTasks();
+  dirtyTasks.value = openTasks.length;
 }
 </script>

--- a/wls-gui-wahllokalsystem/src/components/dse/TheStimmzettelerfassungBeendenDialog.vue
+++ b/wls-gui-wahllokalsystem/src/components/dse/TheStimmzettelerfassungBeendenDialog.vue
@@ -47,8 +47,7 @@ const { addNotification } = useUserNotificationService();
 
 const dataSyncStore = useDataSyncStore();
 const { synchronizeOfflineData } = dataSyncStore;
-const { isOfflineDataSyncing, numberOfDirtyTasksAfterSync } =
-  storeToRefs(dataSyncStore);
+const { isOfflineDataSyncing } = storeToRefs(dataSyncStore);
 
 const isDialogVisible = defineModel("modelValue", {
   type: Boolean,
@@ -69,8 +68,17 @@ function onCancelClicked(): void {
 
 async function onConfirmClicked() {
   isSyncWidgetVisible.value = true;
-  await synchronizeOfflineData();
-  if (numberOfDirtyTasksAfterSync.value) {
+  const syncResult = await synchronizeOfflineData();
+
+  if (!syncResult) {
+    addNotification(
+      "Synchronising läuft bereits. Bitte versuchen Sie es erneut später.",
+      UserNotificationCategoryEnum.WARNING
+    );
+    return;
+  }
+
+  if (syncResult.numberOfDirtyTasksRemaining > 0) {
     addNotification(
       "Beenden kann nicht abgeschlossen werden, weil die Synchronisierung nicht erfolgreich war.",
       UserNotificationCategoryEnum.ERROR

--- a/wls-gui-wahllokalsystem/src/components/dse/TheStimmzettelerfassungBeendenDialog.vue
+++ b/wls-gui-wahllokalsystem/src/components/dse/TheStimmzettelerfassungBeendenDialog.vue
@@ -51,7 +51,7 @@ const props = defineProps<{
 const {
   isSyncWidgetVisible,
   isSaving,
-  syncronizeDataAndPostTeamErfassungDone,
+  synchronizeDataAndPostTeamErfassungDone,
 } = useStimmzettelerfassungBeendenDialogUtils(
   props.wahlId,
   props.wahlbezirkId,
@@ -63,7 +63,7 @@ function onCancelClicked(): void {
 }
 
 async function onConfirmClicked() {
-  await syncronizeDataAndPostTeamErfassungDone();
+  await synchronizeDataAndPostTeamErfassungDone();
 }
 
 function closeDialog() {

--- a/wls-gui-wahllokalsystem/src/components/dse/TheStimmzettelerfassungBeendenDialog.vue
+++ b/wls-gui-wahllokalsystem/src/components/dse/TheStimmzettelerfassungBeendenDialog.vue
@@ -25,28 +25,13 @@
 
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
-import { ref } from "vue";
 
 import BaseDialog from "@/components/common/dialogs/BaseDialog.vue";
 import TheOfflineDataSyncWidget from "@/components/common/widgets/TheOfflineDataSyncWidget.vue";
-import { useStimmzettelerfassungStatusTeamService } from "@/composables/dse/stimmzettelerfassungTeamStatusService.ts";
-import { useUserNotificationService } from "@/composables/userNotification/userNotificationService.ts";
-import { ROUTE_FINISHED } from "@/constants.ts";
-import router from "@/plugins/router.ts";
+import { useStimmzettelerfassungBeendenDialogUtils } from "@/composables/dse/StimmzettelerfassungBeendenDialogUtils.ts";
 import { useDataSyncStore } from "@/stores/dataSyncStore.ts";
-import { useUserStore } from "@/stores/userStore.ts";
-import { StimmzettelerfassungTeamStatusEnum } from "@/types/dse/StimmzettelerfassungTeamStatusEnum.ts";
-import { DseStepsEnum } from "@/types/navigation/DseStepsEnum.ts";
-import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
-
-const { hasRoleErfassungsteam } = storeToRefs(useUserStore());
-const { isSaving, postErfassungTeamStatus } =
-  useStimmzettelerfassungStatusTeamService();
-
-const { addNotification } = useUserNotificationService();
 
 const dataSyncStore = useDataSyncStore();
-const { synchronizeOfflineData } = dataSyncStore;
 const { isOfflineDataSyncing } = storeToRefs(dataSyncStore);
 
 const isDialogVisible = defineModel("modelValue", {
@@ -60,48 +45,22 @@ const props = defineProps<{
   teamId: string;
 }>();
 
-const isSyncWidgetVisible = ref(false);
+const {
+  isSyncWidgetVisible,
+  isSaving,
+  syncronizeDataAndPostTeamErfassungDone,
+} = useStimmzettelerfassungBeendenDialogUtils(
+  props.wahlId,
+  props.wahlbezirkId,
+  closeDialog
+);
 
 function onCancelClicked(): void {
   closeDialog();
 }
 
 async function onConfirmClicked() {
-  isSyncWidgetVisible.value = true;
-  const syncResult = await synchronizeOfflineData();
-
-  if (!syncResult) {
-    addNotification(
-      "Synchronising läuft bereits. Bitte versuchen Sie es erneut später.",
-      UserNotificationCategoryEnum.WARNING
-    );
-    return;
-  }
-
-  if (syncResult.numberOfDirtyTasksRemaining > 0) {
-    addNotification(
-      "Beenden kann nicht abgeschlossen werden, weil die Synchronisierung nicht erfolgreich war.",
-      UserNotificationCategoryEnum.ERROR
-    );
-  } else {
-    await postErfassungTeamStatus(
-      props.wahlId,
-      props.wahlbezirkId,
-      props.teamId,
-      { status: StimmzettelerfassungTeamStatusEnum.ABGESCHLOSSEN },
-      true
-    );
-
-    if (hasRoleErfassungsteam.value) {
-      await router.push({ name: ROUTE_FINISHED });
-    } else {
-      await router.push({
-        name: DseStepsEnum.DSE_MONITORING,
-        params: { wahlId: props.wahlId, wahlbezirkId: props.wahlbezirkId },
-      });
-    }
-    closeDialog();
-  }
+  await syncronizeDataAndPostTeamErfassungDone();
 }
 
 function closeDialog() {

--- a/wls-gui-wahllokalsystem/src/components/dse/TheStimmzettelerfassungBeendenDialog.vue
+++ b/wls-gui-wahllokalsystem/src/components/dse/TheStimmzettelerfassungBeendenDialog.vue
@@ -17,10 +17,7 @@
     <v-card v-if="isSyncWidgetVisible">
       <v-card-title>Offline-Synchronisierung</v-card-title>
       <v-card-text>
-        <base-offline-data-sync-widget
-          v-if="isSyncWidgetVisible"
-          :dirty-tasks="dirtyTasks"
-        />
+        <the-offline-data-sync-widget v-if="isSyncWidgetVisible" />
       </v-card-text>
     </v-card>
   </base-dialog>
@@ -28,10 +25,10 @@
 
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
-import { computed, ref } from "vue";
+import { ref } from "vue";
 
 import BaseDialog from "@/components/common/dialogs/BaseDialog.vue";
-import BaseOfflineDataSyncWidget from "@/components/common/widgets/BaseOfflineDataSyncWidget.vue";
+import TheOfflineDataSyncWidget from "@/components/common/widgets/TheOfflineDataSyncWidget.vue";
 import { useStimmzettelerfassungStatusTeamService } from "@/composables/dse/stimmzettelerfassungTeamStatusService.ts";
 import { useUserNotificationService } from "@/composables/userNotification/userNotificationService.ts";
 import { ROUTE_FINISHED } from "@/constants.ts";
@@ -49,8 +46,9 @@ const { isSaving, postErfassungTeamStatus } =
 const { addNotification } = useUserNotificationService();
 
 const dataSyncStore = useDataSyncStore();
-const { synchronizeOfflineData, getSyncTasks } = dataSyncStore;
-const { isOfflineDataSyncing } = storeToRefs(dataSyncStore);
+const { synchronizeOfflineData } = dataSyncStore;
+const { isOfflineDataSyncing, numberOfDirtyTasksAfterSync } =
+  storeToRefs(dataSyncStore);
 
 const isDialogVisible = defineModel("modelValue", {
   type: Boolean,
@@ -64,8 +62,6 @@ const props = defineProps<{
 }>();
 
 const isSyncWidgetVisible = ref(false);
-const dirtyTasks = ref(0);
-const hasDirtyTasks = computed(() => dirtyTasks.value > 0);
 
 function onCancelClicked(): void {
   closeDialog();
@@ -73,11 +69,8 @@ function onCancelClicked(): void {
 
 async function onConfirmClicked() {
   isSyncWidgetVisible.value = true;
-  await updateDirtyTasks();
-  if (hasDirtyTasks.value) {
-    await synchronizeData();
-  }
-  if (hasDirtyTasks.value) {
+  await synchronizeOfflineData();
+  if (numberOfDirtyTasksAfterSync.value) {
     addNotification(
       "Beenden kann nicht abgeschlossen werden, weil die Synchronisierung nicht erfolgreich war.",
       UserNotificationCategoryEnum.ERROR
@@ -106,17 +99,5 @@ async function onConfirmClicked() {
 function closeDialog() {
   isDialogVisible.value = false;
   isSyncWidgetVisible.value = false;
-}
-
-async function synchronizeData() {
-  if (isOfflineDataSyncing.value) return;
-
-  await synchronizeOfflineData();
-  await updateDirtyTasks();
-}
-
-async function updateDirtyTasks() {
-  const openTasks = await getSyncTasks();
-  dirtyTasks.value = openTasks.length;
 }
 </script>

--- a/wls-gui-wahllokalsystem/src/composables/dse/StimmzettelerfassungBeendenDialogUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/dse/StimmzettelerfassungBeendenDialogUtils.ts
@@ -25,7 +25,7 @@ export function useStimmzettelerfassungBeendenDialogUtils(
 
   const isSyncWidgetVisible = ref(false);
 
-  async function syncronizeDataAndPostTeamErfassungDone() {
+  async function synchronizeDataAndPostTeamErfassungDone() {
     isSyncWidgetVisible.value = true;
     const syncResult = await synchronizeOfflineData();
 
@@ -72,6 +72,6 @@ export function useStimmzettelerfassungBeendenDialogUtils(
     isSyncWidgetVisible,
     isSaving,
 
-    syncronizeDataAndPostTeamErfassungDone,
+    synchronizeDataAndPostTeamErfassungDone,
   };
 }

--- a/wls-gui-wahllokalsystem/src/composables/dse/StimmzettelerfassungBeendenDialogUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/dse/StimmzettelerfassungBeendenDialogUtils.ts
@@ -1,0 +1,77 @@
+import { storeToRefs } from "pinia";
+import { ref } from "vue";
+
+import { useStimmzettelerfassungStatusTeamService } from "@/composables/dse/stimmzettelerfassungTeamStatusService.ts";
+import { useUserNotificationService } from "@/composables/userNotification/userNotificationService.ts";
+import { ROUTE_FINISHED } from "@/constants.ts";
+import router from "@/plugins/router.ts";
+import { useDataSyncStore } from "@/stores/dataSyncStore.ts";
+import { useUserStore } from "@/stores/userStore.ts";
+import { StimmzettelerfassungTeamStatusEnum } from "@/types/dse/StimmzettelerfassungTeamStatusEnum.ts";
+import { DseStepsEnum } from "@/types/navigation/DseStepsEnum.ts";
+import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
+
+export function useStimmzettelerfassungBeendenDialogUtils(
+  wahlId: string,
+  wahlbezirkId: string,
+  closeDialogCallback: () => void
+) {
+  const { addNotification } = useUserNotificationService();
+  const { synchronizeOfflineData } = useDataSyncStore();
+  const { hasRoleErfassungsteam, currentUserTeamName } =
+    storeToRefs(useUserStore());
+  const { isSaving, postErfassungTeamStatus } =
+    useStimmzettelerfassungStatusTeamService();
+
+  const isSyncWidgetVisible = ref(false);
+
+  async function syncronizeDataAndPostTeamErfassungDone() {
+    isSyncWidgetVisible.value = true;
+    const syncResult = await synchronizeOfflineData();
+
+    if (!syncResult) {
+      addNotification(
+        "Synchronising läuft bereits. Bitte versuchen Sie es erneut später.",
+        UserNotificationCategoryEnum.WARNING
+      );
+      return;
+    }
+
+    if (syncResult.numberOfDirtyTasksRemaining > 0) {
+      addNotification(
+        "Beenden kann nicht abgeschlossen werden, weil die Synchronisierung nicht erfolgreich war.",
+        UserNotificationCategoryEnum.ERROR
+      );
+      return;
+    }
+    await postErfassungTeamStatus(
+      wahlId,
+      wahlbezirkId,
+      currentUserTeamName.value,
+      { status: StimmzettelerfassungTeamStatusEnum.ABGESCHLOSSEN },
+      true
+    );
+
+    await _navigateToNextView();
+
+    closeDialogCallback();
+  }
+
+  async function _navigateToNextView() {
+    if (hasRoleErfassungsteam.value) {
+      await router.push({ name: ROUTE_FINISHED });
+    } else {
+      await router.push({
+        name: DseStepsEnum.DSE_MONITORING,
+        params: { wahlId: wahlId, wahlbezirkId: wahlbezirkId },
+      });
+    }
+  }
+
+  return {
+    isSyncWidgetVisible,
+    isSaving,
+
+    syncronizeDataAndPostTeamErfassungDone,
+  };
+}

--- a/wls-gui-wahllokalsystem/src/composables/dse/StimmzettelerfassungBeendenDialogUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/dse/StimmzettelerfassungBeendenDialogUtils.ts
@@ -31,7 +31,7 @@ export function useStimmzettelerfassungBeendenDialogUtils(
 
     if (!syncResult) {
       addNotification(
-        "Synchronising läuft bereits. Bitte versuchen Sie es erneut später.",
+        "Synchronisierung läuft bereits. Bitte versuchen Sie es später erneut.",
         UserNotificationCategoryEnum.WARNING
       );
       return;

--- a/wls-gui-wahllokalsystem/src/composables/indexDB/dataSyncer.ts
+++ b/wls-gui-wahllokalsystem/src/composables/indexDB/dataSyncer.ts
@@ -22,10 +22,7 @@ export function useDataSyncer() {
   const dirtyTasksAfterSync = ref<Task[] | null>(null);
 
   const numberOfDirtyTasksAfterSync = computed(
-    () => dirtyTasksAfterSync.value?.length ?? 0
-  );
-  const hasDirtyTasksAfterSync = computed(
-    () => numberOfDirtyTasksAfterSync.value > 0
+    (): number | undefined => dirtyTasksAfterSync.value?.length
   );
 
   async function getSyncTasks() {
@@ -87,6 +84,5 @@ export function useDataSyncer() {
     lastSyncUpdateTime,
     isOfflineDataSyncing,
     dirtyTasksAfterSync,
-    hasDirtyTasksAfterSync,
   };
 }

--- a/wls-gui-wahllokalsystem/src/composables/indexDB/dataSyncer.ts
+++ b/wls-gui-wahllokalsystem/src/composables/indexDB/dataSyncer.ts
@@ -1,4 +1,5 @@
 import type { IndexDBValue } from "@/types/indexDB/IndexDBValue.ts";
+import type { SyncronizeDataResult } from "@/types/indexDB/SyncronizeDataResult.ts";
 import type { Task } from "@/types/tasks/Task.ts";
 
 import axios from "axios";
@@ -41,8 +42,8 @@ export function useDataSyncer() {
     }));
   }
 
-  async function synchronizeOfflineData() {
-    if (isOfflineDataSyncing.value) return;
+  async function synchronizeOfflineData(): Promise<SyncronizeDataResult | null> {
+    if (isOfflineDataSyncing.value) return null;
 
     isOfflineDataSyncing.value = true;
     try {
@@ -55,6 +56,13 @@ export function useDataSyncer() {
       isOfflineDataSyncing.value = false;
       lastSyncUpdateTime.value = new Date();
     }
+
+    return {
+      numberOfTasksRan: taskManager.numberOfTasksToRun.value,
+      numberOfTasksFailed: taskManager.numberOfTasksFailed.value,
+      numberOfTasksSucceeded: taskManager.numberOfTasksSucceeded.value,
+      numberOfDirtyTasksRemaining: dirtyTasksAfterSync.value.length,
+    };
   }
 
   function _compareSyncItemByTimeStamp(

--- a/wls-gui-wahllokalsystem/src/composables/indexDB/dataSyncer.ts
+++ b/wls-gui-wahllokalsystem/src/composables/indexDB/dataSyncer.ts
@@ -52,9 +52,9 @@ export function useDataSyncer() {
     } catch (e) {
       logDebug("Fehler beim Synchronisieren", e);
     } finally {
-      dirtyTasksAfterSync.value = await getSyncTasks();
       isOfflineDataSyncing.value = false;
       lastSyncUpdateTime.value = new Date();
+      dirtyTasksAfterSync.value = await getSyncTasks();
     }
 
     return {

--- a/wls-gui-wahllokalsystem/src/composables/indexDB/dataSyncer.ts
+++ b/wls-gui-wahllokalsystem/src/composables/indexDB/dataSyncer.ts
@@ -1,7 +1,8 @@
 import type { IndexDBValue } from "@/types/indexDB/IndexDBValue.ts";
+import type { Task } from "@/types/tasks/Task.ts";
 
 import axios from "axios";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 import { basicPostConfig } from "@/api/axios-utils.ts";
 import { useLogging } from "@/composables/common/logging.ts";
@@ -18,6 +19,14 @@ export function useDataSyncer() {
   const taskManager = useTaskManager();
   const isOfflineDataSyncing = ref(false);
   const lastSyncUpdateTime = ref<null | Date>(null);
+  const dirtyTasksAfterSync = ref<Task[] | null>(null);
+
+  const numberOfDirtyTasksAfterSync = computed(
+    () => dirtyTasksAfterSync.value?.length ?? 0
+  );
+  const hasDirtyTasksAfterSync = computed(
+    () => numberOfDirtyTasksAfterSync.value > 0
+  );
 
   async function getSyncTasks() {
     const itemsToSync = await indexDBSingleton.getDirtyItems();
@@ -36,10 +45,13 @@ export function useDataSyncer() {
   }
 
   async function synchronizeOfflineData() {
+    if (isOfflineDataSyncing.value) return;
+
     isOfflineDataSyncing.value = true;
     try {
       taskManager.setTasks(await getSyncTasks());
       await taskManager.runAllTasks();
+      dirtyTasksAfterSync.value = await getSyncTasks();
     } catch (e) {
       logDebug("Fehler beim Synchronisieren", e);
     } finally {
@@ -71,7 +83,10 @@ export function useDataSyncer() {
     ...taskManager,
     getSyncTasks,
     synchronizeOfflineData,
+    numberOfDirtyTasksAfterSync,
     lastSyncUpdateTime,
     isOfflineDataSyncing,
+    dirtyTasksAfterSync,
+    hasDirtyTasksAfterSync,
   };
 }

--- a/wls-gui-wahllokalsystem/src/composables/indexDB/dataSyncer.ts
+++ b/wls-gui-wahllokalsystem/src/composables/indexDB/dataSyncer.ts
@@ -51,10 +51,10 @@ export function useDataSyncer() {
     try {
       taskManager.setTasks(await getSyncTasks());
       await taskManager.runAllTasks();
-      dirtyTasksAfterSync.value = await getSyncTasks();
     } catch (e) {
       logDebug("Fehler beim Synchronisieren", e);
     } finally {
+      dirtyTasksAfterSync.value = await getSyncTasks();
       isOfflineDataSyncing.value = false;
       lastSyncUpdateTime.value = new Date();
     }

--- a/wls-gui-wahllokalsystem/src/stores/dataSyncStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/dataSyncStore.ts
@@ -5,21 +5,7 @@ import { useDataSyncer } from "@/composables/indexDB/dataSyncer.ts";
 const storeID = "dataSync";
 
 export const useDataSyncStore = defineStore(storeID, () => {
-  const {
-    synchronizeOfflineData,
-    getSyncTasks,
-    isOfflineDataSyncing,
-    numberOfTasksFinished,
-    numberOfTasksToRun,
-    lastSyncUpdateTime,
-  } = useDataSyncer();
-
   return {
-    numberOfTasksFinished,
-    numberOfTasksToRun,
-    isOfflineDataSyncing,
-    lastSyncUpdateTime,
-    synchronizeOfflineData,
-    getSyncTasks,
+    ...useDataSyncer(),
   };
 });

--- a/wls-gui-wahllokalsystem/src/stores/dataSyncStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/dataSyncStore.ts
@@ -5,7 +5,29 @@ import { useDataSyncer } from "@/composables/indexDB/dataSyncer.ts";
 const storeID = "dataSync";
 
 export const useDataSyncStore = defineStore(storeID, () => {
+  const {
+    synchronizeOfflineData,
+    getSyncTasks,
+    dirtyTasksAfterSync,
+    hasTasksToRun,
+    hasDirtyTasksAfterSync,
+    isOfflineDataSyncing,
+    numberOfDirtyTasksAfterSync,
+    numberOfTasksFinished,
+    numberOfTasksToRun,
+    lastSyncUpdateTime,
+  } = useDataSyncer();
+
   return {
-    ...useDataSyncer(),
+    dirtyTasksAfterSync,
+    hasDirtyTasksAfterSync,
+    hasTasksToRun,
+    numberOfDirtyTasksAfterSync,
+    numberOfTasksFinished,
+    numberOfTasksToRun,
+    isOfflineDataSyncing,
+    lastSyncUpdateTime,
+    synchronizeOfflineData,
+    getSyncTasks,
   };
 });

--- a/wls-gui-wahllokalsystem/src/stores/dataSyncStore.ts
+++ b/wls-gui-wahllokalsystem/src/stores/dataSyncStore.ts
@@ -10,7 +10,6 @@ export const useDataSyncStore = defineStore(storeID, () => {
     getSyncTasks,
     dirtyTasksAfterSync,
     hasTasksToRun,
-    hasDirtyTasksAfterSync,
     isOfflineDataSyncing,
     numberOfDirtyTasksAfterSync,
     numberOfTasksFinished,
@@ -20,7 +19,6 @@ export const useDataSyncStore = defineStore(storeID, () => {
 
   return {
     dirtyTasksAfterSync,
-    hasDirtyTasksAfterSync,
     hasTasksToRun,
     numberOfDirtyTasksAfterSync,
     numberOfTasksFinished,

--- a/wls-gui-wahllokalsystem/src/types/indexDB/SyncronizeDataResult.ts
+++ b/wls-gui-wahllokalsystem/src/types/indexDB/SyncronizeDataResult.ts
@@ -1,0 +1,6 @@
+export interface SyncronizeDataResult {
+  numberOfTasksRan: number;
+  numberOfTasksFailed: number;
+  numberOfTasksSucceeded: number;
+  numberOfDirtyTasksRemaining: number;
+}

--- a/wls-gui-wahllokalsystem/tests/composables/dse/StimmzettelerfassungBeendenDialogUtils.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/dse/StimmzettelerfassungBeendenDialogUtils.spec.ts
@@ -1,0 +1,184 @@
+import { useCommonTestDataFactory } from "@tests/utils/common/CommonTestDataFactory.ts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useStimmzettelerfassungBeendenDialogUtils } from "@/composables/dse/StimmzettelerfassungBeendenDialogUtils.ts";
+import { ROUTE_FINISHED } from "@/constants.ts";
+import { StimmzettelerfassungTeamStatusEnum } from "@/types/dse/StimmzettelerfassungTeamStatusEnum.ts";
+import { DseStepsEnum } from "@/types/navigation/DseStepsEnum.ts";
+import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
+
+const mockDefinitions = await vi.hoisted(async () => {
+  const { ref } = await import("vue");
+
+  return {
+    synchronizeOfflineData: vi.fn(),
+    addNotification: vi.fn(),
+    postErfassungTeamStatus: vi.fn(),
+    routerPush: vi.fn(),
+    hasRoleErfassungsteamValue: ref(true),
+    currentUserTeamNameValue: ref("TEAM-1"),
+    closeDialogCallback: vi.fn().mockImplementation(() => {
+      return;
+    }),
+    isSavingRef: ref(false),
+  };
+});
+
+vi.mock("@/composables/userNotification/userNotificationService.ts", () => ({
+  useUserNotificationService: () => ({
+    addNotification: mockDefinitions.addNotification,
+  }),
+}));
+
+vi.mock("@/stores/dataSyncStore.ts", () => ({
+  useDataSyncStore: () => ({
+    synchronizeOfflineData: mockDefinitions.synchronizeOfflineData,
+  }),
+}));
+
+vi.mock("@/stores/userStore.ts", () => ({
+  useUserStore: () => ({
+    hasRoleErfassungsteam: mockDefinitions.hasRoleErfassungsteamValue,
+    currentUserTeamName: mockDefinitions.currentUserTeamNameValue,
+  }),
+}));
+
+vi.mock("@/composables/dse/stimmzettelerfassungTeamStatusService.ts", () => ({
+  useStimmzettelerfassungStatusTeamService: () => ({
+    isSaving: mockDefinitions.isSavingRef,
+    postErfassungTeamStatus: mockDefinitions.postErfassungTeamStatus,
+  }),
+}));
+
+vi.mock("@/plugins/router.ts", () => ({
+  default: {
+    push: mockDefinitions.routerPush,
+  },
+}));
+
+const { generateRandomString } = useCommonTestDataFactory();
+
+describe("StimmzettelerfassungBeendenDialogUtils.ts", () => {
+  const wahlId = generateRandomString(10);
+  const wahlbezirkId = generateRandomString(10);
+
+  let unitUnderTest: ReturnType<
+    typeof useStimmzettelerfassungBeendenDialogUtils
+  >;
+
+  beforeEach(() => {
+    unitUnderTest = useStimmzettelerfassungBeendenDialogUtils(
+      wahlId,
+      wahlbezirkId,
+      mockDefinitions.closeDialogCallback
+    );
+
+    mockDefinitions.hasRoleErfassungsteamValue.value = true;
+    mockDefinitions.currentUserTeamNameValue.value = "TEAM-1";
+    mockDefinitions.isSavingRef.value = false;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetAllMocks();
+  });
+
+  describe("isSyncWidgetVisible", () => {
+    it("should_beFalse_when_unitIsInitialized", () => {
+      expect(unitUnderTest.isSyncWidgetVisible.value).toBe(false);
+    });
+
+    it("should_beTrue_when_synchronizeDataAndPostTeamErfassungDoneWasCalled", async () => {
+      mockDefinitions.synchronizeOfflineData.mockResolvedValue(null);
+
+      expect(unitUnderTest.isSyncWidgetVisible.value).toBe(false);
+
+      await unitUnderTest.synchronizeDataAndPostTeamErfassungDone();
+
+      expect(unitUnderTest.isSyncWidgetVisible.value).toBe(true);
+    });
+  });
+
+  describe("isSaving", () => {
+    it("should_exposeIsSaving_when_unitIsInitialized", () => {
+      expect(unitUnderTest.isSaving).toBe(mockDefinitions.isSavingRef);
+
+      mockDefinitions.isSavingRef.value = true;
+      expect(unitUnderTest.isSaving.value).toBe(true);
+    });
+  });
+
+  describe("synchronizeDataAndPostTeamErfassungDone", () => {
+    it("should_showWarningNotification_when_synchronizeOfflineDataReturnsNull", async () => {
+      mockDefinitions.synchronizeOfflineData.mockResolvedValue(null);
+
+      await unitUnderTest.synchronizeDataAndPostTeamErfassungDone();
+
+      expect(mockDefinitions.synchronizeOfflineData).toHaveBeenCalledTimes(1);
+      expect(mockDefinitions.addNotification).toHaveBeenCalledWith(
+        expect.any(String),
+        UserNotificationCategoryEnum.WARNING
+      );
+      expect(mockDefinitions.postErfassungTeamStatus).not.toHaveBeenCalled();
+      expect(mockDefinitions.routerPush).not.toHaveBeenCalled();
+      expect(mockDefinitions.closeDialogCallback).not.toHaveBeenCalled();
+    });
+
+    it("should_showErrorNotification_when_synchronizeOfflineDataReturnsDirtyTasks", async () => {
+      mockDefinitions.synchronizeOfflineData.mockResolvedValue({
+        numberOfDirtyTasksRemaining: 1,
+      });
+
+      await unitUnderTest.synchronizeDataAndPostTeamErfassungDone();
+
+      expect(mockDefinitions.addNotification).toHaveBeenCalledWith(
+        expect.any(String),
+        UserNotificationCategoryEnum.ERROR
+      );
+      expect(mockDefinitions.postErfassungTeamStatus).not.toHaveBeenCalled();
+      expect(mockDefinitions.routerPush).not.toHaveBeenCalled();
+      expect(mockDefinitions.closeDialogCallback).not.toHaveBeenCalled();
+    });
+
+    it("should_postTeamStatusAndNavigateToFinishedRoute_when_syncSuccessfulAndUserHasRoleErfassungsteam", async () => {
+      mockDefinitions.hasRoleErfassungsteamValue.value = true;
+      mockDefinitions.currentUserTeamNameValue.value = "TEAM-ERFASSUNG";
+      mockDefinitions.synchronizeOfflineData.mockResolvedValue({
+        numberOfDirtyTasksRemaining: 0,
+      });
+      mockDefinitions.postErfassungTeamStatus.mockResolvedValue(undefined);
+
+      await unitUnderTest.synchronizeDataAndPostTeamErfassungDone();
+
+      expect(mockDefinitions.postErfassungTeamStatus).toHaveBeenCalledWith(
+        wahlId,
+        wahlbezirkId,
+        "TEAM-ERFASSUNG",
+        { status: StimmzettelerfassungTeamStatusEnum.ABGESCHLOSSEN },
+        true
+      );
+      expect(mockDefinitions.routerPush).toHaveBeenCalledWith({
+        name: ROUTE_FINISHED,
+      });
+      expect(mockDefinitions.closeDialogCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it("should_postTeamStatusAndNavigateToMonitoring_when_syncSuccessfulAndUserHasNotRoleErfassungsteam", async () => {
+      mockDefinitions.hasRoleErfassungsteamValue.value = false;
+      mockDefinitions.currentUserTeamNameValue.value = "TEAM-SONSTIG";
+      mockDefinitions.synchronizeOfflineData.mockResolvedValue({
+        numberOfDirtyTasksRemaining: 0,
+      });
+      mockDefinitions.postErfassungTeamStatus.mockResolvedValue(undefined);
+
+      await unitUnderTest.synchronizeDataAndPostTeamErfassungDone();
+
+      expect(mockDefinitions.postErfassungTeamStatus).toHaveBeenCalled();
+      expect(mockDefinitions.routerPush).toHaveBeenCalledWith({
+        name: DseStepsEnum.DSE_MONITORING,
+        params: { wahlId, wahlbezirkId },
+      });
+      expect(mockDefinitions.closeDialogCallback).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/wls-gui-wahllokalsystem/tests/composables/indexDB/dataSyncer.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/indexDB/dataSyncer.spec.ts
@@ -119,32 +119,6 @@ describe("dataSyncer.ts", () => {
     });
   });
 
-  describe("hasDirtyTasksAfterSync", () => {
-    it("should_returnFalse_when_dirtyTasksAfterSyncIsNull", () => {
-      unitUnderTest.dirtyTasksAfterSync.value = null;
-      expect(unitUnderTest.hasDirtyTasksAfterSync.value).toStrictEqual(false);
-    });
-    it("should_returnFalse_when_dirtyTasksAfterSyncIsEmptyArray", () => {
-      unitUnderTest.dirtyTasksAfterSync.value = [];
-      expect(unitUnderTest.hasDirtyTasksAfterSync.value).toStrictEqual(false);
-    });
-    it("should_returnTrue_when_dirtyTasksAfterSyncIsArrayWithOneItem", () => {
-      unitUnderTest.dirtyTasksAfterSync.value = [createTask("1")];
-      expect(unitUnderTest.hasDirtyTasksAfterSync.value).toStrictEqual(true);
-    });
-    it("should_returnTrue_when_dirtyTasksAfterSyncIsArrayWithMultipleItems", () => {
-      unitUnderTest.dirtyTasksAfterSync.value = [
-        createTask("1"),
-        createTask("2"),
-        createTask("3"),
-        createTask("4"),
-        createTask("5"),
-        createTask("6"),
-      ];
-      expect(unitUnderTest.hasDirtyTasksAfterSync.value).toStrictEqual(true);
-    });
-  });
-
   describe("numberOfDirtyTasksAfterSync", () => {
     it("should_return0_when_dirtyTasksAfterSyncIsNull", () => {
       unitUnderTest.dirtyTasksAfterSync.value = null;

--- a/wls-gui-wahllokalsystem/tests/composables/indexDB/dataSyncer.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/indexDB/dataSyncer.spec.ts
@@ -1,3 +1,4 @@
+import type { SyncronizeDataResult } from "@/types/indexDB/SyncronizeDataResult.ts";
 import type { Task } from "@/types/tasks/Task.ts";
 
 import { useIndexDBValueTestDataFactory } from "@tests/utils/indexDB/IndexDBValueTestDataFactory.ts";
@@ -16,12 +17,25 @@ import {
 import { useDataSyncer } from "@/composables/indexDB/dataSyncer.ts";
 import { FetchStrategiesEnum } from "@/types/api/FetchStrategiesEnum.ts";
 
-const mockDefinitions = vi.hoisted(() => ({
-  getDirtyItems: vi.fn(),
-  basicPostConfig: vi.fn(),
-  setTasks: vi.fn(),
-  runAllTasks: vi.fn(),
-}));
+const mockDefinitions = await vi.hoisted(async () => {
+  const commonTestDataFactoryImport =
+    await import("@tests/utils/common/CommonTestDataFactory.ts");
+  const { generateRandomNumber } =
+    commonTestDataFactoryImport.useCommonTestDataFactory();
+
+  const { ref } = await import("vue");
+  return {
+    getDirtyItems: vi.fn(),
+    basicPostConfig: vi.fn(),
+    taskManager: {
+      setTasks: vi.fn(),
+      runAllTasks: vi.fn(),
+      numberOfTasksToRun: ref(generateRandomNumber(3)),
+      numberOfTasksSucceeded: ref(generateRandomNumber(3)),
+      numberOfTasksFailed: ref(generateRandomNumber(3)),
+    },
+  };
+});
 
 vi.mock(import("axios"));
 vi.mock(import("@/composables/indexDB/indexDB.ts"), () => ({
@@ -34,8 +48,11 @@ vi.mock("@/api/axios-utils.ts", () => ({
 }));
 vi.mock(import("@/composables/tasks/taskManager.ts"), () => ({
   useTaskManager: vi.fn().mockImplementation(() => ({
-    setTasks: mockDefinitions.setTasks,
-    runAllTasks: mockDefinitions.runAllTasks,
+    setTasks: mockDefinitions.taskManager.setTasks,
+    runAllTasks: mockDefinitions.taskManager.runAllTasks,
+    numberOfTasksToRun: mockDefinitions.taskManager.numberOfTasksToRun,
+    numberOfTasksSucceeded: mockDefinitions.taskManager.numberOfTasksSucceeded,
+    numberOfTasksFailed: mockDefinitions.taskManager.numberOfTasksFailed,
   })),
 }));
 
@@ -102,7 +119,7 @@ describe("dataSyncer.ts", () => {
         },
       ];
       mockDefinitions.getDirtyItems.mockResolvedValue(dirtyTasks);
-      mockDefinitions.runAllTasks.mockRejectedValue(
+      mockDefinitions.taskManager.runAllTasks.mockRejectedValue(
         new Error("mocked task manager error")
       );
 
@@ -120,8 +137,14 @@ describe("dataSyncer.ts", () => {
   });
 
   describe("numberOfDirtyTasksAfterSync", () => {
-    it("should_return0_when_dirtyTasksAfterSyncIsNull", () => {
+    it("should_returnUndefined_when_dirtyTasksAfterSyncIsNull", () => {
       unitUnderTest.dirtyTasksAfterSync.value = null;
+      expect(unitUnderTest.numberOfDirtyTasksAfterSync.value).toStrictEqual(
+        undefined
+      );
+    });
+    it("should_returnUndefined_when_dirtyTasksAfterSyncIsEmpty", () => {
+      unitUnderTest.dirtyTasksAfterSync.value = [];
       expect(unitUnderTest.numberOfDirtyTasksAfterSync.value).toStrictEqual(0);
     });
     it("should_returnLength_when_dirtyTasksAfterSyncIsNotNull", () => {
@@ -229,13 +252,37 @@ describe("dataSyncer.ts", () => {
       isOfflineDataSyncingSpy.mockRestore();
     });
 
+    it("should_returnNull_when_syncIsAlreadyInProgress", async () => {
+      const isOfflineDataSyncingSpy = spyOn(
+        unitUnderTest.isOfflineDataSyncing,
+        "value",
+        "get"
+      );
+      isOfflineDataSyncingSpy.mockReturnValue(true);
+
+      const result = await unitUnderTest.synchronizeOfflineData();
+      expect(result).toStrictEqual(null);
+
+      isOfflineDataSyncingSpy.mockRestore();
+    });
+
     it("should_syncingTasks_when_called", async () => {
       mockDefinitions.getDirtyItems.mockResolvedValue([]);
 
-      await unitUnderTest.synchronizeOfflineData();
+      const result = await unitUnderTest.synchronizeOfflineData();
 
-      expect(mockDefinitions.setTasks).toHaveBeenCalledOnce();
-      expect(mockDefinitions.runAllTasks).toHaveBeenCalledOnce();
+      expect(mockDefinitions.taskManager.setTasks).toHaveBeenCalledOnce();
+      expect(mockDefinitions.taskManager.runAllTasks).toHaveBeenCalledOnce();
+
+      const expectedResult: SyncronizeDataResult = {
+        numberOfDirtyTasksRemaining: 0,
+        numberOfTasksSucceeded:
+          mockDefinitions.taskManager.numberOfTasksSucceeded.value,
+        numberOfTasksFailed:
+          mockDefinitions.taskManager.numberOfTasksFailed.value,
+        numberOfTasksRan: mockDefinitions.taskManager.numberOfTasksToRun.value,
+      };
+      expect(result).toStrictEqual(expectedResult);
     });
 
     it("should_notDoAnything_when_syncIsInProgress", async () => {
@@ -244,8 +291,8 @@ describe("dataSyncer.ts", () => {
       unitUnderTest.isOfflineDataSyncing.value = false;
 
       expect(mockDefinitions.getDirtyItems).not.toHaveBeenCalled();
-      expect(mockDefinitions.setTasks).not.toHaveBeenCalled();
-      expect(mockDefinitions.runAllTasks).not.toHaveBeenCalled();
+      expect(mockDefinitions.taskManager.setTasks).not.toHaveBeenCalled();
+      expect(mockDefinitions.taskManager.runAllTasks).not.toHaveBeenCalled();
     });
 
     it("should_setIsSyncingFalse_when_anErrorOccurred", async () => {
@@ -255,13 +302,21 @@ describe("dataSyncer.ts", () => {
         "set"
       );
       mockDefinitions.getDirtyItems.mockResolvedValue([]);
-      mockDefinitions.runAllTasks.mockRejectedValueOnce(
+      mockDefinitions.taskManager.runAllTasks.mockRejectedValueOnce(
         new Error("mocked error while running tasks")
       );
 
+      const expectedResult: SyncronizeDataResult = {
+        numberOfDirtyTasksRemaining: 0,
+        numberOfTasksSucceeded:
+          mockDefinitions.taskManager.numberOfTasksSucceeded.value,
+        numberOfTasksFailed:
+          mockDefinitions.taskManager.numberOfTasksFailed.value,
+        numberOfTasksRan: mockDefinitions.taskManager.numberOfTasksToRun.value,
+      };
       await expect(
         unitUnderTest.synchronizeOfflineData()
-      ).resolves.toBeUndefined();
+      ).resolves.toStrictEqual(expectedResult);
 
       expect(isOfflineDataSyncingSpy.mock.calls).toStrictEqual([
         [true],

--- a/wls-gui-wahllokalsystem/tests/composables/indexDB/dataSyncer.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/indexDB/dataSyncer.spec.ts
@@ -1,6 +1,7 @@
 import type { Task } from "@/types/tasks/Task.ts";
 
 import { useIndexDBValueTestDataFactory } from "@tests/utils/indexDB/IndexDBValueTestDataFactory.ts";
+import { useTasksTestDataFactory } from "@tests/utils/tasks/TasksTestDataFactory.ts";
 import { spyOn } from "storybook/test";
 import {
   afterAll,
@@ -39,6 +40,7 @@ vi.mock(import("@/composables/tasks/taskManager.ts"), () => ({
 }));
 
 const { prepareIndexDBValue } = useIndexDBValueTestDataFactory();
+const { createTask } = useTasksTestDataFactory();
 
 describe("dataSyncer.ts", () => {
   let unitUnderTest: ReturnType<typeof useDataSyncer>;
@@ -53,6 +55,83 @@ describe("dataSyncer.ts", () => {
 
   afterAll(() => {
     vi.resetAllMocks();
+  });
+
+  describe("dirtyTasksAfterSync ", () => {
+    it("should_setListWithTasks_when_dirtyTasksExistAfterRun", async () => {
+      const dirtyTasks = [
+        {
+          key: "key1",
+          item: prepareIndexDBValue().data("data1").timestamp(9).build(),
+        },
+        {
+          key: "key2",
+          item: prepareIndexDBValue().data("2").timestamp(10).build(),
+        },
+      ];
+      mockDefinitions.getDirtyItems.mockResolvedValue(dirtyTasks);
+
+      expect(unitUnderTest.dirtyTasksAfterSync.value).toStrictEqual(null);
+      await unitUnderTest.synchronizeOfflineData();
+
+      const expectedTasks = [
+        { name: "key1", callback: expect.anything() },
+        { name: "key2", callback: expect.anything() },
+      ];
+      expect(unitUnderTest.dirtyTasksAfterSync.value).toStrictEqual(
+        expectedTasks
+      );
+    });
+    it("should_setEmptyList_when_noDirtyTasksExistAfterRun", async () => {
+      mockDefinitions.getDirtyItems.mockResolvedValue([]);
+
+      unitUnderTest.dirtyTasksAfterSync.value = [createTask("task1")];
+
+      await unitUnderTest.synchronizeOfflineData();
+      expect(unitUnderTest.dirtyTasksAfterSync.value).toStrictEqual([]);
+    });
+  });
+
+  describe("hasDirtyTasksAfterSync", () => {
+    it("should_returnFalse_when_dirtyTasksAfterSyncIsNull", () => {
+      unitUnderTest.dirtyTasksAfterSync.value = null;
+      expect(unitUnderTest.hasDirtyTasksAfterSync.value).toStrictEqual(false);
+    });
+    it("should_returnFalse_when_dirtyTasksAfterSyncIsEmptyArray", () => {
+      unitUnderTest.dirtyTasksAfterSync.value = [];
+      expect(unitUnderTest.hasDirtyTasksAfterSync.value).toStrictEqual(false);
+    });
+    it("should_returnTrue_when_dirtyTasksAfterSyncIsArrayWithOneItem", () => {
+      unitUnderTest.dirtyTasksAfterSync.value = [createTask("1")];
+      expect(unitUnderTest.hasDirtyTasksAfterSync.value).toStrictEqual(true);
+    });
+    it("should_returnTrue_when_dirtyTasksAfterSyncIsArrayWithMultipleItems", () => {
+      unitUnderTest.dirtyTasksAfterSync.value = [
+        createTask("1"),
+        createTask("2"),
+        createTask("3"),
+        createTask("4"),
+        createTask("5"),
+        createTask("6"),
+      ];
+      expect(unitUnderTest.hasDirtyTasksAfterSync.value).toStrictEqual(true);
+    });
+  });
+
+  describe("numberOfDirtyTasksAfterSync", () => {
+    it("should_return0_when_dirtyTasksAfterSyncIsNull", () => {
+      unitUnderTest.dirtyTasksAfterSync.value = null;
+      expect(unitUnderTest.numberOfDirtyTasksAfterSync.value).toStrictEqual(0);
+    });
+    it("should_returnLength_when_dirtyTasksAfterSyncIsNotNull", () => {
+      unitUnderTest.dirtyTasksAfterSync.value = [
+        createTask("1"),
+        createTask("2"),
+        createTask("3"),
+      ];
+
+      expect(unitUnderTest.numberOfDirtyTasksAfterSync.value).toStrictEqual(3);
+    });
   });
 
   describe("getSyncTasks", () => {
@@ -156,6 +235,16 @@ describe("dataSyncer.ts", () => {
 
       expect(mockDefinitions.setTasks).toHaveBeenCalledOnce();
       expect(mockDefinitions.runAllTasks).toHaveBeenCalledOnce();
+    });
+
+    it("should_notDoAnything_when_syncIsInProgress", async () => {
+      unitUnderTest.isOfflineDataSyncing.value = true;
+      await unitUnderTest.synchronizeOfflineData();
+      unitUnderTest.isOfflineDataSyncing.value = false;
+
+      expect(mockDefinitions.getDirtyItems).not.toHaveBeenCalled();
+      expect(mockDefinitions.setTasks).not.toHaveBeenCalled();
+      expect(mockDefinitions.runAllTasks).not.toHaveBeenCalled();
     });
 
     it("should_setIsSyncingFalse_when_anErrorOccurred", async () => {

--- a/wls-gui-wahllokalsystem/tests/composables/indexDB/dataSyncer.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/indexDB/dataSyncer.spec.ts
@@ -90,6 +90,33 @@ describe("dataSyncer.ts", () => {
       await unitUnderTest.synchronizeOfflineData();
       expect(unitUnderTest.dirtyTasksAfterSync.value).toStrictEqual([]);
     });
+    it("should_updateDirtyTasksAfterSync_when_runAllTasksThrowError", async () => {
+      const dirtyTasks = [
+        {
+          key: "key1",
+          item: prepareIndexDBValue().data("data1").timestamp(9).build(),
+        },
+        {
+          key: "key2",
+          item: prepareIndexDBValue().data("2").timestamp(10).build(),
+        },
+      ];
+      mockDefinitions.getDirtyItems.mockResolvedValue(dirtyTasks);
+      mockDefinitions.runAllTasks.mockRejectedValue(
+        new Error("mocked task manager error")
+      );
+
+      expect(unitUnderTest.dirtyTasksAfterSync.value).toStrictEqual(null);
+      await unitUnderTest.synchronizeOfflineData();
+
+      const expectedTasks = [
+        { name: "key1", callback: expect.anything() },
+        { name: "key2", callback: expect.anything() },
+      ];
+      expect(unitUnderTest.dirtyTasksAfterSync.value).toStrictEqual(
+        expectedTasks
+      );
+    });
   });
 
   describe("hasDirtyTasksAfterSync", () => {


### PR DESCRIPTION
# Beschreibung:
- Implementierung Syncronisierung vor dem Abschluss
- OfflineSyncer etwas erweitert damit mehr Funktionalität im Composable liegt und die Nutzenden Komponenten weniger machen müssen
- Widget angepasst, da es jetzt komplett mit dem Store interagieren kann

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [X] [Naming Conventions][naming-conventions-link] beachtet
- [X] ~~Doku aktualisiert~~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] Unit-Tests gepflegt
- [X] Texte auf Rechtschreibung und Grammatik geprüft
- [X] ~~Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft~~

# Referenzen[^1]:

Verwandt mit Issue #

Closes #3015

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language
[database-init-script-doc-link]: https://it-at-m.github.io/Wahllokalsystem/technik/guides/user-data-cleanup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated offline synchronization step to ballot-recording completion, including a synchronization widget and updated confirm messaging.

* **Bug Fixes**
  * Completion is now blocked when unsynchronized dirty items remain.
  * Prevented duplicate/offline sync runs while a synchronization is already in progress.

* **UI/UX Updates**
  * Synchronization status is now driven by live store state (including remaining-dirty counts) across the relevant dialogs and widget.

* **Tests**
  * Expanded unit tests for sync result reporting, remaining-dirty calculations, and concurrent-sync protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->