### PR TITLE
2989 Initialisierung und Speichern des "registriert" Status bei Login - Fehler anzeigen

### DIFF
--- a/wls-gui-wahllokalsystem/src/composables/dse/stimmzettelerfassungTeamStatusUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/dse/stimmzettelerfassungTeamStatusUtils.ts
@@ -1,32 +1,43 @@
 import { storeToRefs } from "pinia";
 
 import { useStimmzettelerfassungTeamStatusService } from "@/composables/dse/stimmzettelerfassungTeamStatusService.ts";
+import { useUserNotificationService } from "@/composables/userNotification/userNotificationService.ts";
 import { useUserStore } from "@/stores/userStore.ts";
 import { StimmzettelerfassungTeamStatusEnum } from "@/types/dse/StimmzettelerfassungTeamStatusEnum.ts";
+import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
 
 export function useStimmzettelerfassungTeamStatusUtils() {
   const { loadErfassungTeamStatus, postErfassungTeamStatus } =
     useStimmzettelerfassungTeamStatusService();
   const { currentUserWahlMetadata, currentUserTeamName } =
     storeToRefs(useUserStore());
+  const { addNotification } = useUserNotificationService();
 
   async function initStimmzettelerfassungTeamStatus() {
-    for (const metadata of currentUserWahlMetadata.value) {
-      const teamStatus = await loadErfassungTeamStatus(
-        metadata.wahlID,
-        metadata.wahlbezirkID,
-        currentUserTeamName.value,
-        false
-      );
-      if (!teamStatus) {
-        await postErfassungTeamStatus(
+    try {
+      for (const metadata of currentUserWahlMetadata.value) {
+        const teamStatus = await loadErfassungTeamStatus(
           metadata.wahlID,
           metadata.wahlbezirkID,
           currentUserTeamName.value,
-          { status: StimmzettelerfassungTeamStatusEnum.REGISTRIERT },
           false
         );
+        if (!teamStatus) {
+          await postErfassungTeamStatus(
+            metadata.wahlID,
+            metadata.wahlbezirkID,
+            currentUserTeamName.value,
+            { status: StimmzettelerfassungTeamStatusEnum.REGISTRIERT },
+            false
+          );
+        }
       }
+    } catch (error) {
+      addNotification(
+        "Teamstatus konnte nicht initialisiert werden.",
+        UserNotificationCategoryEnum.ERROR
+      );
+      throw error;
     }
   }
 

--- a/wls-gui-wahllokalsystem/tests/composables/dse/stimmzettelerfassungTeamStatusUtils.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/dse/stimmzettelerfassungTeamStatusUtils.spec.ts
@@ -7,10 +7,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useStimmzettelerfassungTeamStatusUtils } from "@/composables/dse/stimmzettelerfassungTeamStatusUtils.ts";
 import { useUserStore } from "@/stores/userStore.ts";
 import { StimmzettelerfassungTeamStatusEnum } from "@/types/dse/StimmzettelerfassungTeamStatusEnum.ts";
+import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
 
 const mockDefinitions = vi.hoisted(() => ({
   loadErfassungTeamStatus: vi.fn(),
   postErfassungTeamStatus: vi.fn(),
+  addNotification: vi.fn(),
 }));
 
 vi.mock(
@@ -22,6 +24,19 @@ vi.mock(
         ...mod.useStimmzettelerfassungTeamStatusService(),
         loadErfassungTeamStatus: mockDefinitions.loadErfassungTeamStatus,
         postErfassungTeamStatus: mockDefinitions.postErfassungTeamStatus,
+      }),
+    };
+  }
+);
+
+vi.mock(
+  import("@/composables/userNotification/userNotificationService.ts"),
+  async (importOriginal) => {
+    const mod = await importOriginal();
+    return {
+      useUserNotificationService: () => ({
+        ...mod.useUserNotificationService(),
+        addNotification: mockDefinitions.addNotification,
       }),
     };
   }
@@ -80,6 +95,7 @@ describe("stimmzettelerfassungTeamStatusUtils.ts", () => {
         { status: StimmzettelerfassungTeamStatusEnum.REGISTRIERT },
         false,
       ]);
+      expect(mockDefinitions.addNotification).not.toHaveBeenCalled();
     });
 
     it("should_notPostTeamStatus_when_loadedStatusIsPressent", async () => {
@@ -99,6 +115,7 @@ describe("stimmzettelerfassungTeamStatusUtils.ts", () => {
       expect(
         mockDefinitions.postErfassungTeamStatus.mock.calls.length
       ).toStrictEqual(0);
+      expect(mockDefinitions.addNotification).not.toHaveBeenCalled();
     });
 
     it("should_postTeamStatusForEveryWahl_when_loadedStatusIsEmptyforEveryWahl", async () => {
@@ -116,6 +133,53 @@ describe("stimmzettelerfassungTeamStatusUtils.ts", () => {
       expect(
         mockDefinitions.postErfassungTeamStatus.mock.calls.length
       ).toStrictEqual(2);
+      expect(mockDefinitions.addNotification).not.toHaveBeenCalled();
+    });
+
+    it("should_throwErrorAndSendUserNotification_when_loadingOfTeamStatusFailed", async () => {
+      const { currentUserWahlMetadata, currentUserTeamName } =
+        storeToRefs(useUserStore());
+      // @ts-expect-error: cannot set readonly
+      currentUserWahlMetadata.value = [wahlMedata];
+      // @ts-expect-error: cannot set readonly
+      currentUserTeamName.value = teamName;
+
+      const mockedLoadingError = new Error("mocked loading error");
+      mockDefinitions.loadErfassungTeamStatus.mockRejectedValue(
+        mockedLoadingError
+      );
+
+      await expect(
+        unitUnderTest.initStimmzettelerfassungTeamStatus()
+      ).rejects.toThrowError(mockedLoadingError);
+      expect(mockDefinitions.addNotification).toHaveBeenCalledExactlyOnceWith(
+        expect.any(String),
+        UserNotificationCategoryEnum.ERROR
+      );
+    });
+
+    it("should_throwErrorAndSendUserNotification_when_sendingOfTeamStatusFailed", async () => {
+      const { currentUserWahlMetadata, currentUserTeamName } =
+        storeToRefs(useUserStore());
+      // @ts-expect-error: cannot set readonly
+      currentUserWahlMetadata.value = [wahlMedata];
+      // @ts-expect-error: cannot set readonly
+      currentUserTeamName.value = teamName;
+
+      mockDefinitions.loadErfassungTeamStatus.mockReturnValue(null);
+
+      const mockedLoadingError = new Error("mocked loading error");
+      mockDefinitions.postErfassungTeamStatus.mockRejectedValue(
+        mockedLoadingError
+      );
+
+      await expect(
+        unitUnderTest.initStimmzettelerfassungTeamStatus()
+      ).rejects.toThrowError(mockedLoadingError);
+      expect(mockDefinitions.addNotification).toHaveBeenCalledExactlyOnceWith(
+        expect.any(String),
+        UserNotificationCategoryEnum.ERROR
+      );
     });
   });
 });


### PR DESCRIPTION
# Beschreibung:

- wenn beim Laden oder Speichern im Rahmen der Initialisierung ein Fehler auftritt wird das dem User gezeigt

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [X] ~~Doku aktualisiert~~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] Unit-Tests gepflegt
- [X] Texte auf Rechtschreibung und Grammatik geprüft
- [X] Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft

# Referenzen[^1]:

Verwandt mit Issue #

Closes #2989

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language
[database-init-script-doc-link]: https://it-at-m.github.io/Wahllokalsystem/technik/guides/user-data-cleanup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a visible error notification when team status initialization fails.
  * Initialization errors are now properly surfaced instead of being silently handled.

* **Tests**
  * Added coverage for successful initialization without notifications.
  * Added coverage for error notifications and error propagation during loading and status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->