### PR TITLE
3148 - Stimzettelerfassungsprozess unterbrechen - Anpassung Buttonbeschriftung

### DIFF
--- a/wls-gui-wahllokalsystem/src/views/dse/StimmzettelerfassungView.vue
+++ b/wls-gui-wahllokalsystem/src/views/dse/StimmzettelerfassungView.vue
@@ -129,7 +129,12 @@ const {
 } = useStimmzettelErfassungViewUtils(wahlID, wahlbezirkID, teamID);
 
 const startNewStimmzettelButtonText = computed(() =>
-  hasStimmzettel.value ? "Fortsetzen" : "Starten"
+  hasStimmzettel.value ||
+  teamStatus.value?.status ===
+    StimmzettelerfassungTeamStatusEnum.UNTERBROCHEN ||
+  teamStatus.value?.status === StimmzettelerfassungTeamStatusEnum.IN_BEARBEITUNG
+    ? "Fortsetzen"
+    : "Starten"
 );
 
 function onErfassungStartenClicked() {


### PR DESCRIPTION
# Beschreibung:

- Starten heißt es jetzt nur es keine Stimmzettel gibt, und der Status nicht inBearbeitung oder Unterbrochen ist, also nur vor dem ersten Start
- Backend-Kommunikation ist bereits vorhanden

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] ~~[Naming Conventions][naming-conventions-link] beachtet~~
- [X] ~~Doku aktualisiert~~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [X] ~~Unit-Tests gepflegt~~
- [x] ~~Texte auf Rechtschreibung und Grammatik geprüft~~
- [X] ~~Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft~~

# Referenzen[^1]:

Verwandt mit Issue #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language
[database-init-script-doc-link]: https://it-at-m.github.io/Wahllokalsystem/technik/guides/user-data-cleanup

Closes #3148


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * The ballot-entry button now displays **“Fortsetzen”** when work is paused or already in progress.
  * It continues to display **“Starten”** when no ballot-entry work has begun.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->