### PR TITLE
3314 Wahlbeteiligung kommt unvollständig an die EAI

### DIFF
--- a/wls-monitoring-service/src/main/java/de/muenchen/oss/wahllokalsystem/monitoringservice/client/waehleranzahl/WaehleranzahlClientMapper.java
+++ b/wls-monitoring-service/src/main/java/de/muenchen/oss/wahllokalsystem/monitoringservice/client/waehleranzahl/WaehleranzahlClientMapper.java
@@ -14,7 +14,7 @@ public interface WaehleranzahlClientMapper {
 
   ZoneId DEFAULT_ZONE_ID = ZoneId.systemDefault();
 
-  @Mapping(target = "wahlID", ignore = true)
+  @Mapping(target = "wahlID", source = "bezirkUndWahlID.wahlID")
   @Mapping(target = "wahlbezirkID", source = "bezirkUndWahlID.wahlbezirkID")
   @Mapping(target = "meldeZeitpunkt", source = "uhrzeit")
   WahlbeteiligungsMeldungDTO fromModelToRemoteClientDTO(WaehleranzahlModel waehleranzahlModel);

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/client/waehleranzahl/WaehleranzahlClientMapperTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/client/waehleranzahl/WaehleranzahlClientMapperTest.java
@@ -37,7 +37,7 @@ public class WaehleranzahlClientMapperTest {
 
       val expectedWahlbeteiligungsMeldungDTO =
           new WahlbeteiligungsMeldungDTO()
-              .wahlID(null)
+              .wahlID(wahlID)
               .wahlbezirkID(wahlbezirkID)
               .anzahlWaehler(anzahlWahler)
               .meldeZeitpunkt(meldeZeitpunkt);


### PR DESCRIPTION
# Beschreibung:

ignore für wahlID entfernt

# Referenzen[^1]:

Closes #3314

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language
[database-init-script-doc-link]: https://it-at-m.github.io/Wahllokalsystem/technik/guides/user-data-cleanup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected voter turnout data mapping so the election ID is now transmitted accurately.
  - Prevents election ID information from being omitted in monitoring-related data exchanges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->