### PR TITLE
3208 - Keine Notification bei Stimmzettel-Laden-Fehler in Taskfactory

### DIFF
--- a/wls-gui-wahllokalsystem/src/composables/tasks/taskFactories/dseStimmzettelTaskFactory.ts
+++ b/wls-gui-wahllokalsystem/src/composables/tasks/taskFactories/dseStimmzettelTaskFactory.ts
@@ -24,7 +24,8 @@ export function useDSEStimmzettelTaskFactory(): TaskFactory {
         getStimmzettel(
           taskFactoryMetaData.wahlID,
           taskFactoryMetaData.wahlbezirkID,
-          currentUserTeamName.value
+          currentUserTeamName.value,
+          false
         ),
       name: `Stimmzettel für ${taskFactoryMetaData.wahlName}`,
     };

--- a/wls-gui-wahllokalsystem/tests/composables/tasks/taskFactories/dseStimmzettelTaskFactory.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/tasks/taskFactories/dseStimmzettelTaskFactory.spec.ts
@@ -75,7 +75,8 @@ describe("dseStimmzettelTaskFactory.ts", () => {
       expect(mockDefinitions.getStimmzettel).toHaveBeenCalledWith(
         taskFactoryContext.extendedWahlMetaData[0].wahlID,
         taskFactoryContext.extendedWahlMetaData[0].wahlbezirkID,
-        teamID
+        teamID,
+        false
       );
       expect(result[0]?.name).toContain("Stimmzettel");
     });


### PR DESCRIPTION
# Beschreibung:

Keine Notification bei Stimmzettel-Laden-Fehler in Taskfactory.

## Definition of Done (DoD):

### Frontend
- [ ] ~[Naming Conventions][naming-conventions-link] beachtet~
- [ ] ~Doku aktualisiert~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [ ] Unit-Tests gepflegt
- [ ] ~Texte auf Rechtschreibung und Grammatik geprüft~
- [ ] ~Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft~

# Referenzen[^1]:

Closes #3208

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language
[database-init-script-doc-link]: https://it-at-m.github.io/Wahllokalsystem/technik/guides/user-data-cleanup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated ballot retrieval behavior to use the correct request parameters, improving task execution reliability.

* **Tests**
  * Updated automated coverage to verify the revised ballot retrieval request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->