### PR TITLE
UX-Verbesserung - Automatischen setzen des Fokus auf Befehlseingabe

### DIFF
--- a/wls-gui-wahllokalsystem/src/components/dse/stimmzettelerfassung/TheStimmzettelCommandProcessingTextField.vue
+++ b/wls-gui-wahllokalsystem/src/components/dse/stimmzettelerfassung/TheStimmzettelCommandProcessingTextField.vue
@@ -1,6 +1,7 @@
 <template>
   <v-form>
     <v-text-field
+      :ref="COMMAND_TEXT_FIELD_TEMPLATE_REF_NAME"
       :model-value="commandString"
       :error-messages="errorMessage"
       label="Kurzbefehl"
@@ -13,11 +14,14 @@
 <script setup lang="ts">
 import type { StimmzettelManager } from "@/composables/dse/stimmzettelerfassung/stimmzettelManager.ts";
 import type { PropType } from "vue";
+import type { VTextField } from "vuetify/components/VTextField";
 
-import { ref } from "vue";
+import { ref, useTemplateRef } from "vue";
 
 import { CommandExecutionError } from "@/types/dse/error/CommandExecutionError.ts";
 import { UnsupportedCommandError } from "@/types/dse/error/UnsupportedCommandError.ts";
+
+const COMMAND_TEXT_FIELD_TEMPLATE_REF_NAME = "commandTextField";
 
 const props = defineProps({
   stimmzettelManager: {
@@ -26,8 +30,17 @@ const props = defineProps({
   },
 });
 
+defineExpose({ focus });
+
 const commandString = ref("");
 const errorMessage = ref<string | null>(null);
+const commandTextField = useTemplateRef<InstanceType<typeof VTextField>>(
+  COMMAND_TEXT_FIELD_TEMPLATE_REF_NAME
+);
+
+function focus() {
+  commandTextField.value?.focus();
+}
 
 function onEnterPressed() {
   try {

--- a/wls-gui-wahllokalsystem/src/components/dse/stimmzettelerfassung/dialogs/TheStimmzettelErfassungDialog.vue
+++ b/wls-gui-wahllokalsystem/src/components/dse/stimmzettelerfassung/dialogs/TheStimmzettelErfassungDialog.vue
@@ -54,6 +54,7 @@
           style="min-height: 0; min-width: 0"
         >
           <the-stimmzettel-command-processing-text-field
+            :ref="COMMAND_PROCESSING_TEXT_FIELD_TEMPLATE_REF_NAME"
             class="flex-0-0"
             :stimmzettel-manager="stimmzettelManager"
           />
@@ -139,7 +140,7 @@ import type { Wahlvorschlag } from "@/types/wahlvorschlaege/Wahlvorschlag.ts";
 import type { PropType } from "vue";
 
 import { storeToRefs } from "pinia";
-import { computed, ref, watch } from "vue";
+import { computed, nextTick, ref, useTemplateRef, watch } from "vue";
 import { useRoute } from "vue-router";
 
 import BaseSaveButtonWithActionMenu from "@/components/common/buttons/BaseSaveButtonWithActionMenu.vue";
@@ -175,6 +176,8 @@ const emit = defineEmits<{
   confirmNext: [stimmzettel: Stimmzettel];
 }>();
 
+defineExpose({ focusCommandProcessingTextField });
+
 const actions = [
   {
     title: SAVE_CONTINUE,
@@ -186,14 +189,24 @@ const actions = [
   },
 ];
 
+const COMMAND_PROCESSING_TEXT_FIELD_TEMPLATE_REF_NAME =
+  "commandProcessingTextField";
+
 const currentAction = ref(actions[0]);
+const commandProcessingTextField = useTemplateRef<
+  InstanceType<typeof TheStimmzettelCommandProcessingTextField>
+>(COMMAND_PROCESSING_TEXT_FIELD_TEMPLATE_REF_NAME);
 
 watch(
   () => isDialogVisibleModel.value,
-  () => {
-    if (isDialogVisibleModel.value) {
+  (isVisible) => {
+    if (isVisible) {
       currentAction.value = actions[0];
+      void focusCommandProcessingTextField();
     }
+  },
+  {
+    immediate: true,
   }
 );
 
@@ -226,12 +239,18 @@ const latestChangedKandidat = computed<Kandidat | null>(
 
 const isCancelConfirmationDialogVisible = ref(false);
 
+async function focusCommandProcessingTextField() {
+  await nextTick();
+  commandProcessingTextField.value?.focus();
+}
+
 function onCancelClicked() {
   isCancelConfirmationDialogVisible.value = true;
 }
 
 function onCancelConfirmationDialogCancelled() {
   isCancelConfirmationDialogVisible.value = false;
+  focusCommandProcessingTextField();
 }
 
 function onCancelConfirmationDialogConfirmed() {
@@ -245,6 +264,7 @@ function onSavedClickedAndClose() {
 
 function onSavedClickedAndNext() {
   emit("confirmNext", stimmzettelManager.getStimmzettelSnapshot());
+  void focusCommandProcessingTextField();
 }
 
 function onResetClicked() {

--- a/wls-gui-wahllokalsystem/src/views/dse/StimmzettelerfassungView.vue
+++ b/wls-gui-wahllokalsystem/src/views/dse/StimmzettelerfassungView.vue
@@ -65,6 +65,7 @@
     />
     <the-stimmzettel-erfassung-dialog
       v-if="activeStimmzettel"
+      :ref="STIMMZETTEL_ERFASSUNG_DIALOG_TEMPLATE_REF_NAME"
       v-model="isErfassungsDialogVisible"
       :stimmzettel="activeStimmzettel"
       :wahlvorschlaege="wahlvorschlaege"
@@ -98,6 +99,8 @@ import { useUserStore } from "@/stores/userStore.ts";
 import { StimmzettelerfassungTeamStatusEnum } from "@/types/dse/stimmzettelerfassungTeamStatus/StimmzettelerfassungTeamStatusEnum.ts";
 
 const STIMMZETTEL_BEENDEN_DIALOG_TEMPLATE_REF_NAME = "stimmzettelBeendenDialog";
+const STIMMZETTEL_ERFASSUNG_DIALOG_TEMPLATE_REF_NAME =
+  "stimmzettelErfassenDialog";
 
 const route = useRoute();
 const userStore = useUserStore();
@@ -108,6 +111,9 @@ const wahlbezirkID = (route.params.wahlbezirkId as string) || "";
 const templateRefStimmzettelBeendenDialog = useTemplateRef<
   InstanceType<typeof TheStimmzettelerfassungBeendenDialog>
 >(STIMMZETTEL_BEENDEN_DIALOG_TEMPLATE_REF_NAME);
+const templateRefStimmzettelErfassenDialog = useTemplateRef<
+  InstanceType<typeof TheStimmzettelErfassungDialog>
+>(STIMMZETTEL_ERFASSUNG_DIALOG_TEMPLATE_REF_NAME);
 
 const {
   teamStatus,
@@ -146,7 +152,11 @@ async function onStimmzettelkennungConfirmed(stimmzettelKennung: number) {
   await sendStatusInBearbeitung();
   isKennungsDialogVisible.value = false;
   startNewEmptyStimmzettelWithStimmzettelkennung(stimmzettelKennung);
-  isErfassungsDialogVisible.value = true;
+  if (isErfassungsDialogVisible.value) {
+    templateRefStimmzettelErfassenDialog.value?.focusCommandProcessingTextField();
+  } else {
+    isErfassungsDialogVisible.value = true;
+  }
 }
 
 function onStimmzettelkennungCanceled() {


### PR DESCRIPTION
# Beschreibung:

das Setzen des Fokus erfolgt bei:
- öffnen des Erfassungsdialoges
- Abbrechen des Abbrechen der Erfassung im Erfassungsdialog
- nach dem bestätigen der Stimmzettelkennung im Rahmen von Speichern und Weiter

## Definition of Done (DoD):
<!-- Je nach Service bitte nicht relevanten Teil entfernen-->

<!-- Frontend -->
### Frontend
- [x] [Naming Conventions][naming-conventions-link] beachtet
- [X] ~~Doku aktualisiert~~
  - [Fachliche Beschreibung][fachliche-beschreibung-link]
  - [UI/UX-Adrs][ui-ux-adrs-link]
- [X] ~~Unit-Tests gepflegt~~
- [X] ~~Texte auf Rechtschreibung und Grammatik geprüft~~
- [X] ~~Texte auf [gendergerechte Sprache][gender-sensitive-language] geprüft~~

# Referenzen[^1]:

> [^1]: _Nicht zutreffende Referenzen vor dem Speichern entfernen_

[naming-conventions-link]: https://it-at-m.github.io/Wahllokalsystem/technik/naming_conventions/
[fachliche-beschreibung-link]: https://it-at-m.github.io/Wahllokalsystem/about/#fachliche-anforderungen
[ui-ux-adrs-link]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/ui/
[gender-sensitive-language]: https://it-at-m.github.io/Wahllokalsystem/technik/adr/adr-gender-sensitive-language
[database-init-script-doc-link]: https://it-at-m.github.io/Wahllokalsystem/technik/guides/user-data-cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved keyboard navigation in ballot recording.
  * Command entry fields are automatically focused when the recording dialog opens, after cancellation, and when proceeding to the next ballot.
  * Confirming a ballot identifier now returns focus to the command field when the dialog is already open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

closes #3439 