### PR TITLE
Fix Beschlussfassung Workflow

### DIFF
--- a/wls-gui-wahllokalsystem/src/composables/navigation/navigationGuards.ts
+++ b/wls-gui-wahllokalsystem/src/composables/navigation/navigationGuards.ts
@@ -138,8 +138,9 @@ export function useNavigationGuards() {
 
       try {
         const status = await loadDseWorkflowStatus(wahlId, wahlbezirkId, false);
-        return !(
-          status?.status === StimmzettelerfassungStatusEnum.SteBearbeitung
+        return (
+          status !== null &&
+          !(status.status === StimmzettelerfassungStatusEnum.SteBearbeitung)
         );
       } catch {
         return false;

--- a/wls-gui-wahllokalsystem/tests/composables/navigation/navigationGuards.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/navigation/navigationGuards.spec.ts
@@ -780,7 +780,7 @@ describe("navigationGuards.ts", () => {
   });
 
   describe("requiresWorkflowStatusStimmzettelerfassungAbgeschlossen", () => {
-    it("should_returnTrue_when_stimmzettelErfassungTeamStatusIsSteAbgeschlossen", async () => {
+    it("should_returnTrue_when_stimmzettelErfassungStatusIsSteAbgeschlossen", async () => {
       const wahlId = "wahlId";
       const wahlbezirkId = "wahlbezirkId";
       const to = {
@@ -808,7 +808,7 @@ describe("navigationGuards.ts", () => {
       );
       expect(result).toStrictEqual(true);
     });
-    it("should_returnTrue_when_stimmzettelErfassungTeamStatusIsBeAbgeschlossen", async () => {
+    it("should_returnTrue_when_stimmzettelErfassungStatusIsBeAbgeschlossen", async () => {
       const wahlId = "wahlId";
       const wahlbezirkId = "wahlbezirkId";
       const to = {
@@ -836,7 +836,7 @@ describe("navigationGuards.ts", () => {
       );
       expect(result).toStrictEqual(true);
     });
-    it("should_returnFalse_when_stimmzettelErfassungTeamStatusIsInBearbeitung", async () => {
+    it("should_returnFalse_when_stimmzettelErfassungStatusIsInBearbeitung", async () => {
       const wahlId = "wahlId";
       const wahlbezirkId = "wahlbezirkId";
       const to = {
@@ -864,7 +864,7 @@ describe("navigationGuards.ts", () => {
       );
       expect(result).toStrictEqual(false);
     });
-    it("should_returnFalse_when_stimmzettelErfassungTeamStatusIsNull", async () => {
+    it("should_returnFalse_when_stimmzettelErfassungStatusIsNull", async () => {
       const wahlId = "wahlId";
       const wahlbezirkId = "wahlbezirkId";
       const to = {

--- a/wls-gui-wahllokalsystem/tests/composables/navigation/navigationGuards.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/navigation/navigationGuards.spec.ts
@@ -864,6 +864,30 @@ describe("navigationGuards.ts", () => {
       );
       expect(result).toStrictEqual(false);
     });
+    it("should_returnFalse_when_stimmzettelErfassungTeamStatusIsNull", async () => {
+      const wahlId = "wahlId";
+      const wahlbezirkId = "wahlbezirkId";
+      const to = {
+        params: {
+          wahlId: wahlId,
+          wahlbezirkId: wahlbezirkId,
+        },
+      } as unknown as RouteLocationNormalized;
+
+      mockDefinitions.loadDseWorkflowStatus.mockReturnValue(null);
+
+      const result =
+        await requiresWorkflowStatusStimmzettelerfassungAbgeschlossen(
+          to,
+          DUMMY_FROM,
+          DUMMY_NEXT_GUARD
+        );
+
+      expect(mockDefinitions.loadDseWorkflowStatus.mock.calls[0]).toStrictEqual(
+        [wahlId, wahlbezirkId, false]
+      );
+      expect(result).toStrictEqual(false);
+    });
   });
 
   describe("requiresStimmzettelErfassungTeamStatusAbgeschlossen", () => {


### PR DESCRIPTION
# Beschreibung:

Bei der Überprüfung des Workflow-Status vor der Navigation zur Beschlussfassung muss auch darauf geachtet werden, ob der Status null ist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation handling when workflow status information is unavailable.
  * Prevented access to workflow-dependent views when the status is `null`.

* **Tests**
  * Added coverage to verify that navigation is correctly blocked when no workflow status is returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->