### PR TITLE
Fix von fehlendem Gendern bei Fehlernachrichten im Zusammen mit Kurzbefehlen

### DIFF
--- a/wls-gui-wahllokalsystem/src/composables/dse/stimmzettelerfassung/command/addInvalidVotesToSingleKandidatHandler.ts
+++ b/wls-gui-wahllokalsystem/src/composables/dse/stimmzettelerfassung/command/addInvalidVotesToSingleKandidatHandler.ts
@@ -34,7 +34,7 @@ export function useAddInvalidVotesToSingleKandidatHandler(): CommandHandler {
     const commandArguments = _parseCommandArguments(command);
     if (!commandArguments) {
       throw new CommandExecutionError(
-        "Kandidat oder Stimmenanzahl konnten nicht eindeutig identifiziert werden."
+        "Kandidat*in oder Stimmenanzahl konnten nicht eindeutig identifiziert werden."
       );
     }
 

--- a/wls-gui-wahllokalsystem/src/composables/dse/stimmzettelerfassung/command/addStreichungToKandidatenRangeHandler.ts
+++ b/wls-gui-wahllokalsystem/src/composables/dse/stimmzettelerfassung/command/addStreichungToKandidatenRangeHandler.ts
@@ -32,7 +32,7 @@ export function useAddStreichungToKandidatenRangeHandler(): CommandHandler {
     const commandArguments = _parseCommandArguments(command);
     if (!commandArguments) {
       throw new CommandExecutionError(
-        "Kandidat konnte nicht eindeutig identifiziert werden."
+        "Kandidat*in konnte nicht eindeutig identifiziert werden."
       );
     }
 

--- a/wls-gui-wahllokalsystem/src/composables/dse/stimmzettelerfassung/command/addStreichungToSingleKandidatHandler.ts
+++ b/wls-gui-wahllokalsystem/src/composables/dse/stimmzettelerfassung/command/addStreichungToSingleKandidatHandler.ts
@@ -25,7 +25,7 @@ export function useAddStreichungToSingleKandidatHandler(): CommandHandler {
     const commandArgument = _parseCommandArguments(command);
     if (!commandArgument) {
       throw new CommandExecutionError(
-        "Kandidat konnte nicht eindeutig identifiziert werden."
+        "Kandidat*in konnte nicht eindeutig identifiziert werden."
       );
     }
 

--- a/wls-gui-wahllokalsystem/src/composables/dse/stimmzettelerfassung/command/addVotesToKandidatenRangeHandler.ts
+++ b/wls-gui-wahllokalsystem/src/composables/dse/stimmzettelerfassung/command/addVotesToKandidatenRangeHandler.ts
@@ -38,7 +38,7 @@ export function useAddVotesToKandidatenRangeHandler(): CommandHandler {
     const commandArguments = _parseCommandArguments(command);
     if (!commandArguments) {
       throw new CommandExecutionError(
-        "Kandidat oder Stimmenanzahl konnten nicht eindeutig identifiziert werden."
+        "Kandidat*in oder Stimmenanzahl konnten nicht eindeutig identifiziert werden."
       );
     }
 

--- a/wls-gui-wahllokalsystem/src/composables/dse/stimmzettelerfassung/managedStimmzettel.ts
+++ b/wls-gui-wahllokalsystem/src/composables/dse/stimmzettelerfassung/managedStimmzettel.ts
@@ -104,7 +104,7 @@ export function useManagedStimmzettel(
     const kandidat = _getKandidatToAddVotesByUserByOrdnungszahl(ordnungszahl);
     if (!kandidat) {
       throw new ManagedStimmzettelError(
-        `Kandidat mit Ordnungszahl ${ordnungszahl} existiert nicht.`
+        `Kandidat*in mit Ordnungszahl ${ordnungszahl} existiert nicht.`
       );
     }
 
@@ -138,11 +138,11 @@ export function useManagedStimmzettel(
     const kandidat = _getKandidatForStreichungByOrdnungszahl(ordnungszahl);
     if (!kandidat) {
       throw new ManagedStimmzettelError(
-        `Kandidat mit Ordnungszahl ${ordnungszahl} existiert nicht.`
+        `Kandidat*in mit Ordnungszahl ${ordnungszahl} existiert nicht.`
       );
     }
     if (kandidat.durchgestrichen) {
-      throw new ManagedStimmzettelError(`Kandidat ist bereits gestrichen.`);
+      throw new ManagedStimmzettelError(`Kandidat*in ist bereits gestrichen.`);
     }
     _internalAddStreichungToKandidat(kandidat);
   }
@@ -398,7 +398,7 @@ export function useManagedStimmzettel(
         _getKandidatToAddVotesForRangeByOrdnungszahl(ordnungszahl);
       if (!kandidatenByOrdnungszahl) {
         throw new ManagedStimmzettelError(
-          `Kandidat mit Ordnungszahl ${ordnungszahl} existiert nicht.`
+          `Kandidat*in mit Ordnungszahl ${ordnungszahl} existiert nicht.`
         );
       }
       kandidatenByOrdnungszahl.map((kandidat) => kandidaten.push(kandidat));


### PR DESCRIPTION
# Beschreibung:

Gendern von `Kandiat` zu `Kandidat*in` in den Fehlermeldungen des ManagedStimmzettels und der CommandHandler

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] ~~[Naming Conventions][naming-conventions-link] beachtet~~
- [X] ~~Doku aktualisiert~~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [X] ~~Unit-Tests gepflegt~~
- [X] ~~Texte auf Rechtschreibung und Grammatik geprüft~~
- [X] Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft

# Referenzen[^1]:

Verwandt mit Issue #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language
[database-init-script-doc-link]: https://it-at-m.github.io/Wahllokalsystem/technik/guides/user-data-cleanup

Closes #3332


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated candidate-related error messages to use gender-inclusive wording.
  - Applied consistent wording across ballot entry and candidate validation messages.
  - No changes to application behavior, validation logic, or error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->