### PR TITLE
refactor workflowstatus

### DIFF
--- a/wls-gui-wahllokalsystem/src/composables/dse/monitoring/monitoringViewUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/dse/monitoring/monitoringViewUtils.ts
@@ -1,31 +1,30 @@
 import type { StimmzettelerfassungTeamStatusEntry } from "@/types/dse/stimmzettelerfassungTeamStatus/StimmzettelerfassungTeamStatusEntry.ts";
-import type { StimmzettelerfassungStatus } from "@/types/dse/stimmzettelerfassungWorkflowStatus/StimmzettelerfassungStatus.ts";
 
 import { onActivated, ref } from "vue";
 
 import { useStimmzettelerfassungTeamStatusService } from "@/composables/dse/stimmzettelerfassungTeamStatus/stimmzettelerfassungTeamStatusService.ts";
-import { useDseWorkflowStatusService } from "@/composables/dse/stimmzettelerfassungWorkflowStatus/stimmzettelerfassungStatusService.ts";
+import { useStimmzettelerfassungStatusState } from "@/composables/dse/stimmzettelerfassungWorkflowStatus/stimmzettelerfassungStatusState.ts";
 
 export function useMonitoringViewUtils(wahlID: string, wahlbezirkID: string) {
+  const stimmzettelerfassungState = useStimmzettelerfassungStatusState(
+    wahlID,
+    wahlbezirkID
+  );
   const teamstatusList = ref<StimmzettelerfassungTeamStatusEntry[]>([]);
   const lastLoading = ref<Date>();
   const isAktualisierenLoading = ref(false);
-  const isWorkflowStatusLoading = ref(false);
-  const workflowStatus = ref<StimmzettelerfassungStatus | null>(null);
 
   const erfassungTeamStatusService = useStimmzettelerfassungTeamStatusService();
-  const { loadDseWorkflowStatus } = useDseWorkflowStatusService();
 
   async function onMonitoringSynchronisierenClicked() {
     await _loadTeamStatusListe();
   }
 
-  async function reloadWorkflowStatus() {
-    await _loadWorkflowStatus();
-  }
-
   onActivated(async () => {
-    await Promise.allSettled([_loadTeamStatusListe(), _loadWorkflowStatus()]);
+    await Promise.allSettled([
+      _loadTeamStatusListe(),
+      stimmzettelerfassungState.loadWorkflowStatus(),
+    ]);
   });
 
   async function _loadTeamStatusListe() {
@@ -46,26 +45,12 @@ export function useMonitoringViewUtils(wahlID: string, wahlbezirkID: string) {
     }
   }
 
-  async function _loadWorkflowStatus() {
-    isWorkflowStatusLoading.value = true;
-    try {
-      workflowStatus.value = await loadDseWorkflowStatus(
-        wahlID,
-        wahlbezirkID,
-        true
-      );
-    } finally {
-      isWorkflowStatusLoading.value = false;
-    }
-  }
-
   return {
     teamstatusList,
     lastLoading,
     isAktualisierenLoading,
-    isWorkflowStatusLoading,
-    workflowStatus,
     onMonitoringSynchronisierenClicked,
-    reloadWorkflowStatus,
+
+    ...stimmzettelerfassungState,
   };
 }

--- a/wls-gui-wahllokalsystem/src/composables/dse/stimmzettelerfassungWorkflowStatus/stimmzettelerfassungStatusState.ts
+++ b/wls-gui-wahllokalsystem/src/composables/dse/stimmzettelerfassungWorkflowStatus/stimmzettelerfassungStatusState.ts
@@ -1,0 +1,34 @@
+import type { StimmzettelerfassungStatus } from "@/types/dse/stimmzettelerfassungWorkflowStatus/StimmzettelerfassungStatus.ts";
+
+import { readonly, ref } from "vue";
+
+import { useDseWorkflowStatusService } from "@/composables/dse/stimmzettelerfassungWorkflowStatus/stimmzettelerfassungStatusService.ts";
+
+export function useStimmzettelerfassungStatusState(
+  wahlID: string,
+  wahlbezirkID: string
+) {
+  const isWorkflowStatusLoading = ref(false);
+  const workflowStatus = ref<StimmzettelerfassungStatus | null>(null);
+
+  const { loadDseWorkflowStatus } = useDseWorkflowStatusService();
+
+  async function loadWorkflowStatus() {
+    isWorkflowStatusLoading.value = true;
+    try {
+      workflowStatus.value = await loadDseWorkflowStatus(
+        wahlID,
+        wahlbezirkID,
+        true
+      );
+    } finally {
+      isWorkflowStatusLoading.value = false;
+    }
+  }
+
+  return {
+    isWorkflowStatusLoading: readonly(isWorkflowStatusLoading),
+    workflowStatus: readonly(workflowStatus),
+    loadWorkflowStatus,
+  };
+}

--- a/wls-gui-wahllokalsystem/src/views/dse/MonitoringView.vue
+++ b/wls-gui-wahllokalsystem/src/views/dse/MonitoringView.vue
@@ -124,7 +124,7 @@ const {
   isWorkflowStatusLoading,
   workflowStatus,
   onMonitoringSynchronisierenClicked,
-  reloadWorkflowStatus,
+  loadWorkflowStatus,
 } = useMonitoringViewUtils(wahlID, wahlbezirkID);
 
 const beschlussfassungBtnActive = computed(() =>
@@ -184,7 +184,7 @@ async function onBeschlussfassungStartenClicked() {
   beschlussfassungStartenDialogVisible.value = true;
 }
 async function onAktualisierenClicked() {
-  await reloadWorkflowStatus();
+  await loadWorkflowStatus();
   await onMonitoringSynchronisierenClicked();
 }
 

--- a/wls-gui-wahllokalsystem/tests/composables/dse/monitoring/monitoringViewUtils.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/dse/monitoring/monitoringViewUtils.spec.ts
@@ -4,8 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useMonitoringViewUtils } from "@/composables/dse/monitoring/monitoringViewUtils.ts";
 
 const mockDefinitions = await vi.hoisted(async () => {
-  const { ref } = await import("vue");
-
   const activatedCallbacks: (() => Promise<void> | void)[] = [];
 
   return {
@@ -19,16 +17,17 @@ const mockDefinitions = await vi.hoisted(async () => {
     },
     loadErfassungTeamStatusListe: vi.fn(),
     loadDseWorkflowStatus: vi.fn(),
-    // Expose vue.ref for tests if needed
-    ref,
   };
 });
 
-vi.mock("vue", () => ({
-  ref: mockDefinitions.ref,
-  onActivated: (cb: () => Promise<void> | void) =>
-    mockDefinitions.registerActivated(cb),
-}));
+vi.mock("vue", async (importOriginal) => {
+  const actual = (await importOriginal()) as object;
+  return {
+    ...actual,
+    onActivated: (cb: () => Promise<void> | void) =>
+      mockDefinitions.registerActivated(cb),
+  };
+});
 
 vi.mock(
   "@/composables/dse/stimmzettelerfassungTeamStatus/stimmzettelerfassungTeamStatusService.ts",


### PR DESCRIPTION
# Beschreibung:

- auslagern des workflowStatus, weil dieser auch außerhalb der Monitoring view gebraucht wird

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [ ] ~Doku aktualisiert~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [x] Unit-Tests gepflegt
- [x] Texte auf Rechtschreibung und Grammatik geprüft
- [x] Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language
[database-init-script-doc-link]: https://it-at-m.github.io/Wahllokalsystem/technik/guides/user-data-cleanup




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Workflow status handling is now shared across the monitoring experience.
  * Monitoring refresh and activation behavior consistently reloads the latest workflow status.
  * Workflow-status loading and state are exposed through a unified interface, improving consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->