### PR TITLE
3336 verhalten des beschlussfassung starten buttons

### DIFF
--- a/wls-gui-wahllokalsystem/src/composables/dse/monitoringViewUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/dse/monitoringViewUtils.ts
@@ -16,7 +16,6 @@ export function useMonitoringViewUtils(wahlID: string, wahlbezirkID: string) {
   const workflowStatus = ref<StimmzettelerfassungStatus | null>(null);
 
   const erfassungTeamStatusService = useStimmzettelerfassungTeamStatusService();
-  const userNotificationService = useUserNotificationService();
   const { loadDseWorkflowStatus } = useDseWorkflowStatusService();
 
   async function onMonitoringSynchronisierenClicked() {
@@ -24,25 +23,17 @@ export function useMonitoringViewUtils(wahlID: string, wahlbezirkID: string) {
   }
 
   onActivated(async () => {
-    try {
-      await _loadTeamStatusListe(false);
-    } catch {
-      userNotificationService.addNotification(
-        `Team-Status konnten nicht initialisiert werden.`,
-        UserNotificationCategoryEnum.ERROR
-      );
-    }
-    await _loadWorkflowStatus();
+    await Promise.allSettled([_loadTeamStatusListe(), _loadWorkflowStatus()]);
   });
 
-  async function _loadTeamStatusListe(sendNotification = true) {
+  async function _loadTeamStatusListe() {
     try {
       isAktualisierenLoading.value = true;
       const loaded =
         await erfassungTeamStatusService.loadErfassungTeamStatusListe(
           wahlID,
           wahlbezirkID,
-          sendNotification
+          true
         );
       if (loaded) {
         teamstatusList.value = loaded;
@@ -59,7 +50,7 @@ export function useMonitoringViewUtils(wahlID: string, wahlbezirkID: string) {
       workflowStatus.value = await loadDseWorkflowStatus(
         wahlID,
         wahlbezirkID,
-        false
+        true
       );
     } finally {
       isWorkflowStatusLoading.value = false;

--- a/wls-gui-wahllokalsystem/src/composables/dse/monitoringViewUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/dse/monitoringViewUtils.ts
@@ -5,8 +5,6 @@ import { onActivated, ref } from "vue";
 
 import { useDseWorkflowStatusService } from "@/composables/dse/dseWorkflowStatusService.ts";
 import { useStimmzettelerfassungTeamStatusService } from "@/composables/dse/stimmzettelerfassungTeamStatusService.ts";
-import { useUserNotificationService } from "@/composables/userNotification/userNotificationService.ts";
-import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
 
 export function useMonitoringViewUtils(wahlID: string, wahlbezirkID: string) {
   const teamstatusList = ref<StimmzettelerfassungTeamStatusEntry[]>([]);

--- a/wls-gui-wahllokalsystem/src/composables/dse/monitoringViewUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/dse/monitoringViewUtils.ts
@@ -12,6 +12,7 @@ export function useMonitoringViewUtils(wahlID: string, wahlbezirkID: string) {
   const teamstatusList = ref<StimmzettelerfassungTeamStatusEntry[]>([]);
   const lastLoading = ref<Date>();
   const isAktualisierenLoading = ref(false);
+  const isWorkflowStatusLoading = ref(false);
   const workflowStatus = ref<StimmzettelerfassungStatus | null>(null);
 
   const erfassungTeamStatusService = useStimmzettelerfassungTeamStatusService();
@@ -31,11 +32,7 @@ export function useMonitoringViewUtils(wahlID: string, wahlbezirkID: string) {
         UserNotificationCategoryEnum.ERROR
       );
     }
-    workflowStatus.value = await loadDseWorkflowStatus(
-      wahlID,
-      wahlbezirkID,
-      false
-    );
+    await _loadWorkflowStatus();
   });
 
   async function _loadTeamStatusListe(sendNotification = true) {
@@ -56,10 +53,24 @@ export function useMonitoringViewUtils(wahlID: string, wahlbezirkID: string) {
     }
   }
 
+  async function _loadWorkflowStatus() {
+    isWorkflowStatusLoading.value = true;
+    try {
+      workflowStatus.value = await loadDseWorkflowStatus(
+        wahlID,
+        wahlbezirkID,
+        false
+      );
+    } finally {
+      isWorkflowStatusLoading.value = false;
+    }
+  }
+
   return {
     teamstatusList,
     lastLoading,
     isAktualisierenLoading,
+    isWorkflowStatusLoading,
     workflowStatus,
     onMonitoringSynchronisierenClicked,
   };

--- a/wls-gui-wahllokalsystem/src/composables/dse/monitoringViewUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/dse/monitoringViewUtils.ts
@@ -11,7 +11,7 @@ import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotif
 export function useMonitoringViewUtils(wahlID: string, wahlbezirkID: string) {
   const teamstatusList = ref<StimmzettelerfassungTeamStatusEntry[]>([]);
   const lastLoading = ref<Date>();
-  const isAktualisiserenLoading = ref(false);
+  const isAktualisierenLoading = ref(false);
   const workflowStatus = ref<StimmzettelerfassungStatus | null>(null);
 
   const erfassungTeamStatusService = useStimmzettelerfassungTeamStatusService();
@@ -40,7 +40,7 @@ export function useMonitoringViewUtils(wahlID: string, wahlbezirkID: string) {
 
   async function _loadTeamStatusListe(sendNotification = true) {
     try {
-      isAktualisiserenLoading.value = true;
+      isAktualisierenLoading.value = true;
       const loaded =
         await erfassungTeamStatusService.loadErfassungTeamStatusListe(
           wahlID,
@@ -52,14 +52,14 @@ export function useMonitoringViewUtils(wahlID: string, wahlbezirkID: string) {
         lastLoading.value = new Date();
       }
     } finally {
-      isAktualisiserenLoading.value = false;
+      isAktualisierenLoading.value = false;
     }
   }
 
   return {
     teamstatusList,
     lastLoading,
-    isAktualisiserenLoading,
+    isAktualisierenLoading,
     workflowStatus,
     onMonitoringSynchronisierenClicked,
   };

--- a/wls-gui-wahllokalsystem/src/views/dse/MonitoringView.vue
+++ b/wls-gui-wahllokalsystem/src/views/dse/MonitoringView.vue
@@ -54,10 +54,20 @@
           @click="onMonitoringSynchronisierenClicked"
         />
         <base-text-button
-          :active="beschlussfassungStartenBtnActive"
+          v-if="isBeschlussfassungStartenBtnVisible"
+          :active="beschlussfassungBtnActive"
           :is-disabled="isBeschlussfassungStartenBtnDisabled"
+          :loading="isWorkflowStatusLoading"
           @click="onBeschlussfassungStartenClicked"
           >Beschlussfassung starten</base-text-button
+        >
+        <base-text-button
+          v-if="isBeschlussfassungContinueBtnVisible"
+          :active="beschlussfassungBtnActive"
+          :is-disabled="isBeschlussfassungContinueBtnDisabled"
+          :loading="isWorkflowStatusLoading"
+          @click="onBeschlussfassungContinueClicked"
+          >Beschlussfassung fortsetzen</base-text-button
         >
       </v-card-actions>
     </v-card>
@@ -80,8 +90,10 @@ import BaseProgressLinear from "@/components/common/progressLinear/BaseProgressL
 import BaseTeamStatusListItem from "@/components/dse/BaseTeamStatusListItem.vue";
 import TheBeschlussfassungStartenDialog from "@/components/dse/TheBeschlussfassungStartenDialog.vue";
 import { useMonitoringViewUtils } from "@/composables/dse/monitoringViewUtils.ts";
+import router from "@/plugins/router.ts";
 import { StimmzettelerfassungStatusEnum } from "@/types/dse/StimmzettelerfassungStatusEnum.ts";
 import { StimmzettelerfassungTeamStatusEnum } from "@/types/dse/StimmzettelerfassungTeamStatusEnum.ts";
+import { DseStepsEnum } from "@/types/navigation/DseStepsEnum.ts";
 
 const minWidth = "220px";
 const beschlussfassungStartenDialogVisible = ref(false);
@@ -94,25 +106,48 @@ const {
   teamstatusList,
   lastLoading,
   isAktualisierenLoading,
+  isWorkflowStatusLoading,
   workflowStatus,
   onMonitoringSynchronisierenClicked,
 } = useMonitoringViewUtils(wahlID, wahlbezirkID);
 
-const beschlussfassungStartenBtnActive = computed(() =>
+const beschlussfassungBtnActive = computed(() =>
   teamstatusList.value.every(
     (team) => team.status === StimmzettelerfassungTeamStatusEnum.ABGESCHLOSSEN
   )
 );
+
+const isBeschlussfassungContinueBtnDisabled = computed(
+  () =>
+    !beschlussfassungBtnActive.value ||
+    workflowStatus.value?.status !==
+      StimmzettelerfassungStatusEnum.SteAbgeschlossen ||
+    isAktualisierenLoading.value ||
+    isWorkflowStatusLoading.value
+);
+
+const isBeschlussfassungContinueBtnVisible = computed(
+  () =>
+    workflowStatus.value?.status !==
+    StimmzettelerfassungStatusEnum.SteBearbeitung
+);
+
 const isBeschlussfassungStartenBtnDisabled = computed(
   () =>
-    !beschlussfassungStartenBtnActive.value ||
+    !beschlussfassungBtnActive.value ||
     workflowStatus.value?.status !==
       StimmzettelerfassungStatusEnum.SteBearbeitung ||
-    isAktualisierenLoading.value
+    isAktualisierenLoading.value ||
+    isWorkflowStatusLoading.value
 );
-const isRefreshBtnActive = computed(
-  () => !beschlussfassungStartenBtnActive.value
+
+const isBeschlussfassungStartenBtnVisible = computed(
+  () =>
+    workflowStatus.value?.status ===
+    StimmzettelerfassungStatusEnum.SteBearbeitung
 );
+
+const isRefreshBtnActive = computed(() => !beschlussfassungBtnActive.value);
 
 const totalNumberOfTeams = computed(() => teamstatusList.value.length);
 
@@ -121,6 +156,13 @@ const abgeschlossenNumberOfTeams = computed(() => {
     (team) => team.status === StimmzettelerfassungTeamStatusEnum.ABGESCHLOSSEN
   ).length;
 });
+
+async function onBeschlussfassungContinueClicked() {
+  await router.push({
+    name: DseStepsEnum.DSE_BESCHLUSSFASSUNG,
+    params: { wahlId: wahlID, wahlbezirkId: wahlbezirkID },
+  });
+}
 
 async function onBeschlussfassungStartenClicked() {
   beschlussfassungStartenDialogVisible.value = true;

--- a/wls-gui-wahllokalsystem/src/views/dse/MonitoringView.vue
+++ b/wls-gui-wahllokalsystem/src/views/dse/MonitoringView.vue
@@ -12,7 +12,7 @@
           titel="Stimmzettelerfassung abgeschlossen"
           titel-class="d-flex align-center justify-center"
           data-test="base-progress-success"
-          :is-loading="isAktualisiserenLoading"
+          :is-loading="isAktualisierenLoading"
           :current="abgeschlossenNumberOfTeams"
           :total="totalNumberOfTeams"
           color="success"
@@ -50,7 +50,7 @@
       <v-card-actions>
         <base-button-refresh
           :active="isRefreshBtnActive"
-          :loading="isAktualisiserenLoading"
+          :loading="isAktualisierenLoading"
           @click="onMonitoringSynchronisierenClicked"
         />
         <base-text-button
@@ -93,7 +93,7 @@ const wahlbezirkID = (route.params.wahlbezirkId as string) || "";
 const {
   teamstatusList,
   lastLoading,
-  isAktualisiserenLoading,
+  isAktualisierenLoading,
   workflowStatus,
   onMonitoringSynchronisierenClicked,
 } = useMonitoringViewUtils(wahlID, wahlbezirkID);

--- a/wls-gui-wahllokalsystem/src/views/dse/MonitoringView.vue
+++ b/wls-gui-wahllokalsystem/src/views/dse/MonitoringView.vue
@@ -107,7 +107,8 @@ const isBeschlussfassungStartenBtnDisabled = computed(
   () =>
     !beschlussfassungStartenBtnActive.value ||
     workflowStatus.value?.status !==
-      StimmzettelerfassungStatusEnum.SteBearbeitung
+      StimmzettelerfassungStatusEnum.SteBearbeitung ||
+    isAktualisierenLoading.value
 );
 const isRefreshBtnActive = computed(
   () => !beschlussfassungStartenBtnActive.value

--- a/wls-gui-wahllokalsystem/tests/composables/dse/monitoringViewUtils.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/dse/monitoringViewUtils.spec.ts
@@ -74,6 +74,7 @@ describe("monitoringViewUtils.ts", () => {
     expect(unit.teamstatusList.value).toEqual([]);
     expect(unit.lastLoading.value).toBeUndefined();
     expect(unit.isAktualisierenLoading.value).toBe(false);
+    expect(unit.isWorkflowStatusLoading.value).toBe(false);
     expect(unit.workflowStatus.value).toBe(null);
   });
 
@@ -111,7 +112,13 @@ describe("monitoringViewUtils.ts", () => {
     const workflowStatus = createStimmzettelerfassungStatus();
     mockDefinitions.loadErfassungTeamStatusListe.mockResolvedValue(sample);
     mockDefinitions.loadDseWorkflowStatus.mockResolvedValue(workflowStatus);
+    const spyOnIsWorkflowStatusLoading = vi.spyOn(
+      unit.isWorkflowStatusLoading,
+      "value",
+      "set"
+    );
 
+    expect(unit.isWorkflowStatusLoading.value).toStrictEqual(false);
     await mockDefinitions.runActivatedCallbacks();
 
     expect(mockDefinitions.addNotification).not.toHaveBeenCalled();
@@ -124,6 +131,11 @@ describe("monitoringViewUtils.ts", () => {
       wahlbezirkID,
       false
     );
+    expect(spyOnIsWorkflowStatusLoading.mock.calls).toStrictEqual([
+      [true],
+      [false],
+    ]);
+    spyOnIsWorkflowStatusLoading.mockRestore();
   });
 
   it("should_loadTeamStatusListeAndShowError_when_onActivatedCalledWithFailure", async () => {

--- a/wls-gui-wahllokalsystem/tests/composables/dse/monitoringViewUtils.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/dse/monitoringViewUtils.spec.ts
@@ -2,7 +2,6 @@ import { useStimmzettelerfassungStatusTestDataFactory } from "@tests/utils/dse/S
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useMonitoringViewUtils } from "@/composables/dse/monitoringViewUtils.ts";
-import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
 
 const mockDefinitions = await vi.hoisted(async () => {
   const { ref } = await import("vue");
@@ -19,7 +18,6 @@ const mockDefinitions = await vi.hoisted(async () => {
       }
     },
     loadErfassungTeamStatusListe: vi.fn(),
-    addNotification: vi.fn(),
     loadDseWorkflowStatus: vi.fn(),
     // Expose vue.ref for tests if needed
     ref,
@@ -35,12 +33,6 @@ vi.mock("vue", () => ({
 vi.mock("@/composables/dse/stimmzettelerfassungTeamStatusService.ts", () => ({
   useStimmzettelerfassungTeamStatusService: () => ({
     loadErfassungTeamStatusListe: mockDefinitions.loadErfassungTeamStatusListe,
-  }),
-}));
-
-vi.mock("@/composables/userNotification/userNotificationService.ts", () => ({
-  useUserNotificationService: () => ({
-    addNotification: mockDefinitions.addNotification,
   }),
 }));
 
@@ -107,7 +99,7 @@ describe("monitoringViewUtils.ts", () => {
     expect(unit.lastLoading.value).toBeUndefined();
   });
 
-  it("should_loadListAndUpdateStateWithoutNotification_when_onActivatedSuccess", async () => {
+  it("should_loadListAndUpdateState_when_onActivatedSuccess", async () => {
     const sample = [{ team: "T2" }];
     const workflowStatus = createStimmzettelerfassungStatus();
     mockDefinitions.loadErfassungTeamStatusListe.mockResolvedValue(sample);
@@ -121,7 +113,6 @@ describe("monitoringViewUtils.ts", () => {
     expect(unit.isWorkflowStatusLoading.value).toStrictEqual(false);
     await mockDefinitions.runActivatedCallbacks();
 
-    expect(mockDefinitions.addNotification).not.toHaveBeenCalled();
     expect(unit.teamstatusList.value).toStrictEqual(sample);
     expect(unit.lastLoading.value).toBeInstanceOf(Date);
     expect(unit.workflowStatus.value).toStrictEqual(workflowStatus);
@@ -129,31 +120,17 @@ describe("monitoringViewUtils.ts", () => {
     expect(mockDefinitions.loadErfassungTeamStatusListe).toHaveBeenCalledWith(
       wahlID,
       wahlbezirkID,
-      false
+      true
+    );
+    expect(mockDefinitions.loadDseWorkflowStatus).toHaveBeenCalledWith(
+      wahlID,
+      wahlbezirkID,
+      true
     );
     expect(spyOnIsWorkflowStatusLoading.mock.calls).toStrictEqual([
       [true],
       [false],
     ]);
     spyOnIsWorkflowStatusLoading.mockRestore();
-  });
-
-  it("should_loadTeamStatusListeAndShowError_when_onActivatedCalledWithFailure", async () => {
-    mockDefinitions.loadErfassungTeamStatusListe.mockRejectedValue(
-      new Error("fail")
-    );
-
-    await mockDefinitions.runActivatedCallbacks();
-
-    expect(mockDefinitions.addNotification).toHaveBeenCalledWith(
-      "Team-Status konnten nicht initialisiert werden.",
-      UserNotificationCategoryEnum.ERROR
-    );
-
-    expect(mockDefinitions.loadErfassungTeamStatusListe).toHaveBeenCalledWith(
-      wahlID,
-      wahlbezirkID,
-      false
-    );
   });
 });

--- a/wls-gui-wahllokalsystem/tests/composables/dse/monitoringViewUtils.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/dse/monitoringViewUtils.spec.ts
@@ -73,7 +73,7 @@ describe("monitoringViewUtils.ts", () => {
   it("should_BeEmptyAndNotLoading_when_initialState", () => {
     expect(unit.teamstatusList.value).toEqual([]);
     expect(unit.lastLoading.value).toBeUndefined();
-    expect(unit.isAktualisiserenLoading.value).toBe(false);
+    expect(unit.isAktualisierenLoading.value).toBe(false);
     expect(unit.workflowStatus.value).toBe(null);
   });
 
@@ -82,11 +82,11 @@ describe("monitoringViewUtils.ts", () => {
     mockDefinitions.loadErfassungTeamStatusListe.mockResolvedValue(sample);
 
     const promise = unit.onMonitoringSynchronisierenClicked();
-    expect(unit.isAktualisiserenLoading.value).toBe(true);
+    expect(unit.isAktualisierenLoading.value).toBe(true);
 
     await promise;
 
-    expect(unit.isAktualisiserenLoading.value).toBe(false);
+    expect(unit.isAktualisierenLoading.value).toBe(false);
     expect(unit.teamstatusList.value).toStrictEqual(sample);
     expect(unit.lastLoading.value).toBeInstanceOf(Date);
 


### PR DESCRIPTION
# Beschreibung:

- Fortsetzen-Button ergänzt wenn man bereits in der Beschlussfassung war
- Ladezustand bei der Anzeige mehr berücksichtigt

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [X] ~~Doku aktualisiert~~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] Unit-Tests gepflegt
- [x] ~~Texte auf Rechtschreibung und Grammatik geprüft~~
- [x] ~~Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft~~

# Referenzen[^1]:

Verwandt mit Issue #



> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language
[database-init-script-doc-link]: https://it-at-m.github.io/Wahllokalsystem/technik/guides/user-data-cleanup

Closes #3336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Monitoring now distinguishes between starting and continuing the decision-making workflow.
  - Added navigation to the decision-making step when continuing an existing workflow.
  - Added separate loading indicators for refreshing monitoring data and loading workflow status.
- **Bug Fixes**
  - Refresh controls are now disabled when all teams have completed their work.
  - Improved button visibility and disabled-state handling based on workflow progress.
- **Tests**
  - Added coverage for refresh and workflow-status loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->