### PR TITLE
2925 logout interupted on postletzteabmeldung error

### DIFF
--- a/wls-monitoring-service/src/main/java/de/muenchen/oss/wahllokalsystem/monitoringservice/client/common/DummyClientImpl.java
+++ b/wls-monitoring-service/src/main/java/de/muenchen/oss/wahllokalsystem/monitoringservice/client/common/DummyClientImpl.java
@@ -37,7 +37,7 @@ public class DummyClientImpl implements WaehleranzahlClient, WahllokalZustandCli
 
   @Override
   public void postLetzteAbmeldung(
-      String wahlbezirkID, final String teamID, LocalDateTime letzteAbmeldung) throws WlsException {
+      String wahlbezirkID, final String teamID, LocalDateTime letzteAbmeldung) {
     log.info(
         "Dummy client postLetzteAbmeldung() called instead of EAI with: "
             + wahlbezirkID

--- a/wls-monitoring-service/src/main/java/de/muenchen/oss/wahllokalsystem/monitoringservice/client/wahllokalzustand/WahllokalZustandClientImpl.java
+++ b/wls-monitoring-service/src/main/java/de/muenchen/oss/wahllokalsystem/monitoringservice/client/wahllokalzustand/WahllokalZustandClientImpl.java
@@ -48,15 +48,12 @@ public class WahllokalZustandClientImpl implements WahllokalZustandClient {
 
   @Override
   public void postLetzteAbmeldung(
-      String wahlbezirkID, final String teamID, final LocalDateTime letzteAbmeldung)
-      throws WlsException {
+      String wahlbezirkID, final String teamID, final LocalDateTime letzteAbmeldung) {
     try {
       wahllokalzustandControllerApi.saveWahllokalZustandLetzteAbmeldung(
           wahlbezirkID, teamID, letzteAbmeldung);
     } catch (final Exception exception) {
-      log.info("Letzte Abmeldung nicht gesendet. Exception: {}", exception.getMessage());
-      throw exceptionFactory.createTechnischeWlsException(
-          ExceptionConstants.FAILED_COMMUNICATION_WITH_EAI);
+      log.warn("Letzte Abmeldung nicht gesendet. Exception: {}", exception.getMessage());
     }
   }
 

--- a/wls-monitoring-service/src/main/java/de/muenchen/oss/wahllokalsystem/monitoringservice/service/wahllokalzustand/WahllokalZustandClient.java
+++ b/wls-monitoring-service/src/main/java/de/muenchen/oss/wahllokalsystem/monitoringservice/service/wahllokalzustand/WahllokalZustandClient.java
@@ -20,11 +20,9 @@ public interface WahllokalZustandClient {
    * @param wahlbezirkID the id of the election room;
    * @param teamID id of the team;
    * @param letzteAbmeldung containing the information about the last time the room has logged out.
-   * @throws WlsException {@link TechnischeWlsException} if there were trouble during communication
    */
   void postLetzteAbmeldung(
-      final String wahlbezirkID, final String teamID, final LocalDateTime letzteAbmeldung)
-      throws WlsException;
+      final String wahlbezirkID, final String teamID, final LocalDateTime letzteAbmeldung);
 
   /**
    * @param bezirkUndWahlID composed identification of election ID and election room

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/client/wahllokalzustand/WahllokalZustandClientImplTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/client/wahllokalzustand/WahllokalZustandClientImplTest.java
@@ -86,25 +86,22 @@ class WahllokalZustandClientImplTest {
     }
 
     @Test
-    void should_throwTechnischeWlsException_when_eaiApiThrowsAnyException() {
+    void should_completeNormallyAndLogWarning_when_eaiApiThrowsAnyException() {
       val wahlbezirkID = "wahlbezirkID01";
       val teamID = "B";
       val zeitpunkt = LocalDateTime.now();
-
-      val mockedWlsException = TechnischeWlsException.withCode("007").buildWithMessage("Dummy-Msg");
-      Mockito.when(
-              exceptionFactory.createTechnischeWlsException(
-                  ExceptionConstants.FAILED_COMMUNICATION_WITH_EAI))
-          .thenReturn(mockedWlsException);
 
       val mockedApiException = new IllegalArgumentException("Nix-Connect");
       Mockito.doThrow(mockedApiException)
           .when(wahllokalzustandControllerApi)
           .saveWahllokalZustandLetzteAbmeldung(any(), any(), any());
-
-      Assertions.assertThatThrownBy(
-              () -> unitUnderTest.postLetzteAbmeldung(wahlbezirkID, teamID, zeitpunkt))
-          .isSameAs(mockedWlsException);
+      Assertions.assertThatNoException()
+          .isThrownBy(() -> unitUnderTest.postLetzteAbmeldung(wahlbezirkID, teamID, zeitpunkt));
+      Assertions.assertThat(
+              loggerExtension
+                  .getLoggedEventsStream()
+                  .filter(event -> event.getLevel() == Level.WARN)
+                  .count()).isEqualTo(1L);
     }
   }
 

--- a/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/client/wahllokalzustand/WahllokalZustandClientImplTest.java
+++ b/wls-monitoring-service/src/test/java/de/muenchen/oss/wahllokalsystem/monitoringservice/client/wahllokalzustand/WahllokalZustandClientImplTest.java
@@ -101,7 +101,8 @@ class WahllokalZustandClientImplTest {
               loggerExtension
                   .getLoggedEventsStream()
                   .filter(event -> event.getLevel() == Level.WARN)
-                  .count()).isEqualTo(1L);
+                  .count())
+          .isEqualTo(1L);
     }
   }
 


### PR DESCRIPTION
# Beschreibung:

Error bei postLetzteAbmeldung vor der Abmeldung als Warning loggen. Es wird keine Exception mehr geworfen, da sonst wenn EAI defekt, User sich nicht mehr ausloggen kann.

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [x] Doku aktualisiert
- [x] Swagger-API vollständig
- [x] Unit-Tests gepflegt
- [x] Integrationstests gepflegt
- [x] Beispiel-Requests gepflegt
- [x] Bei Datenbankänderungen [database-init-Skript][database-init-script-doc-link] gepflegt
- [x] Texte auf Rechtschreibung und Grammatik geprüft

# Referenzen[^1]:

Verwandt mit Issue #

Closes #2925 

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language
[database-init-script-doc-link]: https://it-at-m.github.io/Wahllokalsystem/technik/guides/user-data-cleanup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of failures when reporting a polling-station sign-off.
  * Communication errors are now logged as warnings without interrupting the surrounding process or propagating an exception.

* **Tests**
  * Updated validation to confirm failures are handled quietly and generate the expected warning log.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->