### PR TITLE
838 archunit rule tests in wls common ausführen

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -246,10 +246,6 @@ export default withMermaid({
             },
             { text: "Mock-Server", link: `${PATH_GUIDES}mock-server.md` },
             {
-              text: "ArchUnit Rules Testen",
-              link: `${PATH_GUIDES}archunit-rule-tests.md`,
-            },
-            {
               text: "Aktualisierung von Images",
               link: `${PATH_GUIDES}update-images.md`,
             },

--- a/docs/src/technik/guides/archunit-rule-tests.md
+++ b/docs/src/technik/guides/archunit-rule-tests.md
@@ -1,4 +1,0 @@
-# Testen der ArchUnit Rules
-
-Um sicherzustellen, dass die in `wls-common` definierten ArchUnit Rules auch korrekt implementiert wurden, werden diese
-separat getestet.

--- a/docs/src/technik/guides/archunit-rule-tests.md
+++ b/docs/src/technik/guides/archunit-rule-tests.md
@@ -2,14 +2,3 @@
 
 Um sicherzustellen, dass die in `wls-common` definierten ArchUnit Rules auch korrekt implementiert wurden, werden diese
 separat getestet.
-
-## Bekanntes Problem
-
-Um einen der Tests zur Verifizierung von ArchUnit Rules auszuführen, kann dieser zum aktuellen Zeitpunkt nicht über den
-play-button in der IDE gestartet werden, da dies zu einem Fehler _"No tests were found"_ führt.
-
-Um also die Verifizierungstests laufen lassen zu können, muss stattdessen `mvn test` ausgeführt werden.
-
-::: info
-🚧 dieses Verhalten wird mit [Issue #838](https://github.com/it-at-m/Wahllokalsystem/issues/838) geklärt.
-:::

--- a/wls-common/testing/pom.xml
+++ b/wls-common/testing/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>com.tngtech.archunit</groupId>
-            <artifactId>archunit-junit5</artifactId>
+            <artifactId>archunit-junit5-api</artifactId>
             <version>1.5.0</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
# Beschreibung:

- Dependency angepasst

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] ~~[Naming Conventions][naming-conventions-link] beachtet~~
- [X] Doku aktualisiert
- [X] ~~Swagger-API vollständig~~
- [X] ~~Unit-Tests gepflegt~~
- [X] ~~Integrationstests gepflegt~~
- [X] ~~Beispiel-Requests gepflegt~~
- [X] ~~Bei Datenbankänderungen [database-init-Skript][database-init-script-doc-link] gepflegt~~
- [X] ~~Texte auf Rechtschreibung und Grammatik geprüft~~

# Referenzen[^1]:

Closes #838

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language
[database-init-script-doc-link]: https://it-at-m.github.io/Wahllokalsystem/technik/guides/user-data-cleanup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the “Known Issue” section covering ArchUnit test execution.

* **Bug Fixes**
  * Updated the ArchUnit test dependency to use the API artifact, improving compatibility for test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->