### PR TITLE
3443 - Anpassung Text: Speichern eines Stimmzettels

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/dse/stimmzettelerfassung/dialogs/TheStimmzettelErfassungDialog.vue
+++ b/wls-gui-wahllokalsystem/src/components/dse/stimmzettelerfassung/dialogs/TheStimmzettelErfassungDialog.vue
@@ -181,7 +181,7 @@ const actions = [
     action: () => onSavedClickedAndNext(),
   },
   {
-    title: "Speichern und schließen",
+    title: "Speichern und Schließen",
     action: () => onSavedClickedAndClose(),
   },
 ];


### PR DESCRIPTION
# Beschreibung:

`Speichern und schließen` -> `Speichern und Schließen`, analog zu `Speichern und Weiter`

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [X] ~~[Naming Conventions][naming-conventions-link] beachtet~~
- [X] ~~Doku aktualisiert~~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [X] Unit-Tests gepflegt~~
- [X] ~~Texte auf Rechtschreibung und Grammatik geprüft
- [X] ~~Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft~~

# Referenzen[^1]:

Verwandt mit Issue #

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language
[database-init-script-doc-link]: https://it-at-m.github.io/Wahllokalsystem/technik/guides/user-data-cleanup

Closes #3443
