### PR TITLE
Use primary-button-border for activeKandidat

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/dse/stimmzettelerfassung/baseComponents/BaseWahlvorschlagCard.vue
+++ b/wls-gui-wahllokalsystem/src/components/dse/stimmzettelerfassung/baseComponents/BaseWahlvorschlagCard.vue
@@ -53,7 +53,7 @@
             :id="`kandidat-${index}`"
             ref="listItems"
             :class="{
-              'border-primary':
+              'primary-button-border':
                 kandidat.kandidatId === activeKandidat?.kandidatId &&
                 kandidat.nennung === activeKandidat?.nennung,
             }"


### PR DESCRIPTION
Ergänzung zu https://github.com/it-at-m/Wahllokalsystem/pull/3430

Refactoring des CSS-Namens hat in der IDE nicht überall gegriffen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling of the active candidate selection indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->