### PR TITLE
Fix: 4 Zeichen für Ordnungszahlspalte bei gütligen Stimmen darstellbar

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/ergebnismeldung/MBW/stapelAB/TheMBWGueltigeStimmzettelErfassenTable.vue
+++ b/wls-gui-wahllokalsystem/src/components/ergebnismeldung/MBW/stapelAB/TheMBWGueltigeStimmzettelErfassenTable.vue
@@ -3,7 +3,7 @@
     <v-table>
       <thead>
         <tr>
-          <th />
+          <th class="ordnungszahlCell" />
           <th class="font-weight-bold text-center">Wahlvorschlag</th>
           <th class="font-weight-bold text-center">
             Stapel a: Wahlvorschlag unverändert gekennzeichnet
@@ -84,3 +84,9 @@ const totalSum = computed(() => {
   return total;
 });
 </script>
+
+<style scoped>
+.ordnungszahlCell {
+  min-width: 4rem;
+}
+</style>


### PR DESCRIPTION
# Beschreibung:
- Behoben wird das Problem das auf dem Zielgerät ungewollte [Zeilenumbrüche auftauchen](https://git.muenchen.de/wls-3.0/management/-/work_items/77)
- zum nachstellen benötigt man eine Auflösung im Bereich large [1280; 1920[
- es lassen sich bei einer 3-stelligen Ordnungszahl erfolgt erst der Umbruch

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] ~~[Naming Conventions][naming-conventions-link] beachtet~~
- [X] ~~Doku aktualisiert~~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [X] ~~Unit-Tests gepflegt~~
- [X] ~~Texte auf Rechtschreibung und Grammatik geprüft~~
- [X] ~~Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft~~

# Referenzen[^1]:

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language
[database-init-script-doc-link]: https://it-at-m.github.io/Wahllokalsystem/technik/guides/user-data-cleanup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout of the valid ballot entry table by applying consistent styling to the first header cell.
  * Ensured the header cell maintains a minimum width for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->