### PR TITLE
3362 - fix: Team A kann den Status anderer Teams setzen

### DIFF
--- a/docs/src/services/backend-services/ergebnismeldung-service/index.md
+++ b/docs/src/services/backend-services/ergebnismeldung-service/index.md
@@ -112,6 +112,10 @@ Der Bearbeitungsstand der Stimmzettelfassung eines Wahlbezirkes einer Wahl wird 
 Der Bearbeitungsstand eines Teams, Schriftführung oder Erfassungsteam, bei der Stimmzettelfassung eines Wahlbezirkes einer Wahl
 wird damit verwaltet. Siehe dazu die [Statusbeschreibung](/dse/#neue-statuswerte).
 
+Das Primärteam, welches in der Anwendung alle Funktionen verwenden kann – in der Regel Team `A`
+bzw. das Team mit dem/der Schriftführer\*In – darf auch den Status von anderen Teams setzen. Das ist zum Beispiel
+notwendig, um die Erfassung für ein Erfassungsteam freizuschalten.
+
 ### Übermittlung einer Ergebnismeldung
 
 Eine Ergebnismeldung kann eine Schnellmeldung oder eine Niederschrift sein, welche an das externe System übermittelt wird.

--- a/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/stimmzettelerfassung/teamstatus/TeamStatusService.java
+++ b/wls-ergebnismeldung-service/src/main/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/stimmzettelerfassung/teamstatus/TeamStatusService.java
@@ -26,7 +26,10 @@ public class TeamStatusService {
   @PreAuthorize(
       "hasAuthority('Ergebnismeldung_BUSINESSACTION_SaveStimmzettelerfassungTeamstatus')"
           + " and @bezirkIdPermissionEvaluator.tokenUserBezirkIdMatches(#param.wahlbezirkID(), authentication)"
-          + " and @teamIDPermissionEvaluator.tokenUserteamIdMatches(#param.teamID(), authentication)")
+          + " and ("
+          + "@teamIDPermissionEvaluator.tokenUserteamIdMatches(#param.teamID(), authentication)"
+          + " or hasAuthority('WLS_WAHLVORSTAND')"
+          + ")")
   @Transactional
   public void saveTeamStatus(
       @P("param") final TeamBezirkUndWahlIDModel id,

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/stimmzettelerfassung/teamstatus/TeamStatusServiceSecurityTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/stimmzettelerfassung/teamstatus/TeamStatusServiceSecurityTest.java
@@ -119,7 +119,7 @@ public class TeamStatusServiceSecurityTest {
     void
         should_getAccess_when_allRequiredAuthoritiesArePresentWithTeamIDEvaluatorReturnsFalseButUserHasWahlvorstandAuthority() {
       de.muenchen.oss.wahllokalsystem.wls.common.testing.SecurityUtils.runWith(
-              ArrayUtils.addAll(Authorities.ALL_AUTHORITIES_SAVE_TEAMSTATUS, "WLS_WAHLVORSTAND"));
+          ArrayUtils.addAll(Authorities.ALL_AUTHORITIES_SAVE_TEAMSTATUS, "WLS_WAHLVORSTAND"));
 
       val teamID = Instancio.create(String.class);
       val wahlbezirkID = Instancio.create(String.class);
@@ -132,7 +132,7 @@ public class TeamStatusServiceSecurityTest {
           .thenReturn(true);
 
       Assertions.assertThatNoException()
-              .isThrownBy(() -> unitUnderTest.saveTeamStatus(id, ErfassungTeamStatusModel.REGISTRIERT));
+          .isThrownBy(() -> unitUnderTest.saveTeamStatus(id, ErfassungTeamStatusModel.REGISTRIERT));
     }
 
     @Test

--- a/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/stimmzettelerfassung/teamstatus/TeamStatusServiceSecurityTest.java
+++ b/wls-ergebnismeldung-service/src/test/java/de/muenchen/oss/wahllokalsystem/ergebnismeldungservice/service/stimmzettelerfassung/teamstatus/TeamStatusServiceSecurityTest.java
@@ -15,6 +15,7 @@ import de.muenchen.oss.wahllokalsystem.wls.common.security.domain.BezirkUndWahlI
 import de.muenchen.oss.wahllokalsystem.wls.common.testing.SecurityUtils;
 import java.util.stream.Stream;
 import lombok.val;
+import org.apache.commons.lang3.ArrayUtils;
 import org.assertj.core.api.Assertions;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.AfterEach;
@@ -112,6 +113,26 @@ public class TeamStatusServiceSecurityTest {
       Assertions.assertThatException()
           .isThrownBy(() -> unitUnderTest.saveTeamStatus(id, ErfassungTeamStatusModel.REGISTRIERT))
           .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void
+        should_getAccess_when_allRequiredAuthoritiesArePresentWithTeamIDEvaluatorReturnsFalseButUserHasWahlvorstandAuthority() {
+      de.muenchen.oss.wahllokalsystem.wls.common.testing.SecurityUtils.runWith(
+              ArrayUtils.addAll(Authorities.ALL_AUTHORITIES_SAVE_TEAMSTATUS, "WLS_WAHLVORSTAND"));
+
+      val teamID = Instancio.create(String.class);
+      val wahlbezirkID = Instancio.create(String.class);
+      val id = new TeamBezirkUndWahlIDModel(teamID, wahlbezirkID, "wahlID");
+
+      Mockito.when(teamIDPermissionEvaluator.tokenUserteamIdMatches(eq(teamID), notNull()))
+          .thenReturn(false);
+      Mockito.when(
+              bezirkIDPermissionEvaluator.tokenUserBezirkIdMatches(eq(wahlbezirkID), notNull()))
+          .thenReturn(true);
+
+      Assertions.assertThatNoException()
+              .isThrownBy(() -> unitUnderTest.saveTeamStatus(id, ErfassungTeamStatusModel.REGISTRIERT));
     }
 
     @Test


### PR DESCRIPTION
# Beschreibung:

- Die Rolle Wahlvorstand (haben die Schriftführer\*Innen, nicht die Erfassungsteams) kann auch den TeamStatus für ein anderes Team setzen

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Backend -->
### Backend ###
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [X] Doku aktualisiert
- [x] ~~Swagger-API vollständig~~
- [x] ~~Unit-Tests gepflegt~~
- [X] Integrationstests gepflegt: SecurityTests aktualisiert
- [X] ~~Beispiel-Requests gepflegt~~
- [X] ~~Bei Datenbankänderungen [database-init-Skript][database-init-script-doc-link] gepflegt~~
- [x] Texte auf Rechtschreibung und Grammatik geprüft

# Referenzen[^1]:

Verwandt mit Issue #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language
[database-init-script-doc-link]: https://it-at-m.github.io/Wahllokalsystem/technik/guides/user-data-cleanup

Closes #3362 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authorized election board members can now save team status updates even when their team ID does not match the specified team.
  * Existing team ID-based access checks remain supported.

* **Tests**
  * Added security coverage for access granted through the election board authority.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->