### PR TITLE
3211 - fix defektes Laden von Schulungsunterlagen aus der IndexedDB

### DIFF
--- a/wls-gui-wahllokalsystem/src/composables/api/requestStrategies.ts
+++ b/wls-gui-wahllokalsystem/src/composables/api/requestStrategies.ts
@@ -173,7 +173,7 @@ export function useRequestStrategies() {
   ): ArrayBuffer | string | null {
     let dataToStore: ArrayBuffer | string | null = null;
     if (contentType && isPdfContext(contentType)) {
-      dataToStore = responseBody;
+      dataToStore = responseBody.byteLength > 0 ? responseBody : null;
     } else if (contentType && isTextContext(contentType)) {
       dataToStore = _arrayBufferToString(responseBody);
     } else {

--- a/wls-gui-wahllokalsystem/src/composables/crypto/cryptoUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/crypto/cryptoUtils.ts
@@ -1,17 +1,19 @@
 export function useCryptoUtils() {
   const algorithm = { name: "AES-GCM", iv: new Uint8Array(16) };
 
-  async function encrypt(data: string | undefined, key: CryptoKey | null) {
+  async function encrypt(data: string | ArrayBuffer, key: CryptoKey | null) {
     if (!key) {
       throw new Error(
         "Verschlüsselung kann ohne CryptoKey nicht durchgeführt werden."
       );
     }
-    return await crypto.subtle.encrypt(
-      algorithm,
-      key,
-      new TextEncoder().encode(data)
-    );
+    let bufferToEncrypt: BufferSource | undefined;
+    if (typeof data === "string") {
+      bufferToEncrypt = new TextEncoder().encode(data);
+    } else {
+      bufferToEncrypt = data;
+    }
+    return await crypto.subtle.encrypt(algorithm, key, bufferToEncrypt);
   }
 
   async function decrypt(
@@ -29,11 +31,9 @@ export function useCryptoUtils() {
     } else {
       dataBuffer = data ?? new ArrayBuffer();
     }
-    const result =
-      dataBuffer.byteLength === 0
-        ? new ArrayBuffer()
-        : await crypto.subtle.decrypt(algorithm, key, dataBuffer);
-    return new TextDecoder("utf-8").decode(result);
+    return dataBuffer.byteLength === 0
+      ? new ArrayBuffer()
+      : await crypto.subtle.decrypt(algorithm, key, dataBuffer);
   }
 
   async function importKey(password: string) {

--- a/wls-gui-wahllokalsystem/src/composables/indexDB/indexDB.ts
+++ b/wls-gui-wahllokalsystem/src/composables/indexDB/indexDB.ts
@@ -100,7 +100,7 @@ export const useIndexDB = () => {
           } else {
             await localforage.setItem(key, {
               ...data,
-              data: await encrypt(data.data?.toString(), this.cryptoKey),
+              data: await encrypt(data.data, this.cryptoKey),
             });
           }
         } catch (error) {

--- a/wls-gui-wahllokalsystem/tests/composables/crypto/cryptoUtils.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/crypto/cryptoUtils.spec.ts
@@ -75,7 +75,7 @@ describe("cryptoUtils.ts", () => {
       vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(mockDecryptedData);
 
       const result = await decrypt(mockEncryptedData, key);
-      expect(result).toBe("Hello, World!");
+      expect(result).toEqual(new TextEncoder().encode("Hello, World!").buffer);
       expect(crypto.subtle.decrypt).toHaveBeenCalledWith(
         { name: "AES-GCM", iv: new Uint8Array(16) },
         key,
@@ -93,9 +93,8 @@ describe("cryptoUtils.ts", () => {
       vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(mockDecryptedData);
 
       const result = await decrypt(mockEncryptedData, key);
-      expect(result).toBe("");
+      expect(result).toEqual(new TextEncoder().encode("").buffer);
       expect(crypto.subtle.decrypt).not.toHaveBeenCalled();
-      expect(mockDecoder.decode).toHaveBeenCalledWith(new ArrayBuffer(0));
     });
 
     it("should_throwAnError_when_cryptoKeyIsMissing", async () => {


### PR DESCRIPTION
# Beschreibung:

- Ursache war dass an Stelle der Daten to-String von ArrayBuffer, `[object ArrayBuffer]`, in der IndexedDB landete.
- manuell den erfolg verifiziert, sowohl für das Handbuch als auch für die anderen Daten in der Anwendung

# ‼️PostMerge
- Nachricht in Chat damit WLS-Nutzer indexedDB leeren, z.B. durch Verwendung eines anderen Benutzers

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [X] ~~Doku aktualisiert~~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] Unit-Tests gepflegt
- [X] ~~Texte auf Rechtschreibung und Grammatik geprüft~~
- [x] ~~Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft~~

# Referenzen[^1]:

Verwandt mit Issue #

Closes #3211 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language
[database-init-script-doc-link]: https://it-at-m.github.io/Wahllokalsystem/technik/guides/user-data-cleanup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of encrypted binary data, including PDFs and other non-text content.
  * Empty PDF responses are now represented consistently as empty values.
  * Decrypted data is preserved in its original binary format instead of being converted to text.

* **Tests**
  * Updated encryption and decryption coverage for binary and empty data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->