### PR TITLE
fix typo in useAppUtils

### DIFF
--- a/wls-gui-wahllokalsystem/src/App.vue
+++ b/wls-gui-wahllokalsystem/src/App.vue
@@ -39,7 +39,7 @@ import TheWahlschlussCheckPopupDialog from "@/components/wahlhandlung/TheWahlsch
 import TheWahlvorstandAnwesenheitsCheckPopupDialog from "@/components/wahlvorstand/TheWahlvorstandAnwesenheitsCheckPopupDialog.vue";
 import TheTestseiteDruckenDialog from "@/components/wlsComponents/TheTestseiteDruckenDialog.vue";
 import TheWlsAppBar from "@/components/wlsComponents/TheWlsAppBar.vue";
-import { useStimmzettelerfassungTeamStatusUtils } from "@/composables/appUtils.ts";
+import { useAppUtils } from "@/composables/appUtils.ts";
 import { useBroadcastCronjobService } from "@/composables/broadcast/broadcastCronjobService.ts";
 import { useDateTimeUtils } from "@/composables/common/dateTimeUtils.ts";
 import { useIndexDB } from "@/composables/indexDB/indexDB.ts";
@@ -69,8 +69,7 @@ const { isTodayOrFuture } = useDateTimeUtils();
 const { startBroadcastMessageInterval, stopBroadcastMessageInterval } =
   useBroadcastCronjobService();
 
-const { initStimmzettelerfassungTeamStatus } =
-  useStimmzettelerfassungTeamStatusUtils();
+const { initStimmzettelerfassungTeamStatus } = useAppUtils();
 
 const isTimeToCheckAnwesenheitInFuture = computed(() =>
   dateTimeToCheckAnwesenheit.value

--- a/wls-gui-wahllokalsystem/src/composables/appUtils.ts
+++ b/wls-gui-wahllokalsystem/src/composables/appUtils.ts
@@ -6,7 +6,7 @@ import { useUserStore } from "@/stores/userStore.ts";
 import { StimmzettelerfassungTeamStatusEnum } from "@/types/dse/stimmzettelerfassungTeamStatus/StimmzettelerfassungTeamStatusEnum.ts";
 import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
 
-export function useStimmzettelerfassungTeamStatusUtils() {
+export function useAppUtils() {
   const { loadErfassungTeamStatus, postErfassungTeamStatus } =
     useStimmzettelerfassungTeamStatusService();
   const { currentUserWahlMetadata, currentUserTeamName } =

--- a/wls-gui-wahllokalsystem/tests/App.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/App.spec.ts
@@ -68,7 +68,7 @@ vi.mock(
   })
 );
 vi.mock(import("@/composables/appUtils.ts"), () => ({
-  useStimmzettelerfassungTeamStatusUtils: () => ({
+  useAppUtils: () => ({
     initStimmzettelerfassungTeamStatus:
       mockDefinitions.initStimmzettelerfassungTeamStatus,
   }),

--- a/wls-gui-wahllokalsystem/tests/composables/appUtils.spec.ts
+++ b/wls-gui-wahllokalsystem/tests/composables/appUtils.spec.ts
@@ -4,7 +4,7 @@ import { useStimmzettelerfassungTeamStatusTestDataFactory } from "@tests/utils/d
 import { setActivePinia, storeToRefs } from "pinia";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useStimmzettelerfassungTeamStatusUtils } from "@/composables/appUtils.ts";
+import { useAppUtils } from "@/composables/appUtils.ts";
 import { useUserStore } from "@/stores/userStore.ts";
 import { StimmzettelerfassungTeamStatusEnum } from "@/types/dse/stimmzettelerfassungTeamStatus/StimmzettelerfassungTeamStatusEnum.ts";
 import { UserNotificationCategoryEnum } from "@/types/userNotification/UserNotificationCategoryEnum.ts";
@@ -43,7 +43,7 @@ vi.mock(
 );
 
 describe("appUtils.ts", () => {
-  let unitUnderTest: ReturnType<typeof useStimmzettelerfassungTeamStatusUtils>;
+  let unitUnderTest: ReturnType<typeof useAppUtils>;
 
   const { generateRandomString } = useCommonTestDataFactory();
   const { createStimmzettelerfassungTeamStatusDTOData } =
@@ -62,7 +62,7 @@ describe("appUtils.ts", () => {
         createSpy: vi.fn,
       })
     );
-    unitUnderTest = useStimmzettelerfassungTeamStatusUtils();
+    unitUnderTest = useAppUtils();
   });
 
   afterEach(() => {


### PR DESCRIPTION
# Beschreibung:

kleiner fix: renaming von `useStimmzettelerfassungTeamStatusUtils` in `useAppUtils` entsprechend dem file name

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] fixed naming



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated application utility access under a unified app utilities interface.
  * Existing ballot-recording team status functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->